### PR TITLE
scylla_install_image:install based on product

### DIFF
--- a/gce/image/build_image.sh
+++ b/gce/image/build_image.sh
@@ -58,6 +58,7 @@ while [ $# -gt 0 ]; do
             ;;
         "--product")
             PRODUCT=$2
+            INSTALL_ARGS="$INSTALL_ARGS --product $2"
             shift 2
             ;;
         "--build-id")

--- a/gce/image/files/scylla_install_image
+++ b/gce/image/files/scylla_install_image
@@ -37,6 +37,8 @@ def parse_cli_args():
     parser = argparse.ArgumentParser(description='Construct AMI')
     parser.add_argument('--localrpm', action='store_true', default=False,
                         help='deploy locally built rpms')
+    parser.add_argument('--product',
+                        help='name of the product', default='scylla')
     parser.add_argument('--repo',
                         help='repository for both install and update, specify .repo file URL')
     parser.add_argument('--repo-for-install',
@@ -67,7 +69,7 @@ if __name__ == '__main__':
         rpms = glob.glob('/home/centos/scylla*.*.rpm')
         run('yum install -y {}'.format(' '.join(rpms)))
     else:
-        run('yum install -y scylla-python3 scylla scylla-machine-image scylla-debuginfo')
+        run('yum install -y {0}-python3 {0} {0}-machine-image {0}-debuginfo'.format(args.product))
 
     run("echo '/opt/scylladb/scylla-machine-image/scylla_login' >> /etc/skel/.bash_profile")
 
@@ -87,5 +89,3 @@ if __name__ == '__main__':
     run('rpm --import https://www.elrepo.org/RPM-GPG-KEY-elrepo.org')
     run('yum install -y https://www.elrepo.org/elrepo-release-8.el8.elrepo.noarch.rpm')
     run('yum -y --enablerepo=elrepo-kernel install kernel-ml kernel-ml-devel')
-
-


### PR DESCRIPTION
When building GCE image in enterprise the build pass although we getting en error as mention below:
7:31:42  [0;32m    googlecompute: Scylla for Centos 8 - x86_64                     34 kB/s |  19 kB     00:00[0m
17:31:42  [0;32m    googlecompute: Scylla for centos 8                             8.8 kB/s | 3.8 kB     00:00[0m
17:31:43  [0;32m    googlecompute: No match for argument: scylla-python3[0m
17:31:43  [0;32m    googlecompute: No match for argument: scylla-machine-image[0m
17:31:43  [0;32m    googlecompute: No match for argument: scylla-debuginfo[0m
(referance https://jenkins.scylladb.com/job/enterprise-2021.1/job/gce-image/7/consoleFull)

Let's start installing scylla in GCE image based on product , so it will
work for both open source and enterprise