### PR TITLE
k8s: Added script for setting up k8s nodes

### DIFF
--- a/aws/scylla_create_devices
+++ b/aws/scylla_create_devices
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import argparse
 import re
 import os
 import sys
@@ -26,8 +27,7 @@ from pathlib import Path
 
 raid_script = "/opt/scylladb/scripts/scylla_raid_setup"
 raid_device = "/dev/md%d"
-scylla_root = "/var/lib/scylla"
-
+scylla_root = ""
 
 def scylla_directory(role):
     if role == "all":
@@ -183,6 +183,12 @@ def get_disk_bundles():
         config_array(typemap[t], role[t], mdidx)
         mdidx += 1
 
-
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Disk creation script for Scylla.')
+    parser.add_argument('--scylla-data-root', dest='scylla_data_root', action='store',
+                        help='location of Scylla root data directory', default="/var/lib/scylla")
+    args = parser.parse_args()
+
+    scylla_root = args.scylla_data_root
+
     get_disk_bundles()

--- a/k8s/Dockerfile
+++ b/k8s/Dockerfile
@@ -1,0 +1,17 @@
+FROM docker.io/scylladb/scylla:4.1.6 as base
+
+# Install scripts dependencies.
+RUN yum -y install epel-release && \
+    yum -y clean expire-cache && \
+    yum -y update && \
+    yum install -y hwloc ethtool python3-yaml python3 python3-devel gcc && \
+    yum clean all
+
+RUN pip3 install pyyaml psutil
+
+ARG cloud_provider
+
+COPY $cloud_provider/scylla_create_devices /opt/scylladb/scylla-machine-image/scylla_create_devices
+COPY k8s/scylla_k8s_node_setup /opt/scylladb/scylla-machine-image/scylla_k8s_node_setup
+
+ENTRYPOINT ["/opt/scylladb/scylla-machine-image/scylla_k8s_node_setup"]

--- a/k8s/build_image.sh
+++ b/k8s/build_image.sh
@@ -1,0 +1,43 @@
+#!/bin/bash -e
+#
+# Copyright 2020 ScyllaDB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+CLOUD_PROVIDER=
+
+print_usage() {
+    echo "build_image.sh -c [aws|gce|azure]"
+    echo "  -c cloud provider"
+    exit 1
+}
+while getopts c: option
+do
+ case "${option}"
+ in
+ c) CLOUD_PROVIDER=${OPTARG};;
+ *) print_usage;;
+ esac
+done
+
+if [[ ! -e k8s/build_image.sh ]]; then
+    echo "run build_image.sh in top of scylla-machine-image dir"
+    exit 1
+fi
+
+echo "Building in $PWD..."
+
+VERSION=$(./SCYLLA-VERSION-GEN)
+PACKAGE_NAME="scylladb/scylla-machine-image-k8s-$CLOUD_PROVIDER:$VERSION"
+
+docker build . -f k8s/Dockerfile --build-arg cloud_provider=$CLOUD_PROVIDER -t $PACKAGE_NAME

--- a/k8s/scylla_k8s_node_setup
+++ b/k8s/scylla_k8s_node_setup
@@ -1,0 +1,83 @@
+#!/usr/bin/python3
+#
+# Copyright 2020 ScyllaDB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import shutil
+import sys
+import pathlib
+import signal
+import argparse
+from subprocess import check_output
+sys.path.append('/opt/scylladb/scripts')
+from scylla_util import *
+
+def copytree(src, dst, symlinks=False, ignore=None):
+    for item in os.listdir(src):
+        s = os.path.join(src, item)
+        d = os.path.join(dst, item)
+        if os.path.isdir(s):
+            shutil.copytree(s, d, symlinks, ignore)
+        else:
+            shutil.copy2(s, d)
+
+def get_pid(name):
+    return int(check_output(["pidof","-s",name]))
+
+if __name__ == '__main__':
+    root_disk = os.environ.get('ROOT_DISK', "/mnt/raid-disks/disk0")
+    scylladconf_mount = os.environ.get('SCYLLAD_CONF_MOUNT', '/mnt/scylla.d/')
+
+    parser = argparse.ArgumentParser(description='Scylla setup for k8s')
+    parser.add_argument('--all', dest='all', action='store_true',
+                        help='Setup everything, it has the same effect as setting each parameter individually')
+    parser.add_argument('--install-dependencies', dest='install_dependencies', action='store_true',
+                        help='installs Scylla dependencies')
+    parser.add_argument('--setup-disks', dest='setup_disks', action='store_true',
+                        help='format disks')
+    parser.add_argument('--setup-network', dest='setup_network', action='store_true',
+                        help='setup network iface')
+    parser.add_argument('--run-io', dest='run_io', action='store_true',
+                        help='run io tuning')
+    args = parser.parse_args()
+
+    if not args.all and not args.install_dependencies and not args.setup_disks and not args.setup_network and not args.run_io:
+        parser.print_help()
+        os.exit(1)
+
+    if args.all or args.install_dependencies:
+        run('/opt/scylladb/scripts/scylla_setup --no-coredump-setup --no-sysconfig-setup --no-raid-setup --no-io-setup --no-bootparam-setup --no-ec2-check --no-cpuscaling-setup --no-kernel-check --no-verify-package --no-enable-service --no-selinux-setup --no-version-check --no-node-exporter')
+
+    if args.all or args.setup_disks:
+        # setup XFS mount
+        run('/opt/scylladb/scylla-machine-image/scylla_create_devices --scylla-data-root {}'.format(root_disk))
+
+    if args.all or args.setup_network:
+        run('/opt/scylladb/scripts/perftune.py --nic eth0 --mode sq --tune net')
+
+        # Notify irqbalance about config change
+        os.kill(get_pid("irqbalance"), signal.SIGHUP)
+
+    if args.all or args.run_io:
+        run('/opt/scylladb/scripts/scylla_io_setup')
+
+        copytree('/etc/scylla.d', scylladconf_mount)
+
+    pathlib.Path('/etc/scylla/machine_image_configured').touch()
+
+    print("Setup done!")
+
+    # infinite sleep
+    signal.pause()


### PR DESCRIPTION
This script allows to configure k8s node disks and tune networking. 
Priviledged pods should run it as a entrypoint, and provide two environmental variables:
* ROOT_DISK - where Scylla root directory should be mounted
* ROOT_MOUNTPOINT - path to directory where host filesystem is mounted 