### PR TITLE
aws: switch AMI distribution to Amazon Linux 2

### DIFF
--- a/aws/ami/build_ami.sh
+++ b/aws/ami/build_ami.sh
@@ -83,9 +83,8 @@ check_rpm_exists () {
         fi
     done
 }
-AMI=ami-ae7bfdb8
 REGION=us-east-1
-SSH_USERNAME=centos
+SSH_USERNAME=ec2-user
 
 if [ $LOCALRPM -eq 1 ]; then
     INSTALL_ARGS="$INSTALL_ARGS --localrpm"
@@ -148,4 +147,4 @@ mkdir -p build
 export PACKER_LOG=1
 export PACKER_LOG_PATH=build/ami.log
 
-/usr/bin/packer build -var-file=variables.json -var install_args="$INSTALL_ARGS" -var region="$REGION" -var source_ami="$AMI" -var ssh_username="$SSH_USERNAME" -var scylla_version="$SCYLLA_VERSION" -var scylla_machine_image_version="$SCYLLA_MACHINE_IMAGE_VERSION" -var scylla_jmx_version="$SCYLLA_JMX_VERSION" -var scylla_tools_version="$SCYLLA_TOOLS_VERSION" -var scylla_python3_version="$SCYLLA_PYTHON3_VERSION" -var scylla_ami_description="${SCYLLA_AMI_DESCRIPTION:0:255}" scylla.json
+/usr/bin/packer build -var-file=variables.json -var install_args="$INSTALL_ARGS" -var region="$REGION" -var ssh_username="$SSH_USERNAME" -var scylla_version="$SCYLLA_VERSION" -var scylla_machine_image_version="$SCYLLA_MACHINE_IMAGE_VERSION" -var scylla_jmx_version="$SCYLLA_JMX_VERSION" -var scylla_tools_version="$SCYLLA_TOOLS_VERSION" -var scylla_python3_version="$SCYLLA_PYTHON3_VERSION" -var scylla_ami_description="${SCYLLA_AMI_DESCRIPTION:0:255}" scylla.json

--- a/aws/ami/files/99_user_alias.cfg
+++ b/aws/ami/files/99_user_alias.cfg
@@ -1,0 +1,5 @@
+runcmd:
+  - /sbin/userdel -r ec2-user
+  - /sbin/groupdel ec2-user
+  - /sbin/useradd -o -u 1001 -g scyllaadm -d /home/scyllaadm centos
+  - ln -sf /home/centos/.bash_profile /home/scyllaadm/.bash_profile

--- a/aws/ami/files/scylla_install_ami
+++ b/aws/ami/files/scylla_install_ami
@@ -38,6 +38,7 @@ if __name__ == '__main__':
     if os.getuid() > 0:
         print('Requires root permission.')
         sys.exit(1)
+    homedir = os.path.abspath(os.path.join(__file__, os.pardir))
     parser = argparse.ArgumentParser(description='Construct AMI')
     parser.add_argument('--localrpm', action='store_true', default=False,
                         help='deploy locally built rpms')
@@ -63,7 +64,7 @@ if __name__ == '__main__':
         run('curl -L -o /etc/yum.repos.d/scylla_install.repo {REPO_FOR_INSTALL}'.format(REPO_FOR_INSTALL=args.repo_for_install))
 
     if args.localrpm:
-        rpms = glob.glob('/home/centos/scylla*.*.rpm')
+        rpms = glob.glob('{}/scylla*.*.rpm'.format(homedir))
         run('yum install -y {}'.format(' '.join(rpms)))
     else:
         run('yum install -y scylla-machine-image scylla-debuginfo')
@@ -84,33 +85,15 @@ if __name__ == '__main__':
     run('/opt/scylladb/scripts/scylla_setup --ntp-domain amazon --no-coredump-setup --no-sysconfig-setup --no-raid-setup --no-io-setup --no-bootparam-setup --no-ec2-check')
     run('/opt/scylladb/scripts/scylla_sysconfig_setup --ami')
     run('/opt/scylladb/scripts/scylla_bootparam_setup --ami')
-    os.remove('/home/centos/.ssh/authorized_keys')
+    os.remove('{}/.ssh/authorized_keys'.format(homedir))
     os.remove('/var/lib/scylla-housekeeping/housekeeping.uuid')
 
-    run('yum -y update kernel')
-    run('yum -y install dkms git grubby kernel-devel')
-    run('rpm -e kernel-$(uname -r)', shell=True)
-    run('rpm --import https://www.elrepo.org/RPM-GPG-KEY-elrepo.org')
-    run('rpm -Uvh http://www.elrepo.org/elrepo-release-7.0-3.el7.elrepo.noarch.rpm')
-    run('yum -y --enablerepo=elrepo-kernel install kernel-ml kernel-ml-devel')
-    os.remove('/etc/udev/rules.d/80-net-name-slot.rules')
-    with open('/etc/default/grub') as f:
-        grub = f.read()
-    grub = re.sub(r'^GRUB_CMDLINE_LINUX="(.+)"$', r'GRUB_CMDLINE_LINUX="\1 net.ifnames=0"', grub, flags=re.MULTILINE)
-    with open('/etc/default/grub', 'w') as f:
-        f.write(grub)
-    run('grub2-mkconfig -o /boot/grub2/grub.cfg')
-    c7kver = get_kver('/boot/vmlinuz-*el7.x86_64')
-    mlkver = get_kver('/boot/vmlinuz-*el7.elrepo.x86_64')
-    run('grubby --grub2 --set-default /boot/vmlinuz-{mlkver}'.format(mlkver=mlkver))
-    with open('/etc/yum.conf', 'a') as f:
-        f.write(u'exclude=kernel kernel-devel')
-
-    run('dracut --verbose --add-drivers "ixgbevf nvme ena" --force --kver {c7kver}'.format(c7kver=c7kver))
-    run('dracut --verbose --add-drivers "ixgbevf nvme ena" --force --kver {mlkver}'.format(mlkver=mlkver))
+    run('sudo amazon-linux-extras install kernel-ng')
 
     with open('/etc/cloud/cloud.cfg') as f:
         cfg = f.read()
-    cfg2 = re.sub('^ssh_deletekeys:   0', 'ssh_deletekeys:   1', cfg, flags=re.MULTILINE)
+    cfg2 = re.sub('^ssh_deletekeys:   false', 'ssh_deletekeys:   true', cfg, flags=re.MULTILINE)
+    cfg2 = re.sub('^    name: ec2-user', '    name: scyllaadm', cfg2, flags=re.MULTILINE)
     with open('/etc/cloud/cloud.cfg', 'w') as f:
         f.write(cfg2)
+    shutil.move('{}/99_user_alias.cfg'.format(homedir), '/etc/cloud/cloud.cfg.d')

--- a/aws/ami/scylla.json
+++ b/aws/ami/scylla.json
@@ -44,14 +44,20 @@
       "launch_block_device_mappings": [
         {
           "delete_on_termination": true,
-          "device_name": "/dev/sda1",
+          "device_name": "/dev/xvda",
           "volume_size": 10
         }
       ],
       "region": "{{user `region`}}",
       "secret_key": "{{user `secret_key`}}",
       "security_group_id": "{{user `security_group_id`}}",
-      "source_ami": "{{user `source_ami`}}",
+      "source_ami_filter": {
+          "filters": {
+              "name": "amzn2-ami-hvm-*-x86_64-gp2"
+          },
+          "owners": ["137112412989"],
+          "most_recent": true
+      },
       "ssh_timeout": "5m",
       "ssh_username": "{{user `ssh_username`}}",
       "subnet_id": "{{user `subnet_id`}}",
@@ -90,7 +96,6 @@
     "region": "",
     "secret_key": "",
     "security_group_id": "",
-    "source_ami": "",
     "ssh_username": "",
     "subnet_id": ""
   }


### PR DESCRIPTION
On Amazon Linux 2, we can get more recent version kernel by default,
with EC2 device driver support.

This commit changes following things:
 - dropped AMI variable to specify source AMI, introduced source_ami_filter
  to automatically lookup latest Amazon Linux 2 AMI insteead.
 - AMI default user changes:
  - changed default user as "scyllaadm"
  - make "centos" user as an alias of "scyllaadm"
  - deleted "ec2-user" user which is default user on Amazon Linux 2
 - dropped kernel-ml installation code and udev/bootparam customize for
  EC2 support, and also initramfs generation for EC2 support. Since
  Amazon Linux 2 is optimized for EC2, we don't need these customize.
 - reuired small changes to make scripts compatible with Amazon Linux 2:
  - build time default user changed to ec2-user
  - cloud.cfg: 'ssh_deletekeys: 0' should be replaced with 'ssh_deletekeys: false'