### PR TITLE
cloudformation:security groups ingress, set to tcp

### DIFF
--- a/aws/cloudformation/scylla.yaml
+++ b/aws/cloudformation/scylla.yaml
@@ -869,7 +869,7 @@ Resources:
         - CidrIp: 172.31.0.0/16
           FromPort: 22
           ToPort: 22
-          IpProtocol: '-1'
+          IpProtocol: 'tcp'
       VpcId: !Ref VPC
 
   SGUser:

--- a/aws/cloudformation/scylla.yaml.j2
+++ b/aws/cloudformation/scylla.yaml.j2
@@ -250,7 +250,7 @@ Resources:
         - CidrIp: 172.31.0.0/16
           FromPort: 22
           ToPort: 22
-          IpProtocol: '-1'
+          IpProtocol: 'tcp'
       VpcId: !Ref VPC
 
   SGUser:


### PR DESCRIPTION
Today we set ipProtocol to -1 which allow inbound traffic of all types.
Let's specify it to tcp

based on 
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-security-group-ingress.html

Fixes: https://github.com/scylladb/scylla-machine-image/issues/154