### PR TITLE
fix(ena_support): move to newer centos base image

### DIFF
--- a/aws/ami/build_ami.sh
+++ b/aws/ami/build_ami.sh
@@ -83,7 +83,7 @@ check_rpm_exists () {
         fi
     done
 }
-AMI=ami-ae7bfdb8
+AMI=ami-0e4bba886a574c2d8
 REGION=us-east-1
 SSH_USERNAME=centos
 


### PR DESCRIPTION
Recently (24-25/Sep), our images started missing ENA support.
seem like out base image was very old moving to
"CentOS Linux 7 x86_64 HVM EBS ENA 1905" (ami-0e4bba886a574c2d8)

Fixes: scylladb/scylla#7295
(cherry picked from commit 461a8bee69d54acb4bee4f7b0a1d9c39743f8d5d)