### PR TITLE
Add user_data_format_version tag to AMI on creation

### DIFF
--- a/aws/ami/scylla.json
+++ b/aws/ami/scylla.json
@@ -63,7 +63,8 @@
           "ScyllaMachineImageVersion": "{{user `scylla_machine_image_version`}}",
           "ScyllaJMXVersion": "{{user `scylla_jmx_version`}}",
           "ScyllaToolsVersion": "{{user `scylla_tools_version`}}",
-          "ScyllaPython3Version": "{{user `scylla_python3_version`}}"
+          "ScyllaPython3Version": "{{user `scylla_python3_version`}}",
+          "user_data_format_version": "2"
       }
     }
   ],


### PR DESCRIPTION
If `user_data_format_version` as missing scylla-cluter-tests fails to use
those AMIs with the correct user-data