### PR TITLE
Preinstall cpupower/cpufrequtils on AMI building time

### DIFF
--- a/aws/ami/files/scylla_install_ami
+++ b/aws/ami/files/scylla_install_ami
@@ -85,6 +85,7 @@ if __name__ == '__main__':
             if not re.match(r'^ - mounts\n$', l):
                 f.write(l)
     run('/opt/scylladb/scripts/scylla_setup --ntp-domain amazon --no-coredump-setup --no-sysconfig-setup --no-raid-setup --no-io-setup --no-bootparam-setup --no-ec2-check --no-swap-setup')
+    run('yum install -y cpupowerutils')
     run('/opt/scylladb/scripts/scylla_sysconfig_setup --ami')
     run('/opt/scylladb/scripts/scylla_bootparam_setup --ami')
     os.remove('{}/.ssh/authorized_keys'.format(homedir))

--- a/common/scylla_image_setup
+++ b/common/scylla_image_setup
@@ -22,6 +22,7 @@ from scylla_util import *
 from subprocess import run
 
 if __name__ == '__main__':
+    run('/opt/scylladb/scripts/scylla_cpuscaling_setup', shell=True, check=True)
     cloud_instance = get_cloud_instance()
     run('/opt/scylladb/scylla-machine-image/scylla_configure.py', shell=True, check=True)
     run('/opt/scylladb/scripts/scylla_sysconfig_setup --nic eth0 --setup-nic --ami', shell=True, check=True)

--- a/gce/image/files/scylla_install_image
+++ b/gce/image/files/scylla_install_image
@@ -79,6 +79,7 @@ if __name__ == '__main__':
     run('systemctl daemon-reload')
     run('systemctl enable scylla-image-setup.service')
     run('/opt/scylladb/scripts/scylla_setup --no-coredump-setup --no-sysconfig-setup --no-raid-setup --no-io-setup --no-bootparam-setup --no-ec2-check --no-swap-setup')
+    run('yum install -y cpupowerutils')
     run('/opt/scylladb/scripts/scylla_sysconfig_setup --ami')
     housekeeping_uuid_path = Path('/var/lib/scylla-housekeeping/housekeeping.uuid')
     if housekeeping_uuid_path.exists():


### PR DESCRIPTION
It is bad to install packages on instance startup time, we want to
finish installing on AMI building time.

Fixes #204