### PR TITLE
switch to subprocess.run()

### DIFF
--- a/common/scylla_image_setup
+++ b/common/scylla_image_setup
@@ -19,17 +19,18 @@ import sys
 import pathlib
 sys.path.append('/opt/scylladb/scripts')
 from scylla_util import *
+from subprocess import run
 
 if __name__ == '__main__':
     cloud_instance = get_cloud_instance()
-    run('/opt/scylladb/scylla-machine-image/scylla_configure.py')
-    run('/opt/scylladb/scylla-machine-image/scylla_create_devices')
-    run('/opt/scylladb/scripts/scylla_sysconfig_setup --nic eth0 --setup-nic --ami')
+    run('/opt/scylladb/scylla-machine-image/scylla_configure.py', shell=True, check=True)
+    run('/opt/scylladb/scylla-machine-image/scylla_create_devices', shell=True, check=True)
+    run('/opt/scylladb/scripts/scylla_sysconfig_setup --nic eth0 --setup-nic --ami', shell=True, check=True)
     if cloud_instance.is_supported_instance_class():
         cloud_instance.io_setup()
     if os.path.ismount('/var/lib/scylla'):
-        run('/opt/scylladb/scripts/scylla_coredump_setup --dump-to-raiddir')
+        run('/opt/scylladb/scripts/scylla_coredump_setup --dump-to-raiddir', shell=True, check=True)
     else:
-        run('/opt/scylladb/scripts/scylla_coredump_setup')
-    run('/opt/scylladb/scripts/scylla_swap_setup --swap-directory /')
+        run('/opt/scylladb/scripts/scylla_coredump_setup', shell=True, check=True)
+    run('/opt/scylladb/scripts/scylla_swap_setup --swap-directory /', shell=True, check=True)
     pathlib.Path('/etc/scylla/machine_image_configured').touch()

--- a/common/scylla_login
+++ b/common/scylla_login
@@ -19,6 +19,7 @@ import os
 import sys
 sys.path.append('/opt/scylladb/scripts')
 from scylla_util import *
+from subprocess import run
 
 MSG_HEADER = '''
 
@@ -102,7 +103,7 @@ $ nodetool status
 '''[1:-1]
 
 if __name__ == '__main__':
-    colorprint(MSG_HEADER.format(scylla_version=out("scylla --version")))
+    colorprint(MSG_HEADER.format(scylla_version=run("scylla --version", shell=True, check=True, capture_output=True, encoding='utf-8').stdout.strip()))
     cloud_instance = get_cloud_instance()
     if not cloud_instance.is_supported_instance_class():
         colorprint(MSG_UNSUPPORTED_INSTANCE_TYPE % cloud_instance.GETTING_STARTED_URL,
@@ -132,6 +133,6 @@ if __name__ == '__main__':
                     colorprint(MSG_SCYLLA_UNKNOWN)
             else:
                 colorprint(MSG_SCYLLA_ACTIVE)
-                run('nodetool status', exception=False)
+                run('nodetool status', shell=True)
         cloud_instance.check()
         print('\n', end='')


### PR DESCRIPTION
Since 3fefa52, we dropped scylla_util.run() and scylla_util.out(), we need to
use subprocess.run() instead.

Related scylladb/scylla#7667

Fixes: scylladb/scylla/issues#7695