### PR TITLE
aws: chown skel files to scyllaadm:scyllaadm

### DIFF
--- a/aws/ami/files/scylla_install_ami
+++ b/aws/ami/files/scylla_install_ami
@@ -147,6 +147,7 @@ if __name__ == '__main__':
     run('ln -sf /home/scyllaadm {}'.format(homedir))
     for skel in glob.glob('/etc/skel/.*'):
         shutil.copy(skel, '/home/scyllaadm')
+        os.chown(skel, 1000, 1000)
     if distro == 'centos':
         profile = '/home/scyllaadm/.bash_profile'
     else:


### PR DESCRIPTION
dot files should be owned by user, so chown them.

Fixes #125