### PR TITLE
Change the default of auto_bootstrap to be True

### DIFF
--- a/aws/scylla_configure.py
+++ b/aws/scylla_configure.py
@@ -19,7 +19,7 @@ class ScyllaAmiConfigurator:
         'scylla_yaml': {
             'cluster_name': "scylladb-cluster-%s" % int(time.time()),
             'experimental': False,
-            'auto_bootstrap': False,
+            'auto_bootstrap': True,
             'listen_address': "",  # will be configured as a private IP when instance meta data is read
             'broadcast_rpc_address': "",  # will be configured as a private IP when instance meta data is read
             'endpoint_snitch': "org.apache.cassandra.locator.Ec2Snitch",


### PR DESCRIPTION
The AMI was setting auto_bootstrap to false, allowing it to be
overriden via user-metadata.

Unofourtunatly, users don't follow guidlines - and we are changing the
default to be true (and allowing it to be overriden to false) if needed

Fixes: #25