### PR TITLE
aws: install aws-cfn-bootstrap on AMI building time

### DIFF
--- a/aws/ami/files/scylla_install_ami
+++ b/aws/ami/files/scylla_install_ami
@@ -37,6 +37,11 @@ def run(cmd, shell=False):
         cmd = shlex.split(cmd)
     return subprocess.check_call(cmd, shell=shell, env=my_env)
 
+def out(cmd, shell=False):
+    if not shell:
+        cmd = shlex.split(cmd)
+    return subprocess.check_output(cmd, shell=shell, env=my_env).decode('utf-8')
+
 def get_kver(pattern):
     for k in glob.glob(pattern):
         return re.sub(r'^/boot/vmlinuz-(.+)$', r'\1', k)
@@ -104,6 +109,27 @@ if __name__ == '__main__':
         os.remove('/etc/apt/sources.list.d/scylla_install.list')
         if args.repo_for_update:
             run('curl -L -o /etc/apt/sources.list.d/scylla.list {REPO_FOR_UPDATE}'.format(REPO_FOR_UPDATE=args.repo_for_update))
+
+    # use easy_install instead of pip, because easy_install requires
+    # fewer dependencies, no need to install gcc, it makes our AMI smaller.
+    if distro == 'centos':
+        run('yum install -y epel-release')
+        run('yum install -y pystache python-daemon python-setuptools')
+        # Default install prefix on CentOS7 is /usr not /usr/local, but we need
+        # to align path for executable, so specify script-dir to /usr/local/bin
+        run('python -m easy_install --script-dir /usr/local/bin https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz')
+        pyver = ''
+    else:
+        # XXX: we want install dependencies from distro repo, but
+        # python-daemon-2.2 on Ubuntu 20.04 is too new for aws-cfn-bootstrap,
+        # so install python-daemon-2.1 from pypi
+        run('apt-get install -y python3-pystache python3-lockfile python3-setuptools')
+        run('python3 -m easy_install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz')
+        pyver = '3'
+    cfnpath = out('python{} -c "import cfnbootstrap as _; print(_.__path__[0])"'.format(pyver))
+    initpath = os.path.abspath('{}/../init/{}/cfn-hup'.format(cfnpath, 'redhat' if distro == 'centos' else 'ubuntu'))
+    shutil.copyfile(initpath, '/etc/init.d/cfn-hup')
+    os.chmod('/etc/init.d/cfn-hup', 0o755)
 
     run('systemctl daemon-reload')
     run('systemctl enable scylla-image-setup.service')

--- a/aws/cloudformation/scylla.yaml
+++ b/aws/cloudformation/scylla.yaml
@@ -159,10 +159,6 @@ Resources:
                 - ''
                 - - !Sub |
                     #!/bin/bash -ex
-                    sudo apt-get update
-                    sudo apt-get -y install python3-pip
-                    sudo pip install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
-
                     /usr/local/bin/cfn-signal --exit-code 0 --resource Node0 --region ${AWS::Region} --stack ${AWS::StackName}
             - '"}'
       NetworkInterfaces:
@@ -233,10 +229,6 @@ Resources:
                 - ''
                 - - !Sub |
                     #!/bin/bash -ex
-                    sudo apt-get update
-                    sudo apt-get -y install python3-pip
-                    sudo pip install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
-
                     /usr/local/bin/cfn-signal --exit-code 0 --resource Node1 --region ${AWS::Region} --stack ${AWS::StackName}
             - '"}'
       NetworkInterfaces:
@@ -307,10 +299,6 @@ Resources:
                 - ''
                 - - !Sub |
                     #!/bin/bash -ex
-                    sudo apt-get update
-                    sudo apt-get -y install python3-pip
-                    sudo pip install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
-
                     /usr/local/bin/cfn-signal --exit-code 0 --resource Node2 --region ${AWS::Region} --stack ${AWS::StackName}
             - '"}'
       NetworkInterfaces:
@@ -381,10 +369,6 @@ Resources:
                 - ''
                 - - !Sub |
                     #!/bin/bash -ex
-                    sudo apt-get update
-                    sudo apt-get -y install python3-pip
-                    sudo pip install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
-
                     /usr/local/bin/cfn-signal --exit-code 0 --resource Node3 --region ${AWS::Region} --stack ${AWS::StackName}
             - '"}'
       NetworkInterfaces:
@@ -455,10 +439,6 @@ Resources:
                 - ''
                 - - !Sub |
                     #!/bin/bash -ex
-                    sudo apt-get update
-                    sudo apt-get -y install python3-pip
-                    sudo pip install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
-
                     /usr/local/bin/cfn-signal --exit-code 0 --resource Node4 --region ${AWS::Region} --stack ${AWS::StackName}
             - '"}'
       NetworkInterfaces:
@@ -529,10 +509,6 @@ Resources:
                 - ''
                 - - !Sub |
                     #!/bin/bash -ex
-                    sudo apt-get update
-                    sudo apt-get -y install python3-pip
-                    sudo pip install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
-
                     /usr/local/bin/cfn-signal --exit-code 0 --resource Node5 --region ${AWS::Region} --stack ${AWS::StackName}
             - '"}'
       NetworkInterfaces:
@@ -603,10 +579,6 @@ Resources:
                 - ''
                 - - !Sub |
                     #!/bin/bash -ex
-                    sudo apt-get update
-                    sudo apt-get -y install python3-pip
-                    sudo pip install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
-
                     /usr/local/bin/cfn-signal --exit-code 0 --resource Node6 --region ${AWS::Region} --stack ${AWS::StackName}
             - '"}'
       NetworkInterfaces:
@@ -677,10 +649,6 @@ Resources:
                 - ''
                 - - !Sub |
                     #!/bin/bash -ex
-                    sudo apt-get update
-                    sudo apt-get -y install python3-pip
-                    sudo pip install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
-
                     /usr/local/bin/cfn-signal --exit-code 0 --resource Node7 --region ${AWS::Region} --stack ${AWS::StackName}
             - '"}'
       NetworkInterfaces:
@@ -751,10 +719,6 @@ Resources:
                 - ''
                 - - !Sub |
                     #!/bin/bash -ex
-                    sudo apt-get update
-                    sudo apt-get -y install python3-pip
-                    sudo pip install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
-
                     /usr/local/bin/cfn-signal --exit-code 0 --resource Node8 --region ${AWS::Region} --stack ${AWS::StackName}
             - '"}'
       NetworkInterfaces:
@@ -825,10 +789,6 @@ Resources:
                 - ''
                 - - !Sub |
                     #!/bin/bash -ex
-                    sudo apt-get update
-                    sudo apt-get -y install python3-pip
-                    sudo pip install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
-
                     /usr/local/bin/cfn-signal --exit-code 0 --resource Node9 --region ${AWS::Region} --stack ${AWS::StackName}
             - '"}'
       NetworkInterfaces:

--- a/aws/cloudformation/scylla.yaml.j2
+++ b/aws/cloudformation/scylla.yaml.j2
@@ -131,10 +131,6 @@ Resources:
                 - ''
                 - - !Sub |
                     #!/bin/bash -ex
-                    sudo apt-get update
-                    sudo apt-get -y install python3-pip
-                    sudo pip install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
-
                     /usr/local/bin/cfn-signal --exit-code 0 --resource Node{{ node_index }} --region ${AWS::Region} --stack ${AWS::StackName}
             - '"}'
 {%- else %}
@@ -150,11 +146,6 @@ Resources:
                 - ''
                 - - !Sub |
                     #!/bin/bash -ex
-
-                    sudo apt-get update
-                    sudo apt-get -y install python3-pip
-                    sudo pip install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
-
                     trap '/usr/local/bin/cfn-signal --exit-code 1 --resource Node{{ node_index }} --region ${AWS::Region} --stack ${AWS::StackName}' ERR
 
                     export PUBLIC_IP=${Node2ElasticIP}


### PR DESCRIPTION
Install aws-cfn-bootstrap on AMI building time, instead of after instance
launched.

Fixes #150