### PR TITLE
get_version_from_remote_rpm: get latest version on release

### DIFF
--- a/aws/ami/build_ami.sh
+++ b/aws/ami/build_ami.sh
@@ -75,7 +75,7 @@ get_version_from_local_rpm () {
 
 get_version_from_remote_rpm () {
     RPM=$1
-    VERSION=$(yum provides $RPM | grep "Provide.*=" | awk '{print $5}')
+    VERSION=$(yum provides $RPM | grep "Provide.*=" | awk '{print $5}'| tail -1)
     echo "$VERSION"
 }
 

--- a/gce/image/build_image.sh
+++ b/gce/image/build_image.sh
@@ -74,7 +74,7 @@ get_version_from_local_rpm () {
 
 get_version_from_remote_rpm () {
     RPM=$1
-    VERSION=$(yum provides $RPM | grep "Provide.*=" | awk '{print $5}')
+    VERSION=$(yum provides $RPM | grep "Provide.*=" | awk '{print $5}'| tail -1)
     echo "$VERSION"
 }
 


### PR DESCRIPTION
An issue was raised by Takuya in https://github.com/scylladb/scylla/issues/7465

upon release when you run get_version_from_remote_rpm, you get an output for all releases instead off the latest one only

Fixing it here