### PR TITLE
GCE image:Set a uniuqe image name

### DIFF
--- a/gce/image/scylla_gce.json
+++ b/gce/image/scylla_gce.json
@@ -12,7 +12,7 @@
       "machine_type": "{{user `instance_type`}}",
       "metadata": {"block-project-ssh-keys": "TRUE"},
       "image_family": "scylla",
-      "image_name": "scylla-{{user `scylla_version`| clean_resource_name}}",
+      "image_name": "scylla-{{user `scylla_branch_version`| clean_resource_name}}-build-{{user `scylla_build_id`| clean_resource_name}}",
       "instance_name": "scylla-{{user `scylla_version`| clean_resource_name}}",
       "image_description": "Official ScyllaDB image v-{{user `scylla_version`| clean_resource_name}}",
       "use_internal_ip": false,
@@ -56,4 +56,3 @@
     "ssh_username": "centos"
   }
 }
-


### PR DESCRIPTION
Today the GCE image name is based on product=scylla and rpm version.
When we are building GCE image more then once based on the same rpm version the image is overriding and deleted

Setting a unique image name so we can keep the history of images

Backport to 4.3 is needed