### PR TITLE
aws: add xen-blkfront driver to kernel-ml initramfs for 4.3

### DIFF
--- a/aws/ami/files/scylla_install_ami
+++ b/aws/ami/files/scylla_install_ami
@@ -110,7 +110,7 @@ if __name__ == '__main__':
         f.write(u'exclude=kernel kernel-devel')
 
     run('dracut --verbose --add-drivers "ixgbevf nvme ena" --force --kver {c7kver}'.format(c7kver=c7kver))
-    run('dracut --verbose --add-drivers "ixgbevf nvme ena" --force --kver {mlkver}'.format(mlkver=mlkver))
+    run('dracut --verbose --add-drivers "xen-blkfront xen-netfront ixgbevf nvme ena" --force --kver {mlkver}'.format(mlkver=mlkver))
 
     with open('/etc/cloud/cloud.cfg') as f:
         cfg = f.read()


### PR DESCRIPTION
Seem like kernel-ml 5.14.1 boot up issue was caused because xen-blkfront
is not installed on its initramfs, we need to re-generate it with the
driver.

See #196