### PR TITLE
aws: configure clocksource on instance first boot time

### DIFF
--- a/aws/ami/files/scylla_install_ami
+++ b/aws/ami/files/scylla_install_ami
@@ -86,7 +86,6 @@ if __name__ == '__main__':
                 f.write(l)
     run('/opt/scylladb/scripts/scylla_setup --ntp-domain amazon --no-coredump-setup --no-sysconfig-setup --no-raid-setup --no-io-setup --no-bootparam-setup --no-ec2-check --no-swap-setup')
     run('/opt/scylladb/scripts/scylla_sysconfig_setup --ami')
-    run('/opt/scylladb/scripts/scylla_bootparam_setup --ami')
     os.remove('{}/.ssh/authorized_keys'.format(homedir))
     os.remove('/var/lib/scylla-housekeeping/housekeeping.uuid')
 

--- a/common/scylla_image_setup
+++ b/common/scylla_image_setup
@@ -25,6 +25,7 @@ if __name__ == '__main__':
     run('/opt/scylladb/scylla-machine-image/scylla_configure.py')
     run('/opt/scylladb/scylla-machine-image/scylla_create_devices')
     run('/opt/scylladb/scripts/scylla_sysconfig_setup --nic eth0 --setup-nic --ami')
+    run('/opt/scylladb/scripts/scylla_bootparam_setup --ami')
     if cloud_instance.is_supported_instance_class():
         cloud_instance.io_setup()
     if os.path.ismount('/var/lib/scylla'):


### PR DESCRIPTION
To use kvm-clock as clocksource on AWS Nitro VMs, run scylla_bootparam_setup on
instance first boot time, instead of AMI image creation time.

see: scylladb/scylla#7444