### PR TITLE
build_deb_image.sh:add debug option for testing

### DIFF
--- a/aws/ami/scylla.json
+++ b/aws/ami/scylla.json
@@ -36,7 +36,7 @@
           "virtual_name": "ephemeral7"
         }
       ],
-      "ami_name": "{{user `image_prefix`}}scylla_{{isotime | clean_resource_name}}",
+      "ami_name": "{{user `image_prefix`}}scylla_{{isotime | clean_resource_name}}-build-{{user `scylla_build_id`| clean_resource_name}}",
       "associate_public_ip_address": "{{user `associate_public_ip_address`}}",
       "sriov_support": true,
       "ena_support": true,

--- a/aws/ami/scylla.json
+++ b/aws/ami/scylla.json
@@ -36,7 +36,7 @@
           "virtual_name": "ephemeral7"
         }
       ],
-      "ami_name": "{{user `ami_prefix`}}scylla_{{isotime | clean_resource_name}}",
+      "ami_name": "{{user `image_prefix`}}scylla_{{isotime | clean_resource_name}}",
       "associate_public_ip_address": "{{user `associate_public_ip_address`}}",
       "sriov_support": true,
       "ena_support": true,
@@ -91,7 +91,7 @@
   ],
   "variables": {
     "access_key": "",
-    "ami_prefix": "",
+    "image_prefix": "",
     "associate_public_ip_address": "",
     "install_args": "",
     "instance_type": "",

--- a/azure/image/scylla.json
+++ b/azure/image/scylla.json
@@ -9,7 +9,7 @@
     "subscription_id": "{{user `subscription_id`}}",
 
     "managed_image_resource_group_name": "scylla-images",
-    "managed_image_name": "ScyllaDB-{{user `scylla_version`}}",
+    "managed_image_name": "{{user `image_prefix`}}ScyllaDB-{{user `scylla_version`}}",
 
     "os_type": "Linux",
     "image_publisher": "Canonical",
@@ -47,6 +47,7 @@
     }
   ],
   "variables": {
-    "ssh_username": ""
+    "ssh_username": "",
+    "image_prefix": ""
   }
 }

--- a/azure/image/scylla.json
+++ b/azure/image/scylla.json
@@ -9,7 +9,7 @@
     "subscription_id": "{{user `subscription_id`}}",
 
     "managed_image_resource_group_name": "scylla-images",
-    "managed_image_name": "{{user `image_prefix`}}ScyllaDB-{{user `scylla_version`}}",
+    "managed_image_name": "{{user `image_prefix`}}ScyllaDB-{{user `scylla_version`}}-build-{{user `scylla_build_id`| clean_resource_name}}",
 
     "os_type": "Linux",
     "image_publisher": "Canonical",

--- a/gce/image/scylla.json
+++ b/gce/image/scylla.json
@@ -11,7 +11,7 @@
       "machine_type": "{{user `instance_type`}}",
       "metadata": {"block-project-ssh-keys": "TRUE"},
       "image_family": "scylla",
-      "image_name": "scylla-{{user `scylla_version`| clean_resource_name}}-build-{{user `scylla_build_id`| clean_resource_name}}",
+      "image_name": "{{user `image_prefix`}}scylla-{{user `scylla_version`| clean_resource_name}}-build-{{user `scylla_build_id`| clean_resource_name}}",
       "image_description": "Official ScyllaDB image v-{{user `scylla_version`| clean_resource_name}}",
       "use_internal_ip": false,
       "preemptible": true,
@@ -59,6 +59,7 @@
     "image_storage_location": "",
     "instance_type": "",
     "ssh_username": "",
-    "source_image_family": ""
+    "source_image_family": "",
+    "image_prefix": ""
   }
 }

--- a/packer/build_deb_image.sh
+++ b/packer/build_deb_image.sh
@@ -23,6 +23,7 @@ DIR=$(dirname $(realpath -se $0))
 PDIRNAME=$(basename $(realpath -se $DIR/..))
 EXIT_STATUS=0
 DRY_RUN=false
+DEBUG=false
 TARGET=
 
 if [ -L "$0" ]; then
@@ -42,8 +43,9 @@ print_usage() {
     echo "  --repo-for-update     repository for update, specify .repo/.list file URL"
     echo "  --product             scylla or scylla-enterprise"
     echo "  --dry-run             validate template only (image is not built)"
-    echo "  --build-id           Set unique build ID, will be part of GCE image name"
+    echo "  --build-id            Set unique build ID, will be part of GCE image name"
     echo "  --download-no-server  download all deb needed excluding scylla from repo-for-install"
+    echo "  --debug               Build debug image with special prefix for image name"
     echo "  --log-file            Path for log. Default build/ami.log on current dir"
     if [ -z "$TARGET" ]; then
         echo "  --target             Specify target cloud (aws/gce/azure)"
@@ -93,6 +95,11 @@ while [ $# -gt 0 ]; do
             ;;
         "--download-no-server")
             DOWNLOAD_ONLY=1
+            shift 1
+            ;;
+        "--debug")
+            echo "!!! Building image for debug !!!"
+            DEBUG=true
             shift 1
             ;;
         "--dry-run")
@@ -250,7 +257,10 @@ elif [ "$TARGET" = "azure" ]; then
     PACKER_ARGS+=(-var tenant_id="$AZURE_TENANT_ID")
     PACKER_ARGS+=(-var subscription_id="$AZURE_SUBSCRIPTION_ID")
     PACKER_ARGS+=(-var scylla_build_id="$BUILD_ID")
+fi
 
+if $DEBUG ; then
+  PACKER_ARGS+=(-var image_prefix="debug-image-")
 fi
 
 if [ ! -f variables.json ]; then

--- a/packer/build_deb_image.sh
+++ b/packer/build_deb_image.sh
@@ -245,7 +245,6 @@ elif [ "$TARGET" = "gce" ]; then
     SOURCE_IMAGE_FAMILY="ubuntu-2004-lts"
 
     PACKER_ARGS+=(-var source_image_family="$SOURCE_IMAGE_FAMILY")
-    PACKER_ARGS+=(-var scylla_build_id="$BUILD_ID")
 elif [ "$TARGET" = "azure" ]; then
     REGION="EAST US"
     SSH_USERNAME=azureuser
@@ -256,7 +255,6 @@ elif [ "$TARGET" = "azure" ]; then
     PACKER_ARGS+=(-var client_secret="$AZURE_CLIENT_SECRET")
     PACKER_ARGS+=(-var tenant_id="$AZURE_TENANT_ID")
     PACKER_ARGS+=(-var subscription_id="$AZURE_SUBSCRIPTION_ID")
-    PACKER_ARGS+=(-var scylla_build_id="$BUILD_ID")
 fi
 
 if $DEBUG ; then
@@ -284,6 +282,7 @@ export PACKER_LOG_PATH
   -var scylla_jmx_version="$SCYLLA_JMX_VERSION" \
   -var scylla_tools_version="$SCYLLA_TOOLS_VERSION" \
   -var scylla_python3_version="$SCYLLA_PYTHON3_VERSION" \
+  -var scylla_build_id="$BUILD_ID" \
   "${PACKER_ARGS[@]}" \
   scylla.json
 


### PR DESCRIPTION
Following scylladb/scylla-pkg#2393, All image builds (official or debug) have the same image name prefix.
Let's make sure when we (releng) building an image (ami,gce or azure) we create the name of the image with a general debug prefix

Once this will be merge, we need also to change hydra.sh script in SCT repo to fetch the latests AMI images and ignore debug ami images prefix (scylladb/scylla-cluster-tests#3950)