### PR TITLE
cloudformation: public ip mapping code cleanup

### DIFF
--- a/aws/cloudformation/scylla.yaml
+++ b/aws/cloudformation/scylla.yaml
@@ -205,7 +205,6 @@ Resources:
           GroupSet:
             - !Ref SGCluster
             - !Ref SGAdmin
-
   Node1:
     Condition: Launch2
     Type: 'AWS::EC2::Instance'
@@ -262,7 +261,6 @@ Resources:
           GroupSet:
             - !Ref SGCluster
             - !Ref SGAdmin
-
   Node2:
     Condition: Launch3
     Type: 'AWS::EC2::Instance'
@@ -319,7 +317,6 @@ Resources:
           GroupSet:
             - !Ref SGCluster
             - !Ref SGAdmin
-
   Node3:
     Condition: Launch4
     Type: 'AWS::EC2::Instance'
@@ -376,7 +373,6 @@ Resources:
           GroupSet:
             - !Ref SGCluster
             - !Ref SGAdmin
-
   Node4:
     Condition: Launch5
     Type: 'AWS::EC2::Instance'
@@ -433,7 +429,6 @@ Resources:
           GroupSet:
             - !Ref SGCluster
             - !Ref SGAdmin
-
   Node5:
     Condition: Launch6
     Type: 'AWS::EC2::Instance'
@@ -490,7 +485,6 @@ Resources:
           GroupSet:
             - !Ref SGCluster
             - !Ref SGAdmin
-
   Node6:
     Condition: Launch7
     Type: 'AWS::EC2::Instance'
@@ -547,7 +541,6 @@ Resources:
           GroupSet:
             - !Ref SGCluster
             - !Ref SGAdmin
-
   Node7:
     Condition: Launch8
     Type: 'AWS::EC2::Instance'
@@ -604,7 +597,6 @@ Resources:
           GroupSet:
             - !Ref SGCluster
             - !Ref SGAdmin
-
   Node8:
     Condition: Launch9
     Type: 'AWS::EC2::Instance'
@@ -661,7 +653,6 @@ Resources:
           GroupSet:
             - !Ref SGCluster
             - !Ref SGAdmin
-
   Node9:
     Condition: Launch10
     Type: 'AWS::EC2::Instance'
@@ -718,7 +709,6 @@ Resources:
           GroupSet:
             - !Ref SGCluster
             - !Ref SGAdmin
-
   Route:
     Type: 'AWS::EC2::Route'
     DependsOn: GatewayAttachment
@@ -849,7 +839,6 @@ Outputs:
     Value: !GetAtt
       - Node0
       - PrivateIp
-
   Node1:
     Condition: Launch2
     Value: !Ref Node1
@@ -863,7 +852,6 @@ Outputs:
     Value: !GetAtt
       - Node1
       - PrivateIp
-
   Node2:
     Condition: Launch3
     Value: !Ref Node2
@@ -877,7 +865,6 @@ Outputs:
     Value: !GetAtt
       - Node2
       - PrivateIp
-
   Node3:
     Condition: Launch4
     Value: !Ref Node3
@@ -891,7 +878,6 @@ Outputs:
     Value: !GetAtt
       - Node3
       - PrivateIp
-
   Node4:
     Condition: Launch5
     Value: !Ref Node4
@@ -905,7 +891,6 @@ Outputs:
     Value: !GetAtt
       - Node4
       - PrivateIp
-
   Node5:
     Condition: Launch6
     Value: !Ref Node5
@@ -919,7 +904,6 @@ Outputs:
     Value: !GetAtt
       - Node5
       - PrivateIp
-
   Node6:
     Condition: Launch7
     Value: !Ref Node6
@@ -933,7 +917,6 @@ Outputs:
     Value: !GetAtt
       - Node6
       - PrivateIp
-
   Node7:
     Condition: Launch8
     Value: !Ref Node7
@@ -947,7 +930,6 @@ Outputs:
     Value: !GetAtt
       - Node7
       - PrivateIp
-
   Node8:
     Condition: Launch9
     Value: !Ref Node8
@@ -961,7 +943,6 @@ Outputs:
     Value: !GetAtt
       - Node8
       - PrivateIp
-
   Node9:
     Condition: Launch10
     Value: !Ref Node9
@@ -975,7 +956,6 @@ Outputs:
     Value: !GetAtt
       - Node9
       - PrivateIp
-
   SGAdmin:
     Value: !Ref SGAdmin
   SGCluster:

--- a/aws/cloudformation/scylla.yaml.j2
+++ b/aws/cloudformation/scylla.yaml.j2
@@ -210,26 +210,6 @@ Resources:
           GroupSet:
             - !Ref SGCluster
             - !Ref SGAdmin
-{% if AssociatePublicIpAddress %}
-  Node{{ node_index }}ElasticIP:
-    Type: 'AWS::EC2::EIP'
-    Properties:
-      Domain: vpc
-  Node{{ node_index }}ElasticIPAssociation:
-    Type: 'AWS::EC2::EIPAssociation'
-    DependsOn: Node{{ node_index }}
-    Properties:
-      AllocationId: !GetAtt
-        - Node{{ node_index }}ElasticIP
-        - AllocationId
-      InstanceId: !Ref Node{{ node_index }}
-      PrivateIpAddress: !Join
-        - '.'
-        - - !Select [0, !Split ['.', !Select [0, !Split ['/', !Ref CIDR]]]]
-          - !Select [1, !Split ['.', !Select [0, !Split ['/', !Ref CIDR]]]]
-          - !Select [2, !Split ['.', !Select [0, !Split ['/', !Ref CIDR]]]]
-          - {{ node_index + 10 }}
-{%- endif %}
 {%- endfor %}
   Route:
     Type: 'AWS::EC2::Route'
@@ -362,13 +342,6 @@ Outputs:
     Value: !GetAtt
       - Node{{ node_index }}
       - PrivateIp
-{% if AssociatePublicIpAddress %}
-  Node{{ node_index }}PublicIp:
-    Condition: Launch{{ node_index + 1 }}
-    Value: !GetAtt
-      - Node{{ node_index }}
-      - PublicIp
-{% endif %}
 {%- endfor %}
   SGAdmin:
     Value: !Ref SGAdmin


### PR DESCRIPTION
In https://github.com/scylladb/scylla-machine-image/pull/147 i have  added a parameter for enabling public ip mapping.
Part of the added code, seems to be not relevant 
Removing it
