### PR TITLE
scylla_create_devices: add persistent disk support for Azure

### DIFF
--- a/common/scylla_create_devices
+++ b/common/scylla_create_devices
@@ -59,7 +59,7 @@ def get_default_devices(instance):
     elif is_gce():
         disk_names = instance.getEphemeralOsDisks()
     elif is_azure():
-        disk_names = instance.getEphemeralOsDisks()
+        disk_names = instance.getEphemeralOsDisks() or instance.getPersistentOsDisks()
     else:
         raise Exception("Running in unknown cloud environment")
     return [str(Path('/dev', name)) for name in disk_names]


### PR DESCRIPTION
Just like EBS disks for EC2, we want to use persistent disk on Azure.
We won't recommend to use it, but still need to support it.

Fixes #218

----

Requires https://github.com/scylladb/scylla/pull/9417 to merge