### PR TITLE
Enable clocksource setting on AMI

### DIFF
--- a/aws/ami/files/scylla_install_ami
+++ b/aws/ami/files/scylla_install_ami
@@ -85,7 +85,7 @@ if __name__ == '__main__':
             if not re.match(r'^ - mounts\n$', l):
                 f.write(l)
     run('/opt/scylladb/scripts/scylla_setup --ntp-domain amazon --no-coredump-setup --no-sysconfig-setup --no-raid-setup --no-io-setup --no-bootparam-setup --no-ec2-check --no-swap-setup')
-    run('/opt/scylladb/scripts/scylla_sysconfig_setup --ami')
+    run('/opt/scylladb/scripts/scylla_sysconfig_setup --ami --set-clocksource')
     run('/opt/scylladb/scripts/scylla_bootparam_setup --ami')
     os.remove('{}/.ssh/authorized_keys'.format(homedir))
     os.remove('/var/lib/scylla-housekeeping/housekeeping.uuid')


### PR DESCRIPTION
Instead of hardcoding clocksource=tsc on bootparameter, we need to configure
it ondemand, since we have different types of hypervisor which required
different clocksource to optimize.
To do so, we need to run perftune.py tune-clock mode to auto-configure clocksource.

Related scylladb/scylla#7444