### PR TITLE
gce-image: set uniqu image name

### DIFF
--- a/gce/image/build_deb_image.sh
+++ b/gce/image/build_deb_image.sh
@@ -180,7 +180,6 @@ echo "SCYLLA_JMX_VERSION: $SCYLLA_JMX_VERSION"
 echo "SCYLLA_TOOLS_VERSION: $SCYLLA_TOOLS_VERSION"
 echo "SCYLLA_PYTHON3_VERSION: $SCYLLA_PYTHON3_VERSION"
 echo "BUILD_ID: $BUILD_ID"
-echo "WORKING_BRANCH: $BRANCH_VERSION"
 echo "Calling Packer..."
 
 /usr/bin/packer ${PACKER_SUB_CMD} \
@@ -194,5 +193,4 @@ echo "Calling Packer..."
   -var scylla_tools_version="$SCYLLA_TOOLS_VERSION" \
   -var scylla_python3_version="$SCYLLA_PYTHON3_VERSION" \
   -var scylla_build_id="$BUILD_ID" \
-  -var scylla_branch_version="$BRANCH_VERSION" \
   scylla_gce.json

--- a/gce/image/build_image.sh
+++ b/gce/image/build_image.sh
@@ -169,7 +169,6 @@ echo "SCYLLA_JMX_VERSION: $SCYLLA_JMX_VERSION"
 echo "SCYLLA_TOOLS_VERSION: $SCYLLA_TOOLS_VERSION"
 echo "SCYLLA_PYTHON3_VERSION: $SCYLLA_PYTHON3_VERSION"
 echo "BUILD_ID: $BUILD_ID"
-echo "WORKING_BRANCH: $BRANCH_VERSION"
 echo "Calling Packer..."
 
 /usr/bin/packer ${PACKER_SUB_CMD} \
@@ -183,5 +182,4 @@ echo "Calling Packer..."
   -var scylla_tools_version="$SCYLLA_TOOLS_VERSION" \
   -var scylla_python3_version="$SCYLLA_PYTHON3_VERSION" \
   -var scylla_build_id="$BUILD_ID" \
-  -var scylla_branch_version="$BRANCH_VERSION" \
   scylla_gce.json

--- a/gce/image/scylla_gce.json
+++ b/gce/image/scylla_gce.json
@@ -11,7 +11,7 @@
       "machine_type": "{{user `instance_type`}}",
       "metadata": {"block-project-ssh-keys": "TRUE"},
       "image_family": "scylla",
-      "image_name": "scylla-{{user `scylla_branch_version`| clean_resource_name}}-build-{{user `scylla_build_id`| clean_resource_name}}",
+      "image_name": "scylla-{{user `scylla_version`| clean_resource_name}}-build-{{user `scylla_build_id`| clean_resource_name}}",
       "instance_name": "scylla-{{user `scylla_version`| clean_resource_name}}",
       "image_description": "Official ScyllaDB image v-{{user `scylla_version`| clean_resource_name}}",
       "use_internal_ip": false,


### PR DESCRIPTION
got the following error during gce-image build:
```
03:09:46  --> googlecompute: Error creating instance: googleapi: Error
409: The resource
'projects/scylla-images/zones/europe-west1-b/instances/scylla-4-6-dev-0-20210521-a2379b96b1-1'
already exists, alreadyExists
```

This is since we are building from same package version and the image
name is not unique.

Let's make sure each gce image buid has a unique name

Fixes: 	https://github.com/scylladb/scylla-pkg/issues/1879
(cherry picked from commit 5c414bfb6b348b2c6ab723dce42c74fbb29e8846)