### PR TITLE
dist/redhat: Make RPM release independent of distribution

### DIFF
--- a/dist/redhat/build_rpm.sh
+++ b/dist/redhat/build_rpm.sh
@@ -91,9 +91,9 @@ pystache dist/redhat/$PACKAGE_NAME.spec.mustache "{ \"version\": \"$SCYLLA_VERSI
 \"$SCYLLA_RELEASE\", \"package_name\": \"$PACKAGE_NAME\", \"cloud_provider\": \"$CLOUD_PROVIDER\",
 \"scylla\": true }" > $RPMBUILD/SPECS/$PACKAGE_NAME.spec
 if [[ "$TARGET" = "centos7" ]]; then
-    rpmbuild -ba --define "_topdir $RPMBUILD" --define "dist .el7" $RPM_JOBS_OPTS $RPMBUILD/SPECS/$PACKAGE_NAME.spec
+    rpmbuild -ba --define '_binary_payload w2.xzdio' --define "_topdir $RPMBUILD" --define "dist .el7" $RPM_JOBS_OPTS $RPMBUILD/SPECS/$PACKAGE_NAME.spec
 else
-    rpmbuild -ba --define "_topdir $RPMBUILD" $RPM_JOBS_OPTS $RPMBUILD/SPECS/$PACKAGE_NAME.spec
+    rpmbuild -ba --define '_binary_payload w2.xzdio' --define "_topdir $RPMBUILD" $RPM_JOBS_OPTS $RPMBUILD/SPECS/$PACKAGE_NAME.spec
 fi
 
 cp ${RPMBUILD}/../aws/cloudformation/scylla.yaml $RPMBUILD/CLOUDFORMATION/scylla_cluster_${SCYLLA_VERSION}_${SCYLLA_RELEASE}.yaml

--- a/dist/redhat/scylla-machine-image.spec.mustache
+++ b/dist/redhat/scylla-machine-image.spec.mustache
@@ -1,6 +1,6 @@
 Name:           {{package_name}}
 Version:        {{version}}
-Release:        {{release}}%{?dist}
+Release:        {{release}}
 Summary:        Scylla Machine Image
 Group:          Applications/Databases
 


### PR DESCRIPTION
To support both CentOS 7 and CentOS 8 with the same RPM, remove
distribution information from the "Release" string in the RPM spec file.

Similar fix was already done in scylla.git in commit:

scylladb/scylla@ef88e1e

Ref: scylladb/scylla#5631.