### PR TITLE
Adding `Obsoletes: scylla-ami` for inplace upgrades of AMIs

### DIFF
--- a/dist/redhat/scylla-machine-image.spec
+++ b/dist/redhat/scylla-machine-image.spec
@@ -10,6 +10,7 @@ Source0:        %{name}-%{version}-%{release}.tar
 Requires:       %{product} = %{version} %{product}-python3 curl
 
 BuildArch:      noarch
+Obsoletes:      %{product}-ami
 
 %global _python_bytecompile_errors_terminate_build 0
 %global __brp_python_bytecompile %{nil}


### PR DESCRIPTION
Seem like we forgot this part, and now when upgrading AMIs from version < 4.0
We run into upgrade error:

```
--> Finished Dependency Resolution
Error: Package: scylla-ami-3.3.4-20200616.0ae14e01506.noarch (@/scylla-ami.noarch)
           Requires: scylla = 3.3.4
           Removing: scylla-3.3.4-0.20200616.ec12331f116.x86_64 (@/scylla.x86_64)
               scylla = 3.3.4-0.20200616.ec12331f116
           Updated By: scylla-4.0.3-0.20200621.1fcf38abd9b.x86_64 (scylla-4.0)
               scylla = 4.0.3-0.20200621.1fcf38abd9b
           Available: scylla-4.0.rc0-0.20200325.78f5afec30.x86_64 (scylla-4.0)
               scylla = 4.0.rc0-0.20200325.78f5afec30
           Available: scylla-4.0.rc1-0.20200406.9908f009a4a.x86_64 (scylla-4.0)
               scylla = 4.0.rc1-0.20200406.9908f009a4a
           Available: scylla-4.0.rc2-0.20200421.89e79023aeb.x86_64 (scylla-4.0)
               scylla = 4.0.rc2-0.20200421.89e79023aeb
           Available: scylla-4.0.rc3-0.20200501.eee4c00e29.x86_64 (scylla-4.0)
               scylla = 4.0.rc3-0.20200501.eee4c00e29
           Available: scylla-4.0.0-0.20200505.d95aa77b62.x86_64 (scylla-4.0)
               scylla = 4.0.0-0.20200505.d95aa77b62
           Available: scylla-4.0.1-0.20200524.8d9bc57aca6.x86_64 (scylla-4.0)
               scylla = 4.0.1-0.20200524.8d9bc57aca6
           Available: scylla-4.0.2-0.20200615.ce57d0174d4.x86_64 (scylla-4.0)
               scylla = 4.0.2-0.20200615.ce57d0174d4
 You could try using --skip-broken to work around the problem
 You could try running: rpm -Va --nofiles --nodigest
```