### PR TITLE
gce: add /usr/bin/python link update for CentOS8 image

### DIFF
--- a/gce/image/scylla_gce.json
+++ b/gce/image/scylla_gce.json
@@ -45,6 +45,7 @@
     {
       "inline": [
         "if [ -f /etc/debian_version ]; then sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.8 1; fi",
+        "if [ -f /etc/redhat-release ]; then sudo alternatives --set python /usr/bin/python3; fi",
         "sudo /home/{{user `ssh_username`}}/scylla_install_image --target-cloud gce {{ user `install_args` }}"
       ],
       "type": "shell"


### PR DESCRIPTION
Just like we do on Ubuntu 20.04 image, we need to create symlink for
/usr/bin/python on CentOS8 image.

Fixes #191