### PR TITLE
scylla_image_setup: run scylla_cpuscaling_setup earlier for branch-4.4

### DIFF
--- a/common/scylla_image_setup
+++ b/common/scylla_image_setup
@@ -22,6 +22,7 @@ from scylla_util import *
 from subprocess import run
 
 if __name__ == '__main__':
+    run('/opt/scylladb/scripts/scylla_cpuscaling_setup', shell=True, check=True)
     cloud_instance = get_cloud_instance()
     run('/opt/scylladb/scylla-machine-image/scylla_configure.py', shell=True, check=True)
     run('/opt/scylladb/scripts/scylla_sysconfig_setup --nic eth0 --setup-nic --ami', shell=True, check=True)


### PR DESCRIPTION
We found that scylla_cpuscaling_setup won't execute until RAID
construction finished, and it may take few minites or more on larger
systems.
To minimize initialization time, configure CPU scaling first, then
execute rest of setup.