### PR TITLE
scylla_login: Minor style, formatting fixes

### DIFF
--- a/common/scylla_login
+++ b/common/scylla_login
@@ -39,8 +39,8 @@ Nodetool:
 CQL Shell:
         cqlsh
 More documentation available at: 
-        http://www.scylladb.com/doc/
-By default, Scylla sends certain information about this node to a data collection server. For information, see http://www.scylladb.com/privacy/
+        https://docs.scylladb.com/
+By default, Scylla sends certain information about this node to a data collection server. For information, see https://www.scylladb.com/privacy/
 
 '''[1:-1]
 MSG_UNSUPPORTED_INSTANCE_TYPE = '''

--- a/common/scylla_login
+++ b/common/scylla_login
@@ -45,13 +45,18 @@ By default, Scylla sends certain information about this node to a data collectio
 '''[1:-1]
 MSG_UNSUPPORTED_INSTANCE_TYPE = '''
     {red}{type} is not eligible for optimized automatic tuning!{nocolor}
-To continue the setup of Scylla on this instance, run 'sudo scylla_io_setup' then 'sudo systemctl start scylla-server'.
+
+To continue the setup of Scylla on this instance, run 'sudo scylla_io_setup' 
+then 'sudo systemctl start scylla-server'.
 For a list of optimized instance types and more instructions, see %s
 
 '''[1:-1]
 MSG_UNSUPPORTED_INSTANCE_TYPE_NO_DISKS = '''
     {red}{type} is not eligible for optimized automatic tuning!{nocolor}
-To continue the setup of Scylla on this instance, you need to attach additional disks, next run 'sudo scylla_create_devices', 'sudo scylla_io_setup' then 'sudo systemctl start scylla-server'.
+
+To continue the setup of Scylla on this instance, you need to attach additional disks, 
+next run 'sudo scylla_create_devices', 'sudo scylla_io_setup' 
+then 'sudo systemctl start scylla-server'.
 For a list of optimized instance types and more instructions, see %s
 '''[1:-1]
 MSG_SETUP_ACTIVATING = '''
@@ -81,6 +86,7 @@ Please wait for Scylla startup to finish. To see its status, run
 '''[1:-1]
 MSG_SCYLLA_FAILED = '''
     {red}Scylla has not started!{nocolor}
+
 To see the status of Scylla, run 
  'systemctl status scylla-server'
 

--- a/common/scylla_login
+++ b/common/scylla_login
@@ -46,14 +46,13 @@ By default, Scylla sends certain information about this node to a data collectio
 MSG_UNSUPPORTED_INSTANCE_TYPE = '''
     {red}{type} is not eligible for optimized automatic tuning!{nocolor}
 To continue the setup of Scylla on this instance, run 'sudo scylla_io_setup' then 'sudo systemctl start scylla-server'.
-For a list of optimized instance types and more EC2 instructions, see '%s'"
+For a list of optimized instance types and more instructions, see %s
 
 '''[1:-1]
 MSG_UNSUPPORTED_INSTANCE_TYPE_NO_DISKS = '''
     {red}{type} is not eligible for optimized automatic tuning!{nocolor}
 To continue the setup of Scylla on this instance, you need to attach additional disks, next run 'sudo scylla_create_devices', 'sudo scylla_io_setup' then 'sudo systemctl start scylla-server'.
-For a list of optimized instance types and more EC2 instructions, see '%s'"
-
+For a list of optimized instance types and more instructions, see %s
 '''[1:-1]
 MSG_SETUP_ACTIVATING = '''
     {green}Constructing RAID volume...{nocolor}

--- a/common/scylla_login
+++ b/common/scylla_login
@@ -45,7 +45,7 @@ By default, Scylla sends certain information about this node to a data collectio
 '''[1:-1]
 MSG_UNSUPPORTED_INSTANCE_TYPE = '''
     {red}{type} is not eligible for optimized automatic tuning!{nocolor}
-To continue startup Scylla on this instance, run 'sudo scylla_io_setup' then 'systemctl start scylla-server'.
+To continue startup Scylla on this instance, run 'sudo scylla_io_setup' then 'sudo systemctl start scylla-server'.
 For a list of optimized instance types and more EC2 instructions see '%s'"
 
 '''[1:-1]

--- a/common/scylla_login
+++ b/common/scylla_login
@@ -45,13 +45,13 @@ By default, Scylla sends certain information about this node to a data collectio
 '''[1:-1]
 MSG_UNSUPPORTED_INSTANCE_TYPE = '''
     {red}{type} is not eligible for optimized automatic tuning!{nocolor}
-To continue startup ScyllaDB on this instance, run 'sudo scylla_io_setup' then 'systemctl start scylla-server'.
+To continue startup Scylla on this instance, run 'sudo scylla_io_setup' then 'systemctl start scylla-server'.
 For a list of optimized instance types and more EC2 instructions see '%s'"
 
 '''[1:-1]
 MSG_UNSUPPORTED_INSTANCE_TYPE_NO_DISKS = '''
     {red}{type} is not eligible for optimized automatic tuning!{nocolor}
-To continue startup ScyllaDB on this instance, you need to attach additional disks, run 'sudo scylla_create_devices', 'sudo scylla_io_setup' then 'sudo systemctl start scylla-server'.
+To continue startup Scylla on this instance, you need to attach additional disks, run 'sudo scylla_create_devices', 'sudo scylla_io_setup' then 'sudo systemctl start scylla-server'.
 For a list of optimized instance types and more EC2 instructions see '%s'"
 
 '''[1:-1]
@@ -74,35 +74,35 @@ To see status, run
 
 '''[1:-1]
 MSG_SCYLLA_ACTIVATING = '''
-    {green}ScyllaDB is starting...{nocolor}
+    {green}Scylla is starting...{nocolor}
 
 Please wait for start. To see status, run 
  'systemctl status scylla-server'
 
 '''[1:-1]
 MSG_SCYLLA_FAILED = '''
-    {red}ScyllaDB is not started!{nocolor}
-Please wait for startup. To see status of ScyllaDB, run 
+    {red}Scylla is not started!{nocolor}
+Please wait for startup. To see status of Scylla, run 
  'systemctl status scylla-server'
 
 '''[1:-1]
 MSG_SCYLLA_MOUNT_FAILED = '''
     {red}Failed mounting RAID volume!{nocolor}
 
-ScyllaDB aborted startup because of RAID volume missing.
+Scylla aborted startup because of RAID volume missing.
 To see status, run
  'systemctl status scylla-server'
 
 '''[1:-1]
 MSG_SCYLLA_UNKNOWN = '''
-    {red}ScyllaDB is not started!{nocolor}
+    {red}Scylla is not started!{nocolor}
 
-To see status of ScyllaDB, run
+To see status of Scylla, run
  'systemctl status scylla-server'
 
 '''[1:-1]
 MSG_SCYLLA_ACTIVE = '''
-    {green}ScyllaDB is active.{nocolor}
+    {green}Scylla is active.{nocolor}
 
 $ nodetool status
 

--- a/common/scylla_login
+++ b/common/scylla_login
@@ -40,64 +40,64 @@ CQL Shell:
         cqlsh
 More documentation available at: 
         https://docs.scylladb.com/
-By default, Scylla sends certain information about this node to a data collection server. For information, see https://www.scylladb.com/privacy/
+By default, Scylla sends certain information about this node to a data collection server. For more details, see https://www.scylladb.com/privacy/
 
 '''[1:-1]
 MSG_UNSUPPORTED_INSTANCE_TYPE = '''
     {red}{type} is not eligible for optimized automatic tuning!{nocolor}
-To continue startup Scylla on this instance, run 'sudo scylla_io_setup' then 'sudo systemctl start scylla-server'.
-For a list of optimized instance types and more EC2 instructions see '%s'"
+To continue the setup of Scylla on this instance, run 'sudo scylla_io_setup' then 'sudo systemctl start scylla-server'.
+For a list of optimized instance types and more EC2 instructions, see '%s'"
 
 '''[1:-1]
 MSG_UNSUPPORTED_INSTANCE_TYPE_NO_DISKS = '''
     {red}{type} is not eligible for optimized automatic tuning!{nocolor}
-To continue startup Scylla on this instance, you need to attach additional disks, run 'sudo scylla_create_devices', 'sudo scylla_io_setup' then 'sudo systemctl start scylla-server'.
-For a list of optimized instance types and more EC2 instructions see '%s'"
+To continue the setup of Scylla on this instance, you need to attach additional disks, next run 'sudo scylla_create_devices', 'sudo scylla_io_setup' then 'sudo systemctl start scylla-server'.
+For a list of optimized instance types and more EC2 instructions, see '%s'"
 
 '''[1:-1]
 MSG_SETUP_ACTIVATING = '''
     {green}Constructing RAID volume...{nocolor}
 
-Please wait for setup. To see status, run 
+Please wait for the setup to finish. To see its status, run 
  'systemctl status scylla-image-setup'
 
-After setup finished, scylla-server service will launch.
-To see status of scylla-server, run 
+After the setup has finished, scylla-server service will launch.
+To see the status of scylla-server, run 
  'systemctl status scylla-server'
 
 '''[1:-1]
 MSG_SETUP_FAILED = '''
-    {red}Initial image configuration failed!{nocolor}
+    {red}Initial image configuration has failed!{nocolor}
 
-To see status, run 
+To see the status of setup service, run 
  'systemctl status scylla-image-setup'
 
 '''[1:-1]
 MSG_SCYLLA_ACTIVATING = '''
     {green}Scylla is starting...{nocolor}
 
-Please wait for start. To see status, run 
+Please wait for Scylla startup to finish. To see its status, run 
  'systemctl status scylla-server'
 
 '''[1:-1]
 MSG_SCYLLA_FAILED = '''
-    {red}Scylla is not started!{nocolor}
-Please wait for startup. To see status of Scylla, run 
+    {red}Scylla has not started!{nocolor}
+To see the status of Scylla, run 
  'systemctl status scylla-server'
 
 '''[1:-1]
 MSG_SCYLLA_MOUNT_FAILED = '''
     {red}Failed mounting RAID volume!{nocolor}
 
-Scylla aborted startup because of RAID volume missing.
-To see status, run
+Scylla has aborted startup because of a missing RAID volume.
+To see the status of Scylla, run
  'systemctl status scylla-server'
 
 '''[1:-1]
 MSG_SCYLLA_UNKNOWN = '''
-    {red}Scylla is not started!{nocolor}
+    {red}Scylla has not started!{nocolor}
 
-To see status of Scylla, run
+To see the status of Scylla, run
  'systemctl status scylla-server'
 
 '''[1:-1]

--- a/common/scylla_login
+++ b/common/scylla_login
@@ -33,13 +33,13 @@ MSG_HEADER = '''
               |___/                        
 
 Version:
-       {scylla_version}
+        {scylla_version}
 Nodetool:
-	nodetool help
+        nodetool help
 CQL Shell:
-	cqlsh
+        cqlsh
 More documentation available at: 
-	http://www.scylladb.com/doc/
+        http://www.scylladb.com/doc/
 By default, Scylla sends certain information about this node to a data collection server. For information, see http://www.scylladb.com/privacy/
 
 '''[1:-1]


### PR DESCRIPTION
This pull request fixes a few minor problems in `scylla_login`:

1. Changing spelling from ScyllaDB (the company) to Scylla (the database) in all places the database (not company) was mentioned.
2. Replacing tabs with spaces in `MSG_HEADER` (spaces and tabs were mixed and an incorrect number of spaces was used).
3. A few style, grammatical, formatting fixes to make the messages more clear.
4. Adding missing `sudo` in a few command tips.
5. Removed places where "EC2" was hardcoded as now there are images for Scylla on GCE. A hardcoded "Getting started Amazon" is replaced with `cloud_instance.GETTING_STARTED_URL` (which was already there, but was not used). Note that those `cloud_instance.GETTING_STARTED_URL` links are incorrect (see issue https://github.com/scylladb/scylla/issues/9043), but it's a problem in a different repository.

