### PR TITLE
fix(scylla_create_devices): improve logic for found devices

### DIFF
--- a/common/scylla_configure.py
+++ b/common/scylla_configure.py
@@ -45,7 +45,16 @@ class ScyllaMachineImageConfigurator:
         'developer_mode': False,
         'post_configuration_script': '',
         'post_configuration_script_timeout': 600,  # seconds
-        'start_scylla_on_first_boot': True
+        'start_scylla_on_first_boot': True,
+        'data_device': 'auto'  # Supported options:
+                               #   instance_store - find all ephemeral devices (only for AWS)
+                               #   attached - find all attached devices and use them
+                               #   auto - automatically select devices using following strategy:
+                               #       GCE: select attached NVMe.
+                               #       AWS:
+                               #           if ephemeral found - use them
+                               #           else if attached EBS found use them
+                               #           else: fail create_devices
     }
 
     DISABLE_START_FILE_PATH = Path("/etc/scylla/ami_disabled")
@@ -146,11 +155,10 @@ class ScyllaMachineImageConfigurator:
             self.DISABLE_START_FILE_PATH.touch()
 
     def create_devices(self):
-        device_type = self.instance_user_data.get("data_device")
-        use_device_type = "--data-device {}".format(device_type) if device_type else ""
-
+        device_type = self.instance_user_data.get("data_device", self.CONF_DEFAULTS['data_device'])
         try:
-            subprocess.run("/opt/scylladb/scylla-machine-image/scylla_create_devices {}".format(use_device_type), shell=True, check=True)
+            LOGGER.info(f"Create scylla data devices as {device_type}")
+            subprocess.run(f"/opt/scylladb/scylla-machine-image/scylla_create_devices --data-device {device_type}", shell=True, check=True)
         except Exception as e:
             LOGGER.error("Failed to create devices: %s", e)
 

--- a/common/scylla_create_devices
+++ b/common/scylla_create_devices
@@ -15,7 +15,6 @@
 # limitations under the License.
 
 import argparse
-import os
 import sys
 from pathlib import Path
 from subprocess import run
@@ -27,6 +26,7 @@ from scylla_util import is_ec2, is_gce, get_cloud_instance
 
 def create_raid(devices):
     scylla_path = Path("/var/lib/scylla")
+    print(f"Devices: {devices}")
     if scylla_path.is_mount():
         print(f"{scylla_path} is already mounted. Will not run 'scylla_raid_setup'!")
         sys.exit(0)
@@ -36,12 +36,14 @@ def create_raid(devices):
 
 def get_disk_devices(instance, device_type):
     if is_ec2():
+        devices = []
         if device_type == "attached":
-            return [os.path.join('/dev/', name) for name in instance.ebs_disks()]
-        elif device_type == "instance_store":
-            return [os.path.join('/dev/', name) for name in instance.ephemeral_disks()]
-        else:
-            raise Exception(f"Unknown devicetype {device_type}")
+            devices = [str(Path('/dev', name)) for name in instance.ebs_disks() if Path('/dev', name).exists()]
+        if not devices or device_type == "instance_store":
+            devices = [str(Path('/dev', name)) for name in instance.ephemeral_disks()]
+        if not devices:
+            raise Exception(f"No block devices were found for '{device_type}' device type")
+        return devices
     elif is_gce():
         return get_default_devices(instance)
     else:
@@ -51,24 +53,24 @@ def get_disk_devices(instance, device_type):
 def get_default_devices(instance):
     disk_names = []
     if is_ec2():
-        disk_names = instance.ephemeral_disks()
+        disk_names = instance.ephemeral_disks() or instance.ebs_disks()
     elif is_gce():
         disk_names = instance.getEphemeralOsDisks()
     else:
         raise Exception("Running in unknown cloud environment")
-    return [os.path.join('/dev/', name) for name in disk_names]
+    return [str(Path('/dev', name)) for name in disk_names]
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Disk creation script for Scylla.')
     parser.add_argument('--data-device', dest='data_device', action='store',
-                        choices=["attached", "instance_store"],
+                        choices=["auto", "attached", "instance_store"],
                         help='Define type of device to use for scylla data: attached|instance_store')
     args = parser.parse_args()
 
     instance = get_cloud_instance()
 
-    if not args.data_device:
+    if not args.data_device or args.data_device == "auto":
         disk_devices = get_default_devices(instance)
     else:
         disk_devices = get_disk_devices(instance, args.data_device)


### PR DESCRIPTION
scylla_create_devices support 3 variants for data_device:
- auto: for aws instance will search nvme(ephemeral) device,
          if not found will search ebs volumes(ebs).
        for gce instances will search nvme(attached) devices
for aws instances:
- attached: will search ebs volumes(attached) and if such volumes
            added to os as nvme devices, will use them
- instance_store: will search nvme(ephemeral) devices and use