### PR TITLE
scylla_login: print warning message when no RAID disks available

### DIFF
--- a/common/scylla_login
+++ b/common/scylla_login
@@ -49,6 +49,12 @@ To continue startup ScyllaDB on this instance, run 'sudo scylla_io_setup' then '
 For a list of optimized instance types and more EC2 instructions see '%s'"
 
 '''[1:-1]
+MSG_UNSUPPORTED_INSTANCE_TYPE_NO_DISKS = '''
+    {red}{type} is not eligible for optimized automatic tuning!{nocolor}
+To continue startup ScyllaDB on this instance, you need to attach additional disks, then run 'sudo scylla_io_setup' then 'systemctl start scylla-server'.
+For a list of optimized instance types and more EC2 instructions see http://www.scylladb.com/doc/getting-started-amazon/"
+
+'''[1:-1]
 MSG_SETUP_ACTIVATING = '''
     {green}Constructing RAID volume...{nocolor}
 
@@ -106,8 +112,13 @@ if __name__ == '__main__':
     colorprint(MSG_HEADER.format(scylla_version=run("scylla --version", shell=True, check=True, capture_output=True, encoding='utf-8').stdout.strip()))
     cloud_instance = get_cloud_instance()
     if not cloud_instance.is_supported_instance_class():
-        colorprint(MSG_UNSUPPORTED_INSTANCE_TYPE % cloud_instance.GETTING_STARTED_URL,
-                   type=cloud_instance.instance_class())
+        if len(cloud_instance.non_root_disks()) == 0:
+            colorprint(MSG_UNSUPPORTED_INSTANCE_TYPE_NO_DISKS % cloud_instance.GETTING_STARTED_URL,
+                type=cloud_instance.instance_class())
+
+        else:
+            colorprint(MSG_UNSUPPORTED_INSTANCE_TYPE % cloud_instance.GETTING_STARTED_URL,
+                type=cloud_instance.instance_class())
     else:
         skip_scylla_server = False
         if not os.path.exists('/etc/scylla/machine_image_configured'):


### PR DESCRIPTION
Scylla AMI requires additional disks to construct data volume, so our
AMI image automatically attaches ephemeral disks for it.
However, some unsupported additional instance types does not supported
any additional disks, so AMI will launch without any additional disks.
On such environment, we have added readable error message on 37ec32c,
but it still only able to check on journalctl.

To warn users more clearly, add new warning message on login prompt.

Fixes scylladb/scylla#8501