### PR TITLE
Revert workaround of kernel-ml boot up issue, fix the problem

### DIFF
--- a/aws/ami/files/elrepo-archive.repo
+++ b/aws/ami/files/elrepo-archive.repo
@@ -1,5 +1,0 @@
-[kernel-ml-archive]
-name=kernel-ml-archive
-baseurl=http://linux-mirrors.fnal.gov/linux/elrepo/archive/kernel/el7/x86_64/
-enabled=1
-gpgcheck=0

--- a/packer/scylla_install_image
+++ b/packer/scylla_install_image
@@ -118,9 +118,6 @@ if __name__ == '__main__':
         # use easy_install instead of pip, because easy_install requires
         # fewer dependencies, no need to install gcc, it makes our AMI smaller.
         if distro == 'centos':
-            # this is for pinning kernel-ml describes later
-            run('cp elrepo-archive.repo /etc/yum.repos.d/')
-
             run('yum install -y epel-release')
             run('yum install -y pystache python-daemon python-setuptools')
             # Default install prefix on CentOS7 is /usr not /usr/local, but we need
@@ -224,9 +221,9 @@ if __name__ == '__main__':
         # So we have to use different kernel here.
         if platform.machine() == 'x86_64':
             run('yum -y install grubby')
-            # kernel-ml 5.14.0 and later does not boot up on EC2 instances https://github.com/scylladb/scylla-machine-image/issues/196
-            # force installing kernel 5.13.13 that is known to be good
-            run('yum -y install kernel-ml-5.13.13 kernel-ml-devel-5.13.13')
+            run('rpm --import https://www.elrepo.org/RPM-GPG-KEY-elrepo.org')
+            run('rpm -Uvh http://www.elrepo.org/elrepo-release-7.0-3.el7.elrepo.noarch.rpm')
+            run('yum -y --enablerepo=elrepo-kernel install kernel-ml')
             mlkver = get_kver('/boot/vmlinuz-*el7.elrepo.x86_64')
             run('grubby --grub2 --set-default /boot/vmlinuz-{mlkver}'.format(mlkver=mlkver))
             with open('/etc/yum.conf', 'a') as f:

--- a/packer/scylla_install_image
+++ b/packer/scylla_install_image
@@ -195,6 +195,8 @@ if __name__ == '__main__':
             cfg = re.sub('^     name: ubuntu', '     name: scyllaadm', cfg, flags=re.MULTILINE)
         with open('/etc/cloud/cloud.cfg', 'w') as f:
             f.write(cfg)
+        # before deleting home directory, need to change current directory
+        os.chdir('/tmp')
         run('userdel -r -f {}'.format(distro))
         run('cloud-init clean')
         run('cloud-init init')
@@ -225,6 +227,7 @@ if __name__ == '__main__':
             run('rpm -Uvh http://www.elrepo.org/elrepo-release-7.0-3.el7.elrepo.noarch.rpm')
             run('yum -y --enablerepo=elrepo-kernel install kernel-ml')
             mlkver = get_kver('/boot/vmlinuz-*el7.elrepo.x86_64')
+            run('dracut --add-drivers "xen-blkfront xen-netfront ixgbevf ena nvme" --force /boot/initramfs-{mlkver}.img {mlkver}'.format(mlkver=mlkver))
             run('grubby --grub2 --set-default /boot/vmlinuz-{mlkver}'.format(mlkver=mlkver))
             with open('/etc/yum.conf', 'a') as f:
                 f.write(u'exclude=kernel kernel-devel')


### PR DESCRIPTION
Seem like kernel-ml 5.14.1 boot up issue was caused because xen-blkfront
is not installed on its initramfs, we need to re-generate it with the
driver.

Revert the workaround since we found a solution.