### PR TITLE
GCE: workaround for login issue on Ubuntu image

### DIFF
--- a/packer/scylla.json
+++ b/packer/scylla.json
@@ -141,6 +141,7 @@
     },
     {
       "inline": [
+        "if [ {{build_name}} = gce ] && [ -f /etc/debian_version ]; then echo '#!/bin/sh\n/usr/bin/systemctl start google-guest-agent'|sudo tee /etc/rc.local;sudo chmod a+rx /etc/rc.local;sudo systemctl enable rc-local.service; fi",
         "if [ {{build_name}} = aws ]; then sudo /usr/bin/cloud-init status --wait; fi",
         "if [ -f /etc/debian_version ]; then sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.8 1; fi",
         "if [ {{build_name}} = gce ] && [ -f /etc/redhat-release ]; then sudo alternatives --set python /usr/bin/python3; fi",


### PR DESCRIPTION
Currently Ubuntu image is broken because google-guest-agent.service is not
started for some reason.
And it doesn't fix by "systemctl enable google-guest-agent.service".
But we still can force launching it from /etc/rc.local.
Until we find a solution, this is a workaroud for the issue.

Fixes #235