### PR TITLE
Fix AMI building straight from a repo without --localrpm

### DIFF
--- a/aws/ami/build_ami.sh
+++ b/aws/ami/build_ami.sh
@@ -53,6 +53,7 @@ while [ $# -gt 0 ]; do
             ;;
         "--product")
             PRODUCT=$2
+            INSTALL_ARGS="$INSTALL_ARGS --product $2"
             shift 2
             ;;
         "--download-no-server")

--- a/aws/ami/files/scylla_install_ami
+++ b/aws/ami/files/scylla_install_ami
@@ -41,6 +41,8 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Construct AMI')
     parser.add_argument('--localrpm', action='store_true', default=False,
                         help='deploy locally built rpms')
+    parser.add_argument('--product',
+                        help='name of the product', default='scylla')
     parser.add_argument('--repo',
                         help='repository for both install and update, specify .repo/.list file URL')
     parser.add_argument('--repo-for-install',
@@ -66,7 +68,7 @@ if __name__ == '__main__':
         rpms = glob.glob('/home/centos/scylla*.*.rpm')
         run('yum install -y {}'.format(' '.join(rpms)))
     else:
-        run('yum install -y scylla-machine-image scylla-debuginfo')
+        run('yum install -y {0}-machine-image {0}-debuginfo'.format(args.product))
 
     if args.repo_for_install:
         os.remove('/etc/yum.repos.d/scylla_install.repo')


### PR DESCRIPTION
on other prodcut (like enterprise) the $PRODUCT was used on the install command
now we pass it into the python install script