### PR TITLE
aws: switch AMI distribution to CentOS8

### DIFF
--- a/aws/ami/build_ami.sh
+++ b/aws/ami/build_ami.sh
@@ -90,7 +90,7 @@ check_rpm_exists () {
         fi
     done
 }
-AMI=ami-00e87074e52e6c9f9
+AMI=ami-01ca03df4a6012157
 REGION=us-east-1
 SSH_USERNAME=centos
 

--- a/aws/ami/files/scylla_install_ami
+++ b/aws/ami/files/scylla_install_ami
@@ -91,7 +91,7 @@ if __name__ == '__main__':
 
     run('yum -y install grubby')
     run('rpm --import https://www.elrepo.org/RPM-GPG-KEY-elrepo.org')
-    run('rpm -Uvh http://www.elrepo.org/elrepo-release-7.0-3.el7.elrepo.noarch.rpm')
+    run('rpm -Uvh https://www.elrepo.org/elrepo-release-8.el8.elrepo.noarch.rpm')
     run('yum -y --enablerepo=elrepo-kernel install kernel-ml')
     os.remove('/etc/udev/rules.d/80-net-name-slot.rules')
     with open('/etc/default/grub') as f:
@@ -100,7 +100,7 @@ if __name__ == '__main__':
     with open('/etc/default/grub', 'w') as f:
         f.write(grub)
     run('grub2-mkconfig -o /boot/grub2/grub.cfg')
-    mlkver = get_kver('/boot/vmlinuz-*el7.elrepo.x86_64')
+    mlkver = get_kver('/boot/vmlinuz-*el8.elrepo.x86_64')
     run('grubby --grub2 --set-default /boot/vmlinuz-{mlkver}'.format(mlkver=mlkver))
     with open('/etc/yum.conf', 'a') as f:
         f.write(u'exclude=kernel kernel-devel')

--- a/aws/ami/scylla.json
+++ b/aws/ami/scylla.json
@@ -76,6 +76,7 @@
     },
     {
       "inline": [
+        "sudo /usr/bin/dnf -y install python2",
         "sudo /home/{{user `ssh_username`}}/scylla_install_ami {{ user `install_args` }}"
       ],
       "type": "shell"


### PR DESCRIPTION
Upgrade AMI distribution from CentOS7 to CentOS8.

----

Please merge https://github.com/scylladb/scylla-machine-image/pull/86 first, since this PR depends on it.
After it merged, I'll rebase this.

Note: This one is for master.

Related: #85 