### PR TITLE
scylla_image_setup: add check current instance has ephemeral disks

### DIFF
--- a/common/scylla_image_setup
+++ b/common/scylla_image_setup
@@ -33,7 +33,13 @@ if __name__ == '__main__':
 
     run('/opt/scylladb/scripts/scylla_sysconfig_setup --nic eth0 --setup-nic --ami', shell=True, check=True)
     if cloud_instance.is_supported_instance_class():
-        cloud_instance.io_setup()
+        # We run io_setup only when ehpemeral disks are available
+        if is_gce():
+            nr_disks = cloud_instance.nvmeDiskCount
+            if nr_disks < 0:
+                cloud_instance.io_setup()
+        else:
+            cloud_instance.io_setup()
     if os.path.ismount('/var/lib/scylla'):
         run('/opt/scylladb/scripts/scylla_coredump_setup --dump-to-raiddir', shell=True, check=True)
     else:


### PR DESCRIPTION
On AWS, "supported" instance type means it should have ephemeral disks.
So scylla_image_setup checks instance type before running io_setup like
this:
    if cloud_instance.is_supported_instance_class():
        cloud_instance.io_setup()

But this is not enough for GCE, it can configure instance without
ephemeral disks even instance type is 'supported' one.
To support such case, we also need to check the instance has ephemeral disks.

Fixes #243

Signed-off-by: Takuya ASADA <syuu@scylladb.com>