### PR TITLE
AMI: Add support for ARM based AMI build

### DIFF
--- a/aws/ami/build_deb_ami.sh
+++ b/aws/ami/build_deb_ami.sh
@@ -117,9 +117,15 @@ check_deb_exists () {
     done
 }
 declare -A AMI
-AMI=(["x86_64"]=ami-0074ee617a234808d ["aarch64"]=ami-0ae74ae9c43584639)
+AMI=(["x86_64"]=ami-0074ee617a234808d ["aarch64"]=ami-0763a1094de643002)
 REGION=us-east-1
 SSH_USERNAME=ubuntu
+
+if [ uname -m | grep x86_64]; then
+  INSTANCE_TYPE="c4.xlarge"
+else
+  INSTANCE_TYPE="a1.xlarge"
+fi
 
 if [ $LOCALDEB -eq 1 ]; then
     INSTALL_ARGS="$INSTALL_ARGS --localrpm"
@@ -186,7 +192,20 @@ mkdir -p build
 export PACKER_LOG=1
 export PACKER_LOG_PATH
 
-/usr/bin/packer ${PACKER_SUB_CMD} -var-file=variables.json -var install_args="$INSTALL_ARGS" -var region="$REGION" -var source_ami="${AMI[$(arch)]}" -var ssh_username="$SSH_USERNAME" -var scylla_version="$SCYLLA_VERSION" -var scylla_machine_image_version="$SCYLLA_MACHINE_IMAGE_VERSION" -var scylla_jmx_version="$SCYLLA_JMX_VERSION" -var scylla_tools_version="$SCYLLA_TOOLS_VERSION" -var scylla_python3_version="$SCYLLA_PYTHON3_VERSION" -var scylla_ami_description="${SCYLLA_AMI_DESCRIPTION:0:255}" -var python="/usr/bin/python3" scylla.json
+/usr/bin/packer ${PACKER_SUB_CMD} \
+  -var-file=variables.json \
+  -var install_args="$INSTALL_ARGS" \
+  -var region="$REGION" \
+  -var instance_type="$INSTANCE_TYPE" \
+  -var source_ami="${AMI[$(arch)]}" \
+  -var ssh_username="$SSH_USERNAME" \
+  -var scylla_version="$SCYLLA_VERSION" \
+  -var scylla_machine_image_version="$SCYLLA_MACHINE_IMAGE_VERSION" \
+  -var scylla_jmx_version="$SCYLLA_JMX_VERSION" \
+  -var scylla_tools_version="$SCYLLA_TOOLS_VERSION" \
+  -var scylla_python3_version="$SCYLLA_PYTHON3_VERSION" \
+  -var scylla_ami_description="${SCYLLA_AMI_DESCRIPTION:0:255}" \
+  -var python="/usr/bin/python3" scylla.json
 
 # For some errors packer gives a success status even if fails.
 # Search log for errors

--- a/aws/ami/variables.json.example
+++ b/aws/ami/variables.json.example
@@ -5,5 +5,5 @@
     "security_group_id": "",
     "region": "us-east-1",
     "associate_public_ip_address": "true",
-    "instance_type": "c4.xlarge"
+    "instance_type": ""
 }


### PR DESCRIPTION
Today we have an AMI based on x86 arch only. Now that we have ARM based
packaging , we want to have also AMI based on ARM

Fixes: #137