### PR TITLE
gce: Disable writeback cache

### DIFF
--- a/gce/image/files/scylla_install_image
+++ b/gce/image/files/scylla_install_image
@@ -105,7 +105,7 @@ if __name__ == '__main__':
     run('systemctl daemon-reload')
     run('systemctl enable scylla-image-setup.service')
     run('/opt/scylladb/scripts/scylla_setup --no-coredump-setup --no-sysconfig-setup --no-raid-setup --no-io-setup --no-bootparam-setup --no-ec2-check --no-swap-setup')
-    run('/opt/scylladb/scripts/scylla_sysconfig_setup --ami')
+    run('/opt/scylladb/scripts/scylla_sysconfig_setup --ami --disable-writeback-cache')
     housekeeping_uuid_path = Path('/var/lib/scylla-housekeeping/housekeeping.uuid')
     if housekeeping_uuid_path.exists():
         housekeeping_uuid_path.unlink()


### PR DESCRIPTION
As outlined in scylladb/scylla#7341, we need to disable writeback cache
on GCE for better performance.