### PR TITLE
scylla_create_devices: add persistent disk support for GCE

### DIFF
--- a/common/scylla_create_devices
+++ b/common/scylla_create_devices
@@ -57,7 +57,7 @@ def get_default_devices(instance):
     if is_ec2():
         disk_names = instance.ephemeral_disks() or instance.ebs_disks()
     elif is_gce():
-        disk_names = instance.getEphemeralOsDisks()
+        disk_names = instance.getEphemeralOsDisks() or instance.getPersistentOsDisks()
     elif is_azure():
         disk_names = instance.getEphemeralOsDisks()
     else:


### PR DESCRIPTION
Just like EBS disks for EC2, we want to use persistent disk on GCE.
We won't recommend to use it, but still need to support it.

Fixes #215

----

Requires https://github.com/scylladb/scylla/pull/9395 to merge