### PR TITLE
cloudformation: SGUser: Add missing egress rule

### DIFF
--- a/aws/cloudformation/scylla.yaml
+++ b/aws/cloudformation/scylla.yaml
@@ -882,6 +882,9 @@ Resources:
           Value: !Sub '${ClusterName}-SGUser'
         - Key: ClusterName
           Value: !Ref ClusterName
+      SecurityGroupEgress:
+        - CidrIp: 0.0.0.0/0
+          IpProtocol: '-1'
       VpcId: !Ref VPC
 
   Subnet:

--- a/aws/cloudformation/scylla.yaml.j2
+++ b/aws/cloudformation/scylla.yaml.j2
@@ -263,6 +263,9 @@ Resources:
           Value: !Sub '${ClusterName}-SGUser'
         - Key: ClusterName
           Value: !Ref ClusterName
+      SecurityGroupEgress:
+        - CidrIp: 0.0.0.0/0
+          IpProtocol: '-1'
       VpcId: !Ref VPC
 
   Subnet:


### PR DESCRIPTION
Missing egress rule in security group means CloudFormation will
automatically add an outbound rule to allow all traffic outbound. Make
this explicit by adding egress rule if it is the desired configuration.
No need to parametize it.

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-security-group.html#aws-properties-ec2-security-group--examples--Remove_Default_Rule

Fixes: https://github.com/scylladb/scylla-machine-image/issues/173