### PR TITLE
dist: remove .bash_profile from package, configure it in scylla_install_ami

### DIFF
--- a/aws/ami/files/scylla_install_ami
+++ b/aws/ami/files/scylla_install_ami
@@ -145,8 +145,13 @@ if __name__ == '__main__':
     run('cloud-init clean')
     run('cloud-init init')
     for skel in glob.glob('/etc/skel/.*'):
-        if not skel.endswith('.bash_profile'):
-            shutil.copy(skel, '/home/scyllaadm')
+        shutil.copy(skel, '/home/scyllaadm')
+    if distro == 'centos':
+        profile = '/home/scyllaadm/.bash_profile'
+    else:
+        profile = '/home/scyllaadm/.profile'
+    with open(profile, 'a') as f:
+        f.write('\n\n/opt/scylladb/scylla-machine-image/scylla_login\n')
     run('useradd -o -u 1000 -g scyllaadm -s /bin/bash -d /home/scyllaadm centos')
     if distro == 'ubuntu':
         run('useradd -o -u 1000 -g scyllaadm -s /bin/bash -d /home/scyllaadm ubuntu')

--- a/dist/debian/debian/conffiles
+++ b/dist/debian/debian/conffiles
@@ -1,1 +1,0 @@
-/home/scyllaadm/.bash_profile

--- a/dist/debian/debian/rules
+++ b/dist/debian/debian/rules
@@ -15,8 +15,6 @@ override_dh_auto_install:
 		--with-python3 $(CURDIR)/debian/tmp/opt/scylladb/python3/bin/python3 \
 	common/scylla_image_setup common/scylla_login common/scylla_configure.py \
 	common/scylla_create_devices
-	install -d -m755 $(CURDIR)/debian/tmp/home/scyllaadm
-	install -m644 common/.bash_profile $(CURDIR)/debian/tmp/home/scyllaadm
 
 override_dh_installinit:
 	dh_installinit --no-start --name scylla-image-setup

--- a/dist/debian/debian/scylla-machine-image.install
+++ b/dist/debian/debian/scylla-machine-image.install
@@ -1,2 +1,1 @@
 opt/scylladb/scylla-machine-image/*
-home/scyllaadm/.bash_profile

--- a/dist/redhat/scylla-machine-image.spec
+++ b/dist/redhat/scylla-machine-image.spec
@@ -41,9 +41,6 @@ install -m755 common/scylla_configure.py common/scylla_create_devices \
     --with-python3 ${RPM_BUILD_ROOT}/opt/scylladb/python3/bin/python3 \
     common/scylla_image_setup common/scylla_login common/scylla_configure.py \
     common/scylla_create_devices
-install -d -m755 $RPM_BUILD_ROOT/home
-install -d -m755 $RPM_BUILD_ROOT/home/scyllaadm
-install -m755 common/.bash_profile $RPM_BUILD_ROOT/home/scyllaadm
 
 %pre
 /usr/sbin/groupadd scylla 2> /dev/null || :
@@ -58,6 +55,15 @@ install -m755 common/.bash_profile $RPM_BUILD_ROOT/home/scyllaadm
 %postun
 %systemd_postun scylla-image-setup.service
 
+%posttrans
+if [ -L /home/scyllaadm/.bash_profile ] && [ ! -e /home/scyllaadm/.bash_profile ]; then
+    rm /home/scyllaadm/.bash_profile
+    cp /etc/skel/.bash_profile /home/scyllaadm/
+    chown scyllaadm:scyllaadm /home/scyllaadm/.bash_profile
+    echo -e '\n' >> /home/scyllaadm/.bash_profile
+    echo "/opt/scylladb/scylla-machine-image/scylla_login" >> /home/scyllaadm/.bash_profile
+fi
+
 %clean
 rm -rf $RPM_BUILD_ROOT
 
@@ -66,7 +72,6 @@ rm -rf $RPM_BUILD_ROOT
 %license LICENSE
 %defattr(-,root,root)
 
-%config /home/scyllaadm/.bash_profile
 %{_unitdir}/scylla-image-setup.service
 /opt/scylladb/scylla-machine-image/*
 


### PR DESCRIPTION
We have permission issue on /home/scyllaadm/, it owned by root:root but
should be scyllaadm:scyllaadm.
However, we create scyllaadm user AFTER installing scylla-machine-image
package, so it's not possible to do that in the package.

We don't really need to keep /home/scyllaadm/.bash_profile in package.
We just need to do "echo /opt/scylladb/scylla-machine-image/scylla_login >> ~/.bash_profile" in scylla_install_ami instead.
In fact, we already do so in GCE since login user of GCE is not static,
we addd scylla_login to /etc/skel/.bash_profile.
So let's align the way to configure .bash_profile to GCE, drop
.bash_profile from rpm/deb packages, configure .bash_profile in
scylla_install_ami.

Also, we need to take care upgrade scylla-machine-image package.
To do so, remove /home/scyllaadm/.bash_profile symlink and generate new
.bash_profile in %posttrans of the rpm package.

Fixes scylladb/scylla-enterprise#1684