### PR TITLE
GCE: Let script return an error

### DIFF
--- a/gce/image/build_image.sh
+++ b/gce/image/build_image.sh
@@ -47,11 +47,13 @@ while [ $# -gt 0 ]; do
             ;;
         "--repo")
             REPO_FOR_INSTALL=$2
+            echo "--repo: $REPO_FOR_INSTALL"
             INSTALL_ARGS="$INSTALL_ARGS --repo $2"
             shift 2
             ;;
         "--repo-for-install")
             REPO_FOR_INSTALL=$2
+            echo "--repo-for-install: $REPO_FOR_INSTALL"
             INSTALL_ARGS="$INSTALL_ARGS --repo-for-install $2"
             shift 2
             ;;
@@ -83,6 +85,7 @@ while [ $# -gt 0 ]; do
             shift 1
             ;;
         *)
+            echo "ERROR: Illegal option: $1"
             print_usage
             ;;
     esac
@@ -128,6 +131,7 @@ if [ $LOCALRPM -eq 1 ]; then
     SCYLLA_PYTHON3_VERSION=$(get_version_from_local_rpm $DIR/files/$PRODUCT-python3*.x86_64.rpm)
 elif [ $DOWNLOAD_ONLY -eq 1 ]; then
     if [ -z "$REPO_FOR_INSTALL" ]; then
+        echo "ERROR: No --repo or --repo-for-install were given on DOWNLOAD_ONLY run."
         print_usage
         exit 1
     fi
@@ -140,6 +144,7 @@ elif [ $DOWNLOAD_ONLY -eq 1 ]; then
     exit 0
 else
     if [ -z "$REPO_FOR_INSTALL" ]; then
+        echo "ERROR: No --repo or --repo-for-install were given."
         print_usage
         exit 1
     fi

--- a/gce/image/build_image.sh
+++ b/gce/image/build_image.sh
@@ -31,12 +31,14 @@ print_usage() {
     echo "  --download-no-server download all rpms needed excluding scylla using .repo provided in --repo-for-install"
     echo "  --dry-run            validate template only (image is not built)"
     echo "  --build-id           Set unique build ID, will be part of GCE image name"
+    echo "  --log-file           Path for log. Default build/packer.log on current dir"
     exit 1
 }
 LOCALRPM=0
 DOWNLOAD_ONLY=0
 PACKER_SUB_CMD="build -force -on-error=abort"
 REPO_FOR_INSTALL=
+PACKER_LOG_PATH=build/packer.log
 while [ $# -gt 0 ]; do
     case "$1" in
         "--localrpm")
@@ -64,6 +66,10 @@ while [ $# -gt 0 ]; do
             ;;
         "--build-id")
             BUILD_ID=$2
+            shift 2
+            ;;
+        "--log-file")
+            PACKER_LOG_PATH=$2
             shift 2
             ;;
         "--download-no-server")
@@ -163,7 +169,7 @@ cd $DIR
 mkdir -p build
 
 export PACKER_LOG=1
-export PACKER_LOG_PATH=build/packer.log
+export PACKER_LOG_PATH
 echo "Scylla versions:"
 echo "SCYLLA_VERSION: $SCYLLA_VERSION"
 echo "SCYLLA_MACHINE_IMAGE_VERSION: $SCYLLA_MACHINE_IMAGE_VERSION"


### PR DESCRIPTION
This is done together with https://github.com/scylladb/scylla-pkg/pull/1997
I want the GCE pipeline to get an error when GCE creation failed.
We also run the process with tee to log file, so we can read the ID from it.
This is a duplication, as the build_image script already writes a log.
- Get the name of the log from caller (still supply the current value as default). This will prevent the need to save a copy of the log (tee on tee).
- Search the log for error, and return status.