### PR TITLE
build_deb_ami.sh: Fix condition typo casuing ami build to fail

### DIFF
--- a/aws/ami/build_deb_ami.sh
+++ b/aws/ami/build_deb_ami.sh
@@ -121,7 +121,7 @@ AMI=(["x86_64"]=ami-0074ee617a234808d ["aarch64"]=ami-0763a1094de643002)
 REGION=us-east-1
 SSH_USERNAME=ubuntu
 
-if [ uname -m | grep x86_64]; then
+if uname -m | grep x86_64 ; then
   INSTANCE_TYPE="c4.xlarge"
 else
   INSTANCE_TYPE="a1.xlarge"


### PR DESCRIPTION
In https://github.com/scylladb/scylla-machine-image/pull/153/commits/27223c6e7eb5ffb93fb5f535f299bafd17174ac3 we started to support AMI build based on ARM.

I missed a condition typo which broke the x86 based AMI build

Fixing it here