### PR TITLE
gce: use unique instance_name

### DIFF
--- a/gce/image/scylla_gce.json
+++ b/gce/image/scylla_gce.json
@@ -12,7 +12,6 @@
       "metadata": {"block-project-ssh-keys": "TRUE"},
       "image_family": "scylla",
       "image_name": "scylla-{{user `scylla_version`| clean_resource_name}}-build-{{user `scylla_build_id`| clean_resource_name}}",
-      "instance_name": "scylla-{{user `scylla_version`| clean_resource_name}}",
       "image_description": "Official ScyllaDB image v-{{user `scylla_version`| clean_resource_name}}",
       "use_internal_ip": false,
       "preemptible": true,


### PR DESCRIPTION
On GCE, instance name must be unique. However, "scylla-{{user `scylla_version`| clean_resource_name}}" can be conflict, because we may build multiple images from single Scylla version.
We should use unique instance name, and default value of instance_name is unique since it uses uuid (packer-{{uuid}}).
So let's drop the variable from scylla_gce.json, just apply default value.

Note that this is not about image name, it is temporary instance name for packer.

Fixes #184