### PR TITLE
Add python3-devel and python3-pip to build_rpm.sh

### DIFF
--- a/dist/redhat/build_rpm.sh
+++ b/dist/redhat/build_rpm.sh
@@ -61,6 +61,8 @@ fi
 pkg_install rpm-build
 pkg_install git
 pkg_install python3
+pkg_install python3-devel
+pkg_install python3-pip
 
 if [[ ! -f /usr/bin/pystache ]]; then
     pkg_install epel-release
@@ -70,7 +72,7 @@ fi
 
 echo "Running unit tests"
 cd tests/aws
-pip3 install pyyaml==5.3
+sudo pip3 install pyyaml==5.3
 python3 -m unittest test_scylla_configure.py
 cd -
 


### PR DESCRIPTION
since unit test running move into build_rpm.sh, those were missing.