### PR TITLE
Set product for AMI and GCE based on SCYLLA-VERSION-GEN

### DIFF
--- a/aws/ami/build_ami.sh
+++ b/aws/ami/build_ami.sh
@@ -14,7 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-PRODUCT=scylla
+source ../../SCYLLA-VERSION-GEN
+
+PRODUCT=$(cat build/SCYLLA-PRODUCT-FILE)
 DIR=$(dirname $(readlink -f $0))
 
 print_usage() {

--- a/gce/image/build_image.sh
+++ b/gce/image/build_image.sh
@@ -14,7 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-PRODUCT=scylla
+source ../../SCYLLA-VERSION-GEN
+
+PRODUCT=$(cat build/SCYLLA-PRODUCT-FILE)
 BUILD_ID=$(date -u '+%FT%H-%M-%S')
 DIR=$(dirname $(readlink -f $0))
 


### PR DESCRIPTION
Today we have PRODUCT definition in SCYLLA-VERSION-GEN , let's start
using it as a source instead of defining it manually for both AMI and
GCE. This way we can have a generic code for both open source and
enterprise