### PR TITLE
move CPU scaling setup from scylla_image_setup to scylla_install_image

### DIFF
--- a/common/scylla_image_setup
+++ b/common/scylla_image_setup
@@ -28,6 +28,7 @@ if __name__ == '__main__':
         print('Failed to initialize RAID volume, exiting setup')
         sys.exit(1)
 
+    run('/opt/scylladb/scripts/scylla_cpuscaling_setup', shell=True, check=True)
     run('/opt/scylladb/scripts/scylla_sysconfig_setup --nic eth0 --setup-nic --ami', shell=True, check=True)
     if cloud_instance.is_supported_instance_class():
         cloud_instance.io_setup()

--- a/packer/scylla_install_image
+++ b/packer/scylla_install_image
@@ -147,7 +147,7 @@ if __name__ == '__main__':
 
     run('systemctl daemon-reload')
     run('systemctl enable scylla-image-setup.service')
-    run('/opt/scylladb/scripts/scylla_setup --no-coredump-setup --no-sysconfig-setup --no-raid-setup --no-io-setup --no-bootparam-setup --no-ec2-check --no-swap-setup')
+    run('/opt/scylladb/scripts/scylla_setup --no-coredump-setup --no-sysconfig-setup --no-raid-setup --no-io-setup --no-bootparam-setup --no-ec2-check --no-swap-setup --no-cpuscaling-setup')
     run('/opt/scylladb/scripts/scylla_sysconfig_setup --ami --set-clocksource {}'.format(sysconfig_opt))
     run('/opt/scylladb/scripts/scylla_bootparam_setup --ami')
     os.remove('{}/.ssh/authorized_keys'.format(homedir))


### PR DESCRIPTION
Currently, CPU scaling setup is mistakenly running in AMI building time.
This is not correct because the AMI image can run other instance type.
To fix this issue, disable CPU scaling setup on scylla_image_setup, and
add it to scylla_install_image.

Fixes scylladb/scylla#9273