### PR TITLE
aws/ami: drop /home/centos, make it symlink of /home/scyllaadm

### DIFF
--- a/aws/ami/files/scylla_install_ami
+++ b/aws/ami/files/scylla_install_ami
@@ -144,7 +144,6 @@ if __name__ == '__main__':
     run('userdel -r -f {}'.format(distro))
     run('cloud-init clean')
     run('cloud-init init')
-    run('ln -sf /home/scyllaadm {}'.format(homedir))
     for skel in glob.glob('/etc/skel/.*'):
         shutil.copy(skel, '/home/scyllaadm')
         os.chown(skel, 1000, 1000)

--- a/aws/ami/files/scylla_install_ami
+++ b/aws/ami/files/scylla_install_ami
@@ -141,9 +141,10 @@ if __name__ == '__main__':
         cfg = re.sub('^     name: ubuntu', '     name: scyllaadm', cfg, flags=re.MULTILINE)
     with open('/etc/cloud/cloud.cfg', 'w') as f:
         f.write(cfg)
-    run('userdel -f {}'.format(distro))
+    run('userdel -r -f {}'.format(distro))
     run('cloud-init clean')
     run('cloud-init init')
+    run('ln -sf /home/scyllaadm {}'.format(homedir))
     for skel in glob.glob('/etc/skel/.*'):
         shutil.copy(skel, '/home/scyllaadm')
         os.chown(skel, 1000, 1000)


### PR DESCRIPTION
Currently, 'centos' user is alias of 'scyllaadm', and its home directory
is /home/scyllaaadm, but original /home/centos is still remain.
To maximize compatibility, drop /home/centos and make it symlink of
/home/scyllaadm.

Fixes #120

(cherry picked from commit 6ef2297cce7fa6a628c6a273fbf7036a71b1e293)