### PR TITLE
scylla_image_setup: bug fix to check ephemeral disks count

### DIFF
--- a/common/scylla_image_setup
+++ b/common/scylla_image_setup
@@ -36,7 +36,7 @@ if __name__ == '__main__':
         # We run io_setup only when ehpemeral disks are available
         if is_gce():
             nr_disks = cloud_instance.nvmeDiskCount
-            if nr_disks < 0:
+            if nr_disks > 0:
                 cloud_instance.io_setup()
         else:
             cloud_instance.io_setup()


### PR DESCRIPTION
We should check nr_disks > 0, not nr_disks < 0.