### PR TITLE
Cloudformation: remove default ingress route

### DIFF
--- a/aws/cloudformation/scylla.yaml.j2
+++ b/aws/cloudformation/scylla.yaml.j2
@@ -58,7 +58,6 @@ Parameters:
     Description: |
         The IP address range that can be used to SSH to the EC2 instances
         (x.x.x.x/32 for specific IP, 0.0.0.0/0 to allow all IP addresses)
-    Default: 0.0.0.0/0
 
   InstanceCount:
     Description: Must be between 1 and {{ total_num_node }}


### PR DESCRIPTION
Default value 0.0.0.0/0. This open the Ingress to the world by default.
Let's delete the default value and let the customer define it

Fixes: https://github.com/scylladb/scylla-machine-image/issues/210