### PR TITLE
cloudformation: SGCluster : Missing egress rule

### DIFF
--- a/aws/cloudformation/scylla.yaml
+++ b/aws/cloudformation/scylla.yaml
@@ -867,9 +867,7 @@ Resources:
           Value: !Ref ClusterName
       SecurityGroupIngress:
         - CidrIp: 172.31.0.0/16
-          FromPort: 22
-          ToPort: 22
-          IpProtocol: 'tcp'
+          IpProtocol: '-1'
       SecurityGroupEgress:
         - CidrIp: 0.0.0.0/0
           IpProtocol: '-1'

--- a/aws/cloudformation/scylla.yaml
+++ b/aws/cloudformation/scylla.yaml
@@ -870,6 +870,9 @@ Resources:
           FromPort: 22
           ToPort: 22
           IpProtocol: 'tcp'
+      SecurityGroupEgress:
+        - CidrIp: 0.0.0.0/0
+          IpProtocol: '-1'
       VpcId: !Ref VPC
 
   SGUser:

--- a/aws/cloudformation/scylla.yaml.j2
+++ b/aws/cloudformation/scylla.yaml.j2
@@ -251,6 +251,9 @@ Resources:
           FromPort: 22
           ToPort: 22
           IpProtocol: 'tcp'
+      SecurityGroupEgress:
+        - CidrIp: 0.0.0.0/0
+          IpProtocol: '-1'
       VpcId: !Ref VPC
 
   SGUser:

--- a/aws/cloudformation/scylla.yaml.j2
+++ b/aws/cloudformation/scylla.yaml.j2
@@ -248,9 +248,7 @@ Resources:
           Value: !Ref ClusterName
       SecurityGroupIngress:
         - CidrIp: 172.31.0.0/16
-          FromPort: 22
-          ToPort: 22
-          IpProtocol: 'tcp'
+          IpProtocol: '-1'
       SecurityGroupEgress:
         - CidrIp: 0.0.0.0/0
           IpProtocol: '-1'


### PR DESCRIPTION
Missing egress rule in security group means CloudFormation will 
automatically add an outbound rule to allow all traffic outbound. Make 
this explicit by adding egress rule if it is the desired configuration. 
No need to parametize it.

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-security-group.html#aws-properties-ec2-security-group--examples--Remove_Default_Rule

Fixes: https://github.com/scylladb/scylla-machine-image/issues/161