### PR TITLE
fix(gce_device_path): fix get full device path for gce image

### DIFF
--- a/common/scylla_create_devices
+++ b/common/scylla_create_devices
@@ -49,12 +49,14 @@ def get_disk_devices(instance, device_type):
 
 
 def get_default_devices(instance):
+    disk_names = []
     if is_ec2():
-        return [os.path.join('/dev/', name) for name in instance.ephemeral_disks()]
+        disk_names = instance.ephemeral_disks()
     elif is_gce():
-        return instance.getEphemeralOsDisks()
+        disk_names = instance.getEphemeralOsDisks()
     else:
         raise Exception("Running in unknown cloud environment")
+    return [os.path.join('/dev/', name) for name in disk_names]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
method from scylla_util for gce instance return only name
of empherial device. Fix method to get_default_devices full path
for gce instances

Fix issue: https://github.com/scylladb/scylla-machine-image/issues/91