### PR TITLE
build: Make package product configurable

### DIFF
--- a/SCYLLA-VERSION-GEN
+++ b/SCYLLA-VERSION-GEN
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+PRODUCT=scylla
 VERSION=666.development
 
 if test -f version
@@ -17,3 +18,4 @@ echo "$SCYLLA_VERSION-$SCYLLA_RELEASE"
 mkdir -p build
 echo "$SCYLLA_VERSION" > build/SCYLLA-VERSION-FILE
 echo "$SCYLLA_RELEASE" > build/SCYLLA-RELEASE-FILE
+echo "$PRODUCT" > build/SCYLLA-PRODUCT-FILE

--- a/dist/redhat/build_rpm.sh
+++ b/dist/redhat/build_rpm.sh
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-PACKAGE_NAME="scylla-machine-image"
-
 . /etc/os-release
 
 TARGET=
@@ -88,13 +86,15 @@ echo "Building in $PWD..."
 VERSION=$(./SCYLLA-VERSION-GEN)
 SCYLLA_VERSION=$(cat build/SCYLLA-VERSION-FILE)
 SCYLLA_RELEASE=$(cat build/SCYLLA-RELEASE-FILE)
+PRODUCT=$(cat build/SCYLLA-PRODUCT-FILE)
 
+PACKAGE_NAME="$PRODUCT-machine-image"
 
 RPMBUILD=$(readlink -f build/)
 mkdir -pv ${RPMBUILD}/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS,CLOUDFORMATION}
 
 git archive --format=tar --prefix=$PACKAGE_NAME-$SCYLLA_VERSION/ HEAD -o $RPMBUILD/SOURCES/$PACKAGE_NAME-$VERSION.tar
-cp dist/redhat/$PACKAGE_NAME.spec $RPMBUILD/SPECS/$PACKAGE_NAME.spec
+cp dist/redhat/scylla-machine-image.spec $RPMBUILD/SPECS/$PACKAGE_NAME.spec
 
 parameters=(
     -D"version $SCYLLA_VERSION"


### PR DESCRIPTION
This adds a PRODUCT environment variable to SCYLLA-VERSION-GEN to allow
changing the product name. This is needed for scylla-enterprise
packaging.