### PR TITLE
scylla_image_setup: enable swap during AMI instance init

### DIFF
--- a/aws/ami/files/scylla_install_ami
+++ b/aws/ami/files/scylla_install_ami
@@ -84,7 +84,7 @@ if __name__ == '__main__':
         for l in lines:
             if not re.match(r'^ - mounts\n$', l):
                 f.write(l)
-    run('/opt/scylladb/scripts/scylla_setup --ntp-domain amazon --no-coredump-setup --no-sysconfig-setup --no-raid-setup --no-io-setup --no-bootparam-setup --no-ec2-check')
+    run('/opt/scylladb/scripts/scylla_setup --ntp-domain amazon --no-coredump-setup --no-sysconfig-setup --no-raid-setup --no-io-setup --no-bootparam-setup --no-ec2-check --no-swap-setup')
     run('/opt/scylladb/scripts/scylla_sysconfig_setup --ami')
     run('/opt/scylladb/scripts/scylla_bootparam_setup --ami')
     os.remove('{}/.ssh/authorized_keys'.format(homedir))

--- a/aws/ami/scylla.json
+++ b/aws/ami/scylla.json
@@ -45,7 +45,7 @@
         {
           "delete_on_termination": true,
           "device_name": "/dev/xvda",
-          "volume_size": 10
+          "volume_size": 30
         }
       ],
       "region": "{{user `region`}}",

--- a/aws/scylla_image_setup
+++ b/aws/scylla_image_setup
@@ -31,5 +31,6 @@ if __name__ == '__main__':
         run('/opt/scylladb/scripts/scylla_coredump_setup --dump-to-raiddir')
     else:
         run('/opt/scylladb/scripts/scylla_coredump_setup')
+    run('/opt/scylladb/scripts/scylla_swap_setup --swap-directory /')
     pathlib.Path('/etc/scylla/machine_image_configured').touch()
                                                                                                                         


### PR DESCRIPTION
This PR enable swap in scylla_image_setup, it will be enabled during AMI instance init.
The swap is always helpful, and recommended for scylla user. We don't need to make it configurable, and just enable it all the time.

Current default root disk size (10G) might be not enough if the instance type is very large. Let's increase it to 30G.
The last patch disabled swap setup in creating AMI stage, scylla_setup is executed there.

/CC @fruch 

Fixes: https://github.com/scylladb/scylla/issues/6973