### PR TITLE
Preinstall cpupower/cpufrequtils on AMI building time for branch-4.5

### DIFF
--- a/aws/ami/files/scylla_install_ami
+++ b/aws/ami/files/scylla_install_ami
@@ -108,6 +108,17 @@ if __name__ == '__main__':
     run('systemctl daemon-reload')
     run('systemctl enable scylla-image-setup.service')
     run('/opt/scylladb/scripts/scylla_setup --ntp-domain amazon --no-coredump-setup --no-sysconfig-setup --no-raid-setup --no-io-setup --no-bootparam-setup --no-ec2-check --no-swap-setup')
+
+    # The difference comes from two different services to configure CPU scaling.
+    # On CentOS 'cpupower' fails when CPU scaling is not supported, so we can't
+    # enable it here.
+    # On Ubuntu 'cpufrequtils' never fails even CPU scaling is not supported,
+    # so we want to enable it here.
+    if distro == 'centos':
+        run('yum install -y cpupowerutils')
+    else:
+        run('/opt/scylladb/scripts/scylla_cpuscaling_setup --force')
+
     run('/opt/scylladb/scripts/scylla_sysconfig_setup --ami --set-clocksource')
     run('/opt/scylladb/scripts/scylla_bootparam_setup --ami')
     os.remove('{}/.ssh/authorized_keys'.format(homedir))

--- a/common/scylla_image_setup
+++ b/common/scylla_image_setup
@@ -22,6 +22,9 @@ from scylla_util import *
 from subprocess import run
 
 if __name__ == '__main__':
+    # On Ubuntu, we configure CPU scaling while AMI building time
+    if is_redhat_variant():
+        run('/opt/scylladb/scripts/scylla_cpuscaling_setup', shell=True, check=True)
     cloud_instance = get_cloud_instance()
     run('/opt/scylladb/scylla-machine-image/scylla_configure.py', shell=True, check=True)
     if not os.path.ismount('/var/lib/scylla'):

--- a/gce/image/files/scylla_install_image
+++ b/gce/image/files/scylla_install_image
@@ -105,6 +105,17 @@ if __name__ == '__main__':
     run('systemctl daemon-reload')
     run('systemctl enable scylla-image-setup.service')
     run('/opt/scylladb/scripts/scylla_setup --no-coredump-setup --no-sysconfig-setup --no-raid-setup --no-io-setup --no-bootparam-setup --no-ec2-check --no-swap-setup')
+
+    # The difference comes from two different services to configure CPU scaling.
+    # On CentOS 'cpupower' fails when CPU scaling is not supported, so we can't
+    # enable it here.
+    # On Ubuntu 'cpufrequtils' never fails even CPU scaling is not supported,
+    # so we want to enable it here.
+    if distro == 'centos':
+        run('yum install -y cpupowerutils')
+    else:
+        run('/opt/scylladb/scripts/scylla_cpuscaling_setup --force')
+
     run('/opt/scylladb/scripts/scylla_sysconfig_setup --ami')
     housekeeping_uuid_path = Path('/var/lib/scylla-housekeeping/housekeeping.uuid')
     if housekeeping_uuid_path.exists():


### PR DESCRIPTION
It is bad to install packages on instance startup time, we want to
finish installing on AMI building time.

For CentOS AMI, install cpupower on AMI building time.
For Ubuntu AMI, install cpufrequtils and configure it on AMI building
time.

Fixes #204