### PR TITLE
Revert "GCE: workaround for login issue on Ubuntu image"

### DIFF
--- a/packer/scylla.json
+++ b/packer/scylla.json
@@ -141,7 +141,6 @@
     },
     {
       "inline": [
-        "if [ {{build_name}} = gce ] && [ -f /etc/debian_version ]; then echo '#!/bin/sh\n/usr/bin/systemctl start google-guest-agent'|sudo tee /etc/rc.local;sudo chmod a+rx /etc/rc.local;sudo systemctl enable rc-local.service; fi",
         "if [ {{build_name}} = aws ]; then sudo /usr/bin/cloud-init status --wait; fi",
         "if [ -f /etc/debian_version ]; then sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.8 1; fi",
         "if [ {{build_name}} = gce ] && [ -f /etc/redhat-release ]; then sudo alternatives --set python /usr/bin/python3; fi",


### PR DESCRIPTION
This reverts commit d49709f4318a4a6cee94b0540c8c5561d9b9d0fa.

Still we cannot find root cause of the problem, but we found that the
issue does not reproduced on latest scylla / packer / ubuntu image.
So we can revert the workaround now.