### PR TITLE
aws: add support package manifest file

### DIFF
--- a/packer/scylla.json
+++ b/packer/scylla.json
@@ -148,6 +148,12 @@
         "sudo /home/{{user `ssh_username`}}/scylla_install_image --target-cloud {{build_name}} {{user `install_args`}}"
       ],
       "type": "shell"
+    },
+    {
+      "source": "/home/{{user `ssh_username`}}/scylla-packages.txt",
+      "destination": "build/",
+      "direction": "download",
+      "type": "file"
     }
   ],
   "variables": {

--- a/packer/scylla_install_image
+++ b/packer/scylla_install_image
@@ -245,3 +245,20 @@ if __name__ == '__main__':
                 f.write(u'exclude=kernel kernel-devel')
         elif platform.machine() == 'aarch64':
             run('yum -y --enablerepo=centos-kernel update kernel')
+
+    # generate package manifest to scylla-packages.txt
+    if distro == 'centos':
+        run('yum install -y yum-utils')
+        packages = subprocess.check_output('repoquery --requires --resolve --recursive --installed scylla', stderr=subprocess.STDOUT, shell=True)
+        with open('{}/scylla-packages.txt'.format(homedir), 'w') as f:
+            f.write(packages)
+    else:
+        deps = subprocess.check_output('apt-cache depends --recurse --no-recommends --no-suggests --no-conflicts --no-breaks --no-replaces --no-enhances --installed scylla', stderr=subprocess.STDOUT, shell=True, encoding='utf-8').splitlines()
+        pkgs=[]
+        for d in deps:
+            if re.match(r'^\w', d) and not re.match(r'.+:i386$', d) and d not in pkgs:
+                pkgs.append(d)
+        with open('{}/scylla-packages.txt'.format(homedir), 'w') as f:
+            for pkg_name in pkgs:
+                pkg_name_version = subprocess.check_output("dpkg-query --showformat='${{Package}}-${{Version}}' --show {}".format(pkg_name), shell=True, encoding='utf-8')
+                f.write('{}\n'.format(pkg_name_version))


### PR DESCRIPTION
To fullfill SOC2 requirement, we need to make sure OS is up to date.
However, just running 'yum update' on whole cluster nodes may install
different versions of packages, that can cause issue on Scylla.
So generate package manifest that records package versions of all
required packages for Scylla, and use the manifest for Scylla upgrade.

Package manifest build while generating AMI, download to
build/scylla-packages.txt on build host.

Related with https://github.com/scylladb/scylla-pkg/issues/1869