### PR TITLE
On Docker image, make packer always up-to-date

### DIFF
--- a/aws/ami/Dockerfile
+++ b/aws/ami/Dockerfile
@@ -1,11 +1,5 @@
 FROM centos:7
 
 RUN yum install -y wget curl unzip yum-utils sudo git
-
-ENV PACKER_VERSION=1.5.1
-ENV EXPECTED="3305ede8886bc3fd83ec0640fb87418cc2a702b2cb1567b48c8cb9315e80047d  packer_linux_amd64.zip"
-
-RUN wget -nv https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip -O packer_linux_amd64.zip && \
-    echo $EXPECTED | sha256sum --check && \
-    unzip -x packer_linux_amd64.zip -d /usr/bin && \
-    rm packer_linux_amd64.zip 
+RUN yum-config-manager --add-repo https://rpm.releases.hashicorp.com/RHEL/hashicorp.repo
+RUN yum install -y packer

--- a/aws/ami/Dockerfile_deb
+++ b/aws/ami/Dockerfile_deb
@@ -1,12 +1,8 @@
 FROM ubuntu:20.04
 
 RUN apt-get update
-RUN apt-get install -y wget curl unzip sudo git findutils gnupg2 dpkg-dev
-
-ENV PACKER_VERSION=1.7.0
-ENV EXPECTED="935e81c07381a964bdbaddde2d890c91d52e88b9e5375f3882840925f6a96893  packer_linux_amd64.zip"
-
-RUN wget -nv https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip -O packer_linux_amd64.zip && \
-    echo $EXPECTED | sha256sum --check && \
-    unzip -x packer_linux_amd64.zip -d /usr/bin && \
-    rm packer_linux_amd64.zip
+RUN apt-get install -y curl sudo git findutils gnupg2 dpkg-dev
+RUN curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
+RUN echo "deb https://apt.releases.hashicorp.com focal main" | sudo tee -a /etc/apt/sources.list.d/packer.list
+RUN apt-get update
+RUN apt-get install -y packer

--- a/azure/image/Dockerfile_deb
+++ b/azure/image/Dockerfile_deb
@@ -1,12 +1,8 @@
 FROM ubuntu:20.04
 
 RUN apt-get update --fix-missing
-RUN apt-get install -y wget curl unzip sudo git findutils gnupg2 dpkg-dev
-
-ENV PACKER_VERSION=1.7.0
-ENV EXPECTED="935e81c07381a964bdbaddde2d890c91d52e88b9e5375f3882840925f6a96893  packer_linux_amd64.zip"
-
-RUN wget -nv https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip -O packer_linux_amd64.zip && \
-    echo $EXPECTED | sha256sum --check && \
-    unzip -x packer_linux_amd64.zip -d /usr/bin && \
-    rm packer_linux_amd64.zip
+RUN apt-get install -y curl sudo git findutils gnupg2 dpkg-dev
+RUN curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
+RUN echo "deb https://apt.releases.hashicorp.com focal main" | sudo tee -a /etc/apt/sources.list.d/packer.list
+RUN apt-get update
+RUN apt-get install -y packer


### PR DESCRIPTION
Packer now has official .rpm/.deb package, let's switch to it and use
up-to-date version to build our EC2/GCE/Azure images.