### PR TITLE
Stop traceback when no ephemeral disks attached, print human readable message

### DIFF
--- a/common/scylla_create_devices
+++ b/common/scylla_create_devices
@@ -75,4 +75,7 @@ if __name__ == "__main__":
     else:
         disk_devices = get_disk_devices(instance, args.data_device)
 
-    create_raid(disk_devices)
+    if len(disk_devices) == 0:
+        print('No data disks found')
+    else:
+        create_raid(disk_devices)

--- a/common/scylla_image_setup
+++ b/common/scylla_image_setup
@@ -24,6 +24,10 @@ from subprocess import run
 if __name__ == '__main__':
     cloud_instance = get_cloud_instance()
     run('/opt/scylladb/scylla-machine-image/scylla_configure.py', shell=True, check=True)
+    if not os.path.ismount('/var/lib/scylla'):
+        print('Failed to initialize RAID volume, exiting setup')
+        sys.exit(1)
+
     run('/opt/scylladb/scripts/scylla_sysconfig_setup --nic eth0 --setup-nic --ami', shell=True, check=True)
     if cloud_instance.is_supported_instance_class():
         cloud_instance.io_setup()


### PR DESCRIPTION
When we run AMI without ephemeral disks, scylla-image-setup.service will
fail with python traceback.
It is not user friendly, it's better to print human readable message.

Fixes #111
Fixes #112