### PR TITLE
Azure:set image name to match azure rules

### DIFF
--- a/packer/build_deb_image.sh
+++ b/packer/build_deb_image.sh
@@ -157,14 +157,12 @@ echo "INSTALL_ARGS: |$INSTALL_ARGS|"
 get_version_from_local_deb () {
     DEB=$1
     VERSION=$(dpkg -f "$DEB" version)
-    VERSION=$(echo $VERSION | sed 's/\(.*\)\~)*/\1./')
     echo "$VERSION"
 }
 
 get_version_from_remote_deb () {
     DEB=$1
     VERSION=$(sudo apt-cache madison "$DEB"|head -n1|awk '{print $3}')
-    VERSION=$(echo $VERSION | sed 's/\(.*\)\~)*/\1./')
     echo "$VERSION"
 }
 

--- a/packer/build_deb_image.sh
+++ b/packer/build_deb_image.sh
@@ -280,6 +280,7 @@ elif [ "$TARGET" = "azure" ]; then
     REGION="EAST US"
     SSH_USERNAME=azureuser
     SCYLLA_IMAGE_DESCRIPTION="scylla-$SCYLLA_VERSION scylla-machine-image-$SCYLLA_MACHINE_IMAGE_VERSION scylla-jmx-$SCYLLA_JMX_VERSION scylla-tools-$SCYLLA_TOOLS_VERSION scylla-python3-$SCYLLA_PYTHON3_VERSION"
+    SCYLLA_VERSION=$(echo $SCYLLA_VERSION | sed 's/\(.*\)\~)*/\1./')
 
     PACKER_ARGS+=(-var scylla_image_description="${SCYLLA_IMAGE_DESCRIPTION:0:255}")
     PACKER_ARGS+=(-var client_id="$AZURE_CLIENT_ID")


### PR DESCRIPTION
during Azure image build in 4.6 we got the following error
```
15:45:50  1 error(s) occurred:
15:45:50
15:45:50  * The setting managed_image_name must match the regular expression
15:45:50  "^[^_\\W][\\w-._)]{0,79}$", and not end with a '-' or '.'.
```
This is due to the use of `~` char when we spin a release candidate

Fixing it