### PR TITLE
aws: add xen-blkfront driver to kernel-ml initramfs

### DIFF
--- a/aws/ami/files/scylla_install_ami
+++ b/aws/ami/files/scylla_install_ami
@@ -116,6 +116,7 @@ if __name__ == '__main__':
         run('rpm -Uvh http://www.elrepo.org/elrepo-release-7.0-3.el7.elrepo.noarch.rpm')
         run('yum -y --enablerepo=elrepo-kernel install kernel-ml')
         mlkver = get_kver('/boot/vmlinuz-*el7.elrepo.x86_64')
+        run('dracut --add-drivers "xen-blkfront xen-netfront ixgbevf ena nvme" --force /boot/initramfs-{mlkver}.img {mlkver}'.format(mlkver=mlkver))
         run('grubby --grub2 --set-default /boot/vmlinuz-{mlkver}'.format(mlkver=mlkver))
         with open('/etc/yum.conf', 'a') as f:
             f.write(u'exclude=kernel kernel-devel')


### PR DESCRIPTION
Seem like kernel-ml 5.14.1 boot up issue was caused because xen-blkfront
is not installed on its initramfs, we need to re-generate it with the
driver.

See #196