### PR TITLE
aws/scylla_create_devices: drop --update-fstab from scylla_raid_setup

### DIFF
--- a/aws/scylla_create_devices
+++ b/aws/scylla_create_devices
@@ -82,8 +82,7 @@ def config_array(disks, role, mdidx):
     subprocess.run([raid_script, "--raiddev",
                     raid_device % mdidx, "--disks", ",".join(disk_devs),
                     "--root", scylla_root,
-                    "--volume-role", role,
-                    "--update-fstab"], check=True)
+                    "--volume-role", role], check=True)
 
 
 def xenify(devname):


### PR DESCRIPTION
This is part of scylladb/scylla#6706, we are dropping --update-fstab option.