### PR TITLE
cloudformation:SGAdmin:define public access source

### DIFF
--- a/aws/cloudformation/scylla.yaml
+++ b/aws/cloudformation/scylla.yaml
@@ -13,6 +13,11 @@ Parameters:
   ClusterName:
     Type: String
 
+  PublicCidrAccess:
+    Type: String
+    Description: Please set CIDR to x.x.x.x/32 to allow one specific IP address access (For SSH only), 0.0.0.0/0 to allow all IP addresses access or another CIDR range.
+    Default: 0.0.0.0/0
+
   InstanceCount:
     Description: Number of EC2 instances (must be between 1 and 10).
     Type: Number
@@ -846,7 +851,7 @@ Resources:
         - Key: ClusterName
           Value: !Ref ClusterName
       SecurityGroupIngress:
-        - CidrIp: 0.0.0.0/0
+        - CidrIp: !Ref PublicCidrAccess
           FromPort: 22
           ToPort: 22
           IpProtocol: tcp

--- a/aws/cloudformation/scylla.yaml.j2
+++ b/aws/cloudformation/scylla.yaml.j2
@@ -18,6 +18,11 @@ Parameters:
   ClusterName:
     Type: String
 
+  PublicCidrAccess:
+    Type: String
+    Description: Please set CIDR to x.x.x.x/32 to allow one specific IP address access (For SSH only), 0.0.0.0/0 to allow all IP addresses access or another CIDR range.
+    Default: 0.0.0.0/0
+
   InstanceCount:
     Description: Number of EC2 instances (must be between 1 and {{ total_num_node }}).
     Type: Number
@@ -227,7 +232,7 @@ Resources:
         - Key: ClusterName
           Value: !Ref ClusterName
       SecurityGroupIngress:
-        - CidrIp: 0.0.0.0/0
+        - CidrIp: !Ref PublicCidrAccess
           FromPort: 22
           ToPort: 22
           IpProtocol: tcp


### PR DESCRIPTION
Security Groups found with CIDR open to world on ingress. Today it is opened to all IPs allowing only SSH access.
Let's give the customer more control and allow him to specifiy the IP or
rane for public access

Fixes: https://github.com/scylladb/scylla-machine-image/issues/172