### PR TITLE
aws/ami: drop /home/centos, make it symlink of /home/scyllaadm

### DIFF
--- a/aws/ami/files/scylla_install_ami
+++ b/aws/ami/files/scylla_install_ami
@@ -141,9 +141,10 @@ if __name__ == '__main__':
         cfg = re.sub('^     name: ubuntu', '     name: scyllaadm', cfg, flags=re.MULTILINE)
     with open('/etc/cloud/cloud.cfg', 'w') as f:
         f.write(cfg)
-    run('userdel -f {}'.format(distro))
+    run('userdel -r -f {}'.format(distro))
     run('cloud-init clean')
     run('cloud-init init')
+    run('ln -sf /home/scyllaadm {}'.format(homedir))
     for skel in glob.glob('/etc/skel/.*'):
         if not skel.endswith('.bash_profile'):
             shutil.copy(skel, '/home/scyllaadm')


### PR DESCRIPTION
Currently, 'centos' user is alias of 'scyllaadm', and its home directory
is /home/scyllaaadm, but original /home/centos is still remain.
To maximize compatibility, drop /home/centos and make it symlink of
/home/scyllaadm.

Fixes #120