### PR TITLE
Preinstall cpupower/cpufrequtils on AMI building time

### DIFF
--- a/common/scylla_image_setup
+++ b/common/scylla_image_setup
@@ -22,7 +22,9 @@ from scylla_util import *
 from subprocess import run
 
 if __name__ == '__main__':
-    run('/opt/scylladb/scripts/scylla_cpuscaling_setup', shell=True, check=True)
+    # On Ubuntu, we configure CPU scaling while AMI building time
+    if is_redhat_variant():
+        run('/opt/scylladb/scripts/scylla_cpuscaling_setup', shell=True, check=True)
     cloud_instance = get_cloud_instance()
     run('/opt/scylladb/scylla-machine-image/scylla_configure.py', shell=True, check=True)
     if not os.path.ismount('/var/lib/scylla'):

--- a/packer/scylla_install_image
+++ b/packer/scylla_install_image
@@ -148,6 +148,17 @@ if __name__ == '__main__':
     run('systemctl daemon-reload')
     run('systemctl enable scylla-image-setup.service')
     run('/opt/scylladb/scripts/scylla_setup --no-coredump-setup --no-sysconfig-setup --no-raid-setup --no-io-setup --no-bootparam-setup --no-ec2-check --no-swap-setup --no-cpuscaling-setup')
+
+    # The difference comes from two different services to configure CPU scaling.
+    # On CentOS 'cpupower' fails when CPU scaling is not supported, so we can't
+    # enable it here.
+    # On Ubuntu 'cpufrequtils' never fails even CPU scaling is not supported,
+    # so we want to enable it here.
+    if distro == 'centos':
+        run('yum install -y cpupowerutils')
+    else:
+        run('/opt/scylladb/scripts/scylla_cpuscaling_setup --force')
+
     run('/opt/scylladb/scripts/scylla_sysconfig_setup --ami --set-clocksource {}'.format(sysconfig_opt))
     run('/opt/scylladb/scripts/scylla_bootparam_setup --ami')
     os.remove('{}/.ssh/authorized_keys'.format(homedir))


### PR DESCRIPTION
It is bad to install packages on instance startup time, we want to
finish installing on AMI building time.

For CentOS AMI, install cpupower on AMI building time.
For Ubuntu AMI, install cpufrequtils and configure it on AMI building
time.

Fixes #204

----

**This requires https://github.com/scylladb/scylla/pull/9326 to merge, otherwise fails to build.**