### PR TITLE
aws: clear /root/.ssh/authorized_keys entry for Packer temporary SSH key

### DIFF
--- a/aws/ami/scylla.json
+++ b/aws/ami/scylla.json
@@ -54,6 +54,7 @@
       "source_ami": "{{user `source_ami`}}",
       "ssh_timeout": "5m",
       "ssh_username": "{{user `ssh_username`}}",
+      "ssh_clear_authorized_keys": true,
       "subnet_id": "{{user `subnet_id`}}",
       "type": "amazon-ebs",
       "user_data_file": "user_data.txt",


### PR DESCRIPTION
Drop /root/.ssh/authorized_keys entry for Packer temporary SSH key,
since we never need it.

Fixes #133