### PR TITLE
aws/ami: fix broken Docker build for CentOS AMI

### DIFF
--- a/aws/ami/Dockerfile
+++ b/aws/ami/Dockerfile
@@ -1,6 +1,6 @@
 FROM centos:7
 
-RUN yum install -y wget curl unzip yum-utils sudo
+RUN yum install -y wget curl unzip yum-utils sudo git
 
 ENV PACKER_VERSION=1.5.1
 ENV EXPECTED="3305ede8886bc3fd83ec0640fb87418cc2a702b2cb1567b48c8cb9315e80047d  packer_linux_amd64.zip"

--- a/aws/ami/build_with_docker.sh
+++ b/aws/ami/build_with_docker.sh
@@ -16,7 +16,7 @@
 
 docker build  . -t scylladb/packer-builder
 
-DOCKER_ID=$(docker run -e AWS_SECRET_ACCESS_KEY -e AWS_ACCESS_KEY_ID -d  -v $HOME/.aws:/root/.aws -v `pwd`:/ami scylladb/packer-builder /bin/bash -c "cd /ami ; bash ./build_ami.sh $*")
+DOCKER_ID=$(docker run -e AWS_SECRET_ACCESS_KEY -e AWS_ACCESS_KEY_ID -d  -v $HOME/.aws:/root/.aws -v `pwd`/../..:/scylla-machine-image scylladb/packer-builder /bin/bash -c "cd /scylla-machine-image/aws/ami; ./build_ami.sh $*")
 
 kill_it() {
     if [[ -n "$DOCKER_ID" ]]; then


### PR DESCRIPTION
build_with_docker.sh currently fails to call ../../SCYLLA-VERSION-GEN,
fixed the issue to make it runnable again.