### PR TITLE
aws: add group alias to centos/ubuntu

### DIFF
--- a/aws/ami/files/scylla_install_ami
+++ b/aws/ami/files/scylla_install_ami
@@ -148,8 +148,10 @@ if __name__ == '__main__':
         if not skel.endswith('.bash_profile'):
             shutil.copy(skel, '/home/scyllaadm')
     run('useradd -o -u 1000 -g scyllaadm -s /bin/bash -d /home/scyllaadm centos')
+    run('groupadd -o -g 1000 centos')
     if distro == 'ubuntu':
         run('useradd -o -u 1000 -g scyllaadm -s /bin/bash -d /home/scyllaadm ubuntu')
+        run('groupadd -o -g 1000 ubuntu')
 
     if distro == 'centos':
         # We need to install LTS kernel for the AMI.


### PR DESCRIPTION
Just like user alias, add group alias to centos/ubuntu.

Fixes #123