### PR TITLE
GCE: use underscores in image labels

### DIFF
--- a/packer/scylla.json
+++ b/packer/scylla.json
@@ -93,9 +93,9 @@
           "scylla_jmx_version": "{{user `scylla_jmx_version`| clean_resource_name}}",
           "scylla_tools_version": "{{user `scylla_tools_version`| clean_resource_name}}",
           "scylla_python3_version": "{{user `scylla_python3_version`| clean_resource_name}}",
-          "build-id": "{{user `scylla_build_id`| clean_resource_name}}",
+          "build_id": "{{user `scylla_build_id`| clean_resource_name}}",
           "branch": "{{user `branch`| clean_resource_name}}",
-          "operating-system": "{{user `operating_system`| clean_resource_name}}",
+          "operating_system": "{{user `operating_system`| clean_resource_name}}",
           "user_data_format_version": "2"
       },
       "labels": {


### PR DESCRIPTION
Unfortunately, GCE API works pretty bad with dashes in labels.
We can't align with AWS here and switched to underscores.