### PR TITLE
scylla_login: fix message to apply format parameter

### DIFF
--- a/common/scylla_login
+++ b/common/scylla_login
@@ -52,7 +52,7 @@ For a list of optimized instance types and more EC2 instructions see '%s'"
 MSG_UNSUPPORTED_INSTANCE_TYPE_NO_DISKS = '''
     {red}{type} is not eligible for optimized automatic tuning!{nocolor}
 To continue startup ScyllaDB on this instance, you need to attach additional disks, then run 'sudo scylla_io_setup' then 'systemctl start scylla-server'.
-For a list of optimized instance types and more EC2 instructions see http://www.scylladb.com/doc/getting-started-amazon/"
+For a list of optimized instance types and more EC2 instructions see '%s'"
 
 '''[1:-1]
 MSG_SETUP_ACTIVATING = '''


### PR DESCRIPTION
MSG_UNSUPPORTED_INSTANCE_TYPE_NO_DISKS is not applied format parameter,
even it passed with '%'.