### PR TITLE
dist/redhat: Fix Scylla and Python dependencies

### DIFF
--- a/dist/redhat/build_rpm.sh
+++ b/dist/redhat/build_rpm.sh
@@ -97,6 +97,7 @@ git archive --format=tar --prefix=$PACKAGE_NAME-$SCYLLA_VERSION/ HEAD -o $RPMBUI
 cp dist/redhat/scylla-machine-image.spec $RPMBUILD/SPECS/$PACKAGE_NAME.spec
 
 parameters=(
+    -D"product $PRODUCT"
     -D"version $SCYLLA_VERSION"
     -D"release $SCYLLA_RELEASE"
     -D"package_name $PACKAGE_NAME"

--- a/dist/redhat/scylla-machine-image.spec
+++ b/dist/redhat/scylla-machine-image.spec
@@ -7,7 +7,7 @@ Group:          Applications/Databases
 License:        ASL 2.0
 URL:            http://www.scylladb.com/
 Source0:        %{name}-%{version}-%{release}.tar
-Requires:       scylla = %{version} scylla-python3 curl
+Requires:       %{product} = %{version} %{product}-python3 curl
 
 BuildArch:      noarch
 


### PR DESCRIPTION
The package names for enterprise are "scylla-enterprise" and
"scylla-enterprise-python3". Let's fix the hard-coded open source
package names in spec file dependencies list.

Reported-by: Yaron Kaikov <yaronkaikov@scylladb.com>