### PR TITLE
Revert adding 'name' option for builders

### DIFF
--- a/packer/build_deb_image.sh
+++ b/packer/build_deb_image.sh
@@ -130,6 +130,14 @@ while [ $# -gt 0 ]; do
     esac
 done
 
+if [ "$TARGET" = "aws" ]; then
+    TARGET_TYPE="amazon-ebs"
+elif [ "$TARGET" = "gce" ]; then
+    TARGET_TYPE="googlecompute"
+elif [ "$TARGET" = "azure" ]; then
+    TARGET_TYPE="azure-arm"
+fi
+
 get_version_from_local_deb () {
     DEB=$1
     VERSION=$(dpkg -f "$DEB" version)
@@ -274,7 +282,7 @@ export PACKER_LOG=1
 export PACKER_LOG_PATH
 
 /usr/bin/packer ${PACKER_SUB_CMD} \
-  -only="$TARGET" \
+  -only="$TARGET_TYPE" \
   -var-file=variables.json \
   -var install_args="$INSTALL_ARGS" \
   -var ssh_username="$SSH_USERNAME" \

--- a/packer/build_image.sh
+++ b/packer/build_image.sh
@@ -123,6 +123,12 @@ while [ $# -gt 0 ]; do
     esac
 done
 
+if [ "$TARGET" = "aws" ]; then
+    TARGET_TYPE="amazon-ebs"
+elif [ "$TARGET" = "gce" ]; then
+    TARGET_TYPE="googlecompute"
+fi
+
 get_version_from_local_rpm () {
     RPM=$1
     RELEASE=$(rpm -qi $RPM | awk '/Release/ { print $3 }' )
@@ -238,7 +244,7 @@ export PACKER_LOG=1
 export PACKER_LOG_PATH
 
 /usr/bin/packer ${PACKER_SUB_CMD} \
-  -only="$TARGET" \
+  -only="$TARGET_TYPE" \
   -var-file=variables.json \
   -var install_args="$INSTALL_ARGS" \
   -var ssh_username="$SSH_USERNAME" \

--- a/packer/scylla.json
+++ b/packer/scylla.json
@@ -1,7 +1,6 @@
 {
   "builders": [
     {
-      "name": "aws",
       "type": "amazon-ebs",
       "access_key": "{{user `access_key`}}",
       "ami_block_device_mappings": [
@@ -70,7 +69,6 @@
       }
     },
     {
-      "name": "gce",
       "type": "googlecompute",
       "source_image_family": "{{user `source_image_family`}}",
       "ssh_username": "{{user `ssh_username`}}",
@@ -101,7 +99,6 @@
       }
     },
     {
-      "name": "azure",
       "type": "azure-arm",
       "ssh_username": "{{user `ssh_username`}}",
       "client_id": "{{user `client_id`}}",
@@ -138,10 +135,13 @@
     },
     {
       "inline": [
-        "if [ {{build_name}} = aws ]; then sudo /usr/bin/cloud-init status --wait; fi",
+        "if [ {{build_type}} = amazon-ebs ]; then export TARGET_CLOUD=aws; fi",
+        "if [ {{build_type}} = googlecompute ]; then export TARGET_CLOUD=gce; fi",
+        "if [ {{build_type}} = azure-arm ]; then export TARGET_CLOUD=azure; fi",
+        "if [ $TARGET_CLOUD = aws ]; then sudo /usr/bin/cloud-init status --wait; fi",
         "if [ -f /etc/debian_version ]; then sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.8 1; fi",
-        "if [ {{build_name}} = gce ] && [ -f /etc/redhat-release ]; then sudo alternatives --set python /usr/bin/python3; fi",
-        "sudo /home/{{user `ssh_username`}}/scylla_install_image --target-cloud {{build_name}} {{user `install_args`}}"
+        "if [ $TARGET_CLOUD = gce ] && [ -f /etc/redhat-release ]; then sudo alternatives --set python /usr/bin/python3; fi",
+        "sudo /home/{{user `ssh_username`}}/scylla_install_image --target-cloud $TARGET_CLOUD {{user `install_args`}}"
       ],
       "type": "shell"
     }


### PR DESCRIPTION
On 4f5c2a7e4d0f8c8da8bf2630bcfe71dad07c48bb, we added 'name' option for
each IaaS builders, to pass target cloud name for scylla_install_image.
However, this change affect output of packer.log, it renamed builder
name on the log like this.

Before: googlecompute: Disk has been deleted!
After: gce: Disk has been deleted!

We are checking log output on Jenkins to make sure the build suceed,
so we shouldn't change the output.