### PR TITLE
cloudformation: remove ipv6 from ingress security group

### DIFF
--- a/aws/cloudformation/scylla.yaml.j2
+++ b/aws/cloudformation/scylla.yaml.j2
@@ -314,10 +314,6 @@ Resources:
           FromPort: 22
           ToPort: 22
           IpProtocol: tcp
-        - CidrIpv6: ::/0
-          FromPort: 22
-          ToPort: 22
-          IpProtocol: tcp
       SecurityGroupEgress:
         - CidrIp: 0.0.0.0/0
           IpProtocol: '-1'


### PR DESCRIPTION
We don't allow ipv6 on AWS::EC2::VPC so it doesn't affect and relevant
to anything. in addition we don't want to add this option since it's not
common and will complex the flow.

Fixes #211