### PR TITLE
dist/debian: Fix scylla-image-setup.service rename

### DIFF
--- a/dist/debian/debian_files_gen.py
+++ b/dist/debian/debian_files_gen.py
@@ -64,7 +64,7 @@ if product != 'scylla':
         #    -> scylla-enterprise-conf.install
 
         if m := re.match(r'^scylla(-[^.]+)\.service$', p.name):
-            p.rename(p.parent / f'{product}{m.group(1)}.{p.name}')
+            p.rename(p.parent / f'{p.name}')
         elif m := re.match(r'^scylla(-[^.]+\.scylla-[^.]+\.[^.]+)$', p.name):
             p.rename(p.parent / f'{product}{m.group(1)}')
         else:


### PR DESCRIPTION
Ubuntu based AMI in enterprise failed due to:
```
16:40:23  [1;31m==> amazon-ebs: Failed to enable unit: Unit file scylla-image-setup.service does not exist.[0m
```

Let's make sure scylla-image-setup.service is constant and not product
based

Fixes: https://github.com/scylladb/scylla-enterprise/issues/1726