### PR TITLE
support run build_image.sh/build_deb_image.sh directly

### DIFF
--- a/aws/ami/build_ami.sh
+++ b/aws/ami/build_ami.sh
@@ -1,1 +1,1 @@
-../../packer/scripts/build_image.sh
+../../packer/build_image.sh

--- a/aws/ami/build_deb_ami.sh
+++ b/aws/ami/build_deb_ami.sh
@@ -1,1 +1,1 @@
-../../packer/scripts/build_deb_image.sh
+../../packer/build_deb_image.sh

--- a/azure/image/build_azure_image.sh
+++ b/azure/image/build_azure_image.sh
@@ -1,1 +1,1 @@
-../../packer/scripts/build_deb_image.sh
+../../packer/build_deb_image.sh

--- a/gce/image/build_deb_image.sh
+++ b/gce/image/build_deb_image.sh
@@ -1,1 +1,1 @@
-../../packer/scripts/build_deb_image.sh
+../../packer/build_deb_image.sh

--- a/gce/image/build_image.sh
+++ b/gce/image/build_image.sh
@@ -1,1 +1,1 @@
-../../packer/scripts/build_image.sh
+../../packer/build_image.sh

--- a/packer/build_image.sh
+++ b/packer/build_image.sh
@@ -14,7 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-source ../../SCYLLA-VERSION-GEN
+REALDIR=$(dirname $(readlink -f "$0"))
+source "$REALDIR"/../SCYLLA-VERSION-GEN
 
 PRODUCT=$(cat build/SCYLLA-PRODUCT-FILE)
 BUILD_ID=$(date -u '+%FT%H-%M-%S')
@@ -22,6 +23,16 @@ DIR=$(dirname $(realpath -se $0))
 PDIRNAME=$(basename $(realpath -se $DIR/..))
 EXIT_STATUS=0
 DRY_RUN=false
+TARGET=
+
+if [ -L "$0" ]; then
+    if [ "$PDIRNAME" = "aws" ] || [ "$PDIRNAME" = "gce" ]; then
+        TARGET="$PDIRNAME"
+    else
+        echo "no target detected"
+        exit 1
+    fi
+fi
 
 print_usage() {
     echo "build_ami.sh --localrpm --repo [URL] --target [distribution]"
@@ -34,6 +45,9 @@ print_usage() {
     echo "  --build-id           Set unique build ID, will be part of GCE image name"
     echo "  --download-no-server download all rpm needed excluding scylla from `repo-for-install`"
     echo "  --log-file           Path for log. Default build/ami.log on current dir"
+    if [ -z "$TARGET" ]; then
+        echo "  --target             Specify target cloud (aws/gce/azure)"
+    fi
     exit 1
 }
 LOCALRPM=0
@@ -41,13 +55,6 @@ DOWNLOAD_ONLY=0
 PACKER_SUB_CMD="build"
 REPO_FOR_INSTALL=
 PACKER_LOG_PATH=build/ami.log
-
-if [ "$PDIRNAME" = "aws" ] || [ "$PDIRNAME" = "gce" ]; then
-    TARGET="$PDIRNAME"
-else
-    echo "no target detected"
-    exit 1
-fi
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -93,6 +100,21 @@ while [ $# -gt 0 ]; do
             PACKER_SUB_CMD="validate"
             DRY_RUN=true
             shift 1
+            ;;
+        "--target")
+            if [ -n "$TARGET" ]; then
+                print_usage
+            fi
+            if [ "$2" = "aws" ]; then
+                DIR="$REALDIR/../$2/ami"
+            elif [ "$2" = "gce" ]; then
+                DIR="$REALDIR/../$2/image"
+            else
+                print_usage
+            fi
+            cd "$DIR"
+            TARGET="$2"
+            shift 2
             ;;
         *)
             echo "ERROR: Illegal option: $1"


### PR DESCRIPTION
Support run build_image.sh/build_deb_image.sh directly by --target <cloud> option.
The script currently located subdirectory of packer to adjust directory
depth of each cloud directories, but it's inconvenient to call longer
path.
So move the script to packer directory, and detect executed via symlink
or not.
To keep compatibility with existing build, direct run will be chdir to
target cloud directory, to use files/ and variables.json for the target.

Fixes #197