### PR TITLE
dist/debian: fix renaming debian/scylla-* files rule

### DIFF
--- a/dist/debian/debian_files_gen.py
+++ b/dist/debian/debian_files_gen.py
@@ -23,8 +23,9 @@
 
 import string
 import os
-import glob
 import shutil
+import re
+from pathlib import Path
 
 class DebianFilesTemplate(string.Template):
     delimiter = '%'
@@ -51,8 +52,23 @@ if os.path.exists('build/debian/scylla-machine-image/debian'):
 shutil.copytree('dist/debian/debian', 'build/debian/scylla-machine-image/debian')
 
 if product != 'scylla':
-    for p in glob.glob('build/debian/scylla-machine-image/debian/scylla-*'):
-        shutil.move(p, p.replace('scylla-', '{}-'.format(product)))
+    # Unlike other packages, scylla-machine-image is not relocatable package,
+    # so we don't generate debian direcotry on build/debian/debian
+    # to relocatable tar.gz
+    for p in Path('build/debian/scylla-machine-image/debian').glob('scylla-*'):
+        # pat1: scylla-server.service
+        #    -> scylla-enterprise-server.scylla-server.service
+        # pat2: scylla-server.scylla-fstrim.service
+        #    -> scylla-enterprise-server.scylla-fstrim.service
+        # pat3: scylla-conf.install
+        #    -> scylla-enterprise-conf.install
+
+        if m := re.match(r'^scylla(-[^.]+)\.service$', p.name):
+            p.rename(p.parent / f'{product}{m.group(1)}.{p.name}')
+        elif m := re.match(r'^scylla(-[^.]+\.scylla-[^.]+\.[^.]+)$', p.name):
+            p.rename(p.parent / f'{product}{m.group(1)}')
+        else:
+            p.rename(p.parent / p.name.replace('scylla', product, 1))
 
 s = DebianFilesTemplate(changelog_template)
 changelog_applied = s.substitute(product=product, version=version, release=release, revision='1', codename='stable')


### PR DESCRIPTION
Ported https://github.com/scylladb/scylla/commit/d7f202f9008ce312a8d0b71b41d073db7923ce1c to scylla-machine-image to fix scylladb/scylla-enterprise-machine-image#16.

----

Current renaming rule of debian/scylla-* files is buggy, it fails to
install some .service files when custom product name specified.

Introduce regex based rewriting instead of adhoc renaming, and fixed
wrong renaming rule.

Fixes scylladb/scylla-enterprise-machine-image#16