### PR TITLE
dist/debian/build_deb.sh:debian version number fix

### DIFF
--- a/dist/debian/build_deb.sh
+++ b/dist/debian/build_deb.sh
@@ -100,6 +100,11 @@ PRODUCT=$(cat build/SCYLLA-PRODUCT-FILE)
 BUILDDIR=build/debian
 PACKAGE_NAME="$PRODUCT-machine-image"
 
+if echo $SCYLLA_VERSION | grep rc >/dev/null ; then
+ SCYLLA_VERSION=$(echo $SCYLLA_VERSION |sed 's/\(.*\)\.)*/\1~/')
+ VERSION="$SCYLLA_VERSION-$SCYLLA_RELEASE"
+fi
+
 rm -rf "$BUILDDIR"
 mkdir -p "$BUILDDIR"/scylla-machine-image
 


### PR DESCRIPTION
We recently started to build deb package in scylla-machine-image but
package version is X.X.X while spinning RCs we need to change the
version format to X.X~rcX

When tried to build unified-deb in 4.5 (rc0) we saw the following error:
```
13:19:41  This package has a Debian revision number but there does not seem to be
13:19:41  an appropriate original tar file or .orig directory in the parent directory;
13:19:41  (expected one of scylla-machine-image_4.5~rc0-20210405.0ef5d340d7f.orig.tar.gz, scylla-machine-image_4.5~rc0-20210405.0ef5d340d7f.orig.tar.bz2,
13:19:41  scylla-machine-image_4.5~rc0-20210405.0ef5d340d7f.orig.tar.lzma,  scylla-machine-image_4.5~rc0-20210405.0ef5d340d7f.orig.tar.xz or scylla-machine-image.orig)
13:19:41  continue anyway? (y/n) Use of uninitialized value $ans in pattern match (m//) at /usr/bin/debuild line 1009.
```
Fixes: https://github.com/scylladb/scylla-machine-image/issues/118