### PR TITLE
aws: support building aarch64 AMI

### DIFF
--- a/aws/ami/build_ami.sh
+++ b/aws/ami/build_ami.sh
@@ -81,7 +81,7 @@ get_version_from_remote_rpm () {
 
 check_rpm_exists () {
     BASE_DIR=$1
-    rpm_files="$BASE_DIR/$PRODUCT-server*.x86_64.rpm $BASE_DIR/$PRODUCT-machine-image*.noarch.rpm $BASE_DIR/$PRODUCT-jmx*.noarch.rpm $BASE_DIR/$PRODUCT-tools-*.noarch.rpm $BASE_DIR/$PRODUCT-python3*.x86_64.rpm"
+    rpm_files="$BASE_DIR/$PRODUCT-server*.$(arch).rpm $BASE_DIR/$PRODUCT-machine-image*.noarch.rpm $BASE_DIR/$PRODUCT-jmx*.noarch.rpm $BASE_DIR/$PRODUCT-tools-*.noarch.rpm $BASE_DIR/$PRODUCT-python3*.$(arch).rpm"
     for rpm in $rpm_files
     do
         if [[ ! -f "$rpm" ]]; then
@@ -90,7 +90,8 @@ check_rpm_exists () {
         fi
     done
 }
-AMI=ami-00e87074e52e6c9f9
+declare -A AMI
+AMI=(["x86_64"]=ami-00e87074e52e6c9f9 ["aarch64"]=ami-0b802bd2b502aa382)
 REGION=us-east-1
 SSH_USERNAME=centos
 
@@ -99,11 +100,11 @@ if [ $LOCALRPM -eq 1 ]; then
 
     check_rpm_exists $DIR/files
 
-    SCYLLA_VERSION=$(get_version_from_local_rpm $DIR/files/$PRODUCT-server*.x86_64.rpm)
+    SCYLLA_VERSION=$(get_version_from_local_rpm $DIR/files/$PRODUCT-server*.$(arch).rpm)
     SCYLLA_MACHINE_IMAGE_VERSION=$(get_version_from_local_rpm $DIR/files/$PRODUCT-machine-image*.noarch.rpm)
     SCYLLA_JMX_VERSION=$(get_version_from_local_rpm $DIR/files/$PRODUCT-jmx*.noarch.rpm)
     SCYLLA_TOOLS_VERSION=$(get_version_from_local_rpm $DIR/files/$PRODUCT-tools-*.noarch.rpm)
-    SCYLLA_PYTHON3_VERSION=$(get_version_from_local_rpm $DIR/files/$PRODUCT-python3*.x86_64.rpm)
+    SCYLLA_PYTHON3_VERSION=$(get_version_from_local_rpm $DIR/files/$PRODUCT-python3*.$(arch).rpm)
 elif [ $DOWNLOAD_ONLY -eq 1 ]; then
     if [ -z "$REPO_FOR_INSTALL" ]; then
         print_usage
@@ -149,4 +150,4 @@ mkdir -p build
 export PACKER_LOG=1
 export PACKER_LOG_PATH=build/ami.log
 
-/usr/bin/packer build -var-file=variables.json -var install_args="$INSTALL_ARGS" -var region="$REGION" -var source_ami="$AMI" -var ssh_username="$SSH_USERNAME" -var scylla_version="$SCYLLA_VERSION" -var scylla_machine_image_version="$SCYLLA_MACHINE_IMAGE_VERSION" -var scylla_jmx_version="$SCYLLA_JMX_VERSION" -var scylla_tools_version="$SCYLLA_TOOLS_VERSION" -var scylla_python3_version="$SCYLLA_PYTHON3_VERSION" -var scylla_ami_description="${SCYLLA_AMI_DESCRIPTION:0:255}" scylla.json
+/usr/bin/packer build -var-file=variables.json -var install_args="$INSTALL_ARGS" -var region="$REGION" -var source_ami="${AMI[$(arch)]}" -var ssh_username="$SSH_USERNAME" -var scylla_version="$SCYLLA_VERSION" -var scylla_machine_image_version="$SCYLLA_MACHINE_IMAGE_VERSION" -var scylla_jmx_version="$SCYLLA_JMX_VERSION" -var scylla_tools_version="$SCYLLA_TOOLS_VERSION" -var scylla_python3_version="$SCYLLA_PYTHON3_VERSION" -var scylla_ami_description="${SCYLLA_AMI_DESCRIPTION:0:255}" scylla.json

--- a/aws/ami/files/scylla_install_ami
+++ b/aws/ami/files/scylla_install_ami
@@ -24,6 +24,7 @@ import shlex
 import tarfile
 import argparse
 import subprocess
+import platform
 
 def run(cmd, shell=False):
     if not shell:
@@ -89,10 +90,6 @@ if __name__ == '__main__':
     os.remove('{}/.ssh/authorized_keys'.format(homedir))
     os.remove('/var/lib/scylla-housekeeping/housekeeping.uuid')
 
-    run('yum -y install grubby')
-    run('rpm --import https://www.elrepo.org/RPM-GPG-KEY-elrepo.org')
-    run('rpm -Uvh http://www.elrepo.org/elrepo-release-7.0-3.el7.elrepo.noarch.rpm')
-    run('yum -y --enablerepo=elrepo-kernel install kernel-ml')
     os.remove('/etc/udev/rules.d/80-net-name-slot.rules')
     with open('/etc/default/grub') as f:
         grub = f.read()
@@ -100,10 +97,6 @@ if __name__ == '__main__':
     with open('/etc/default/grub', 'w') as f:
         f.write(grub)
     run('grub2-mkconfig -o /boot/grub2/grub.cfg')
-    mlkver = get_kver('/boot/vmlinuz-*el7.elrepo.x86_64')
-    run('grubby --grub2 --set-default /boot/vmlinuz-{mlkver}'.format(mlkver=mlkver))
-    with open('/etc/yum.conf', 'a') as f:
-        f.write(u'exclude=kernel kernel-devel')
 
     with open('/etc/cloud/cloud.cfg') as f:
         cfg = f.read()
@@ -112,3 +105,19 @@ if __name__ == '__main__':
     with open('/etc/cloud/cloud.cfg', 'w') as f:
         f.write(cfg2)
     shutil.move('{}/99_user_alias.cfg'.format(homedir), '/etc/cloud/cloud.cfg.d')
+
+    # We need to install LTS kernel for the AMI.
+    # However, elrepo-kernel only provides x86_64 package,
+    # and centos-kernel (altarch/7/kernel) only provides aarch64 package.
+    # So we have to use different kernel here.
+    if platform.machine() == 'x86_64':
+        run('yum -y install grubby')
+        run('rpm --import https://www.elrepo.org/RPM-GPG-KEY-elrepo.org')
+        run('rpm -Uvh http://www.elrepo.org/elrepo-release-7.0-3.el7.elrepo.noarch.rpm')
+        run('yum -y --enablerepo=elrepo-kernel install kernel-ml')
+        mlkver = get_kver('/boot/vmlinuz-*el7.elrepo.x86_64')
+        run('grubby --grub2 --set-default /boot/vmlinuz-{mlkver}'.format(mlkver=mlkver))
+        with open('/etc/yum.conf', 'a') as f:
+            f.write(u'exclude=kernel kernel-devel')
+    elif platform.machine() == 'aarch64':
+        run('yum -y --enablerepo=centos-kernel update kernel')

--- a/dist/redhat/build_rpm.sh
+++ b/dist/redhat/build_rpm.sh
@@ -64,11 +64,6 @@ if [[ ! -e dist/redhat/build_rpm.sh ]]; then
     exit 1
 fi
 
-if [[ "$(arch)" != "x86_64" ]]; then
-    echo "Unsupported architecture: $(arch)"
-    exit 1
-fi
-
 pkg_install rpm-build
 pkg_install git
 pkg_install python3


### PR DESCRIPTION
Currently we don't provide aarch64 rpm on our official repo, but it can
build locally by standard procedure of building package, on aarch64 machine.
Let's support the architecture on scylla-machine-image too, for testing purposes.

Related: scylladb/scylla#7026