### PR TITLE
drop "-force -on-error=abort" option from packer build

### DIFF
--- a/aws/ami/build_ami.sh
+++ b/aws/ami/build_ami.sh
@@ -35,7 +35,7 @@ print_usage() {
 }
 LOCALRPM=0
 DOWNLOAD_ONLY=0
-PACKER_SUB_CMD="build -force -on-error=abort"
+PACKER_SUB_CMD="build"
 REPO_FOR_INSTALL=
 PACKER_LOG_PATH=build/ami.log
 

--- a/aws/ami/build_deb_ami.sh
+++ b/aws/ami/build_deb_ami.sh
@@ -35,7 +35,7 @@ print_usage() {
 }
 LOCALDEB=0
 DOWNLOAD_ONLY=0
-PACKER_SUB_CMD="build -force -on-error=abort"
+PACKER_SUB_CMD="build"
 REPO_FOR_INSTALL=
 PACKER_LOG_PATH=build/ami.log
 

--- a/azure/image/build_azure_image.sh
+++ b/azure/image/build_azure_image.sh
@@ -36,7 +36,7 @@ print_usage() {
 }
 LOCALDEB=0
 DOWNLOAD_ONLY=0
-PACKER_SUB_CMD="build -force -on-error=abort"
+PACKER_SUB_CMD="build"
 REPO_FOR_INSTALL=
 PACKER_LOG_PATH=build/packer.log
 

--- a/gce/image/build_deb_image.sh
+++ b/gce/image/build_deb_image.sh
@@ -36,7 +36,7 @@ print_usage() {
 }
 LOCALDEB=0
 DOWNLOAD_ONLY=0
-PACKER_SUB_CMD="build -force -on-error=abort"
+PACKER_SUB_CMD="build"
 REPO_FOR_INSTALL=
 PACKER_LOG_PATH=build/packer.log
 while [ $# -gt 0 ]; do

--- a/gce/image/build_image.sh
+++ b/gce/image/build_image.sh
@@ -36,7 +36,7 @@ print_usage() {
 }
 LOCALRPM=0
 DOWNLOAD_ONLY=0
-PACKER_SUB_CMD="build -force -on-error=abort"
+PACKER_SUB_CMD="build"
 REPO_FOR_INSTALL=
 PACKER_LOG_PATH=build/packer.log
 while [ $# -gt 0 ]; do


### PR DESCRIPTION
-force -on-error=abort means keep alive packer instance when building
failed, it's good feature to debug images, but if we do that by default
we may leave multiple instances unexpectedly, especially with Jenkins.

It should safer to build images without these options.

Related #184