### PR TITLE
fix(gce image): do not setup swap when creating an image

### DIFF
--- a/gce/image/files/scylla_install_image
+++ b/gce/image/files/scylla_install_image
@@ -78,7 +78,7 @@ if __name__ == '__main__':
 
     run('systemctl daemon-reload')
     run('systemctl enable scylla-image-setup.service')
-    run('/opt/scylladb/scripts/scylla_setup --no-coredump-setup --no-sysconfig-setup --no-raid-setup --no-io-setup --no-bootparam-setup --no-ec2-check')
+    run('/opt/scylladb/scripts/scylla_setup --no-coredump-setup --no-sysconfig-setup --no-raid-setup --no-io-setup --no-bootparam-setup --no-ec2-check --no-swap-setup')
     run('/opt/scylladb/scripts/scylla_sysconfig_setup --ami')
     housekeeping_uuid_path = Path('/var/lib/scylla-housekeeping/housekeeping.uuid')
     if housekeeping_uuid_path.exists():


### PR DESCRIPTION
scylla_swap_setup runs as part of scylla_setup during first boot of the instance that is created from the image