### PR TITLE
Make root disk only environment usable in development mode

### DIFF
--- a/common/scylla_create_devices
+++ b/common/scylla_create_devices
@@ -23,8 +23,24 @@ from subprocess import run
 sys.path.append('/opt/scylladb/scripts')
 from scylla_util import is_ec2, is_gce, is_azure, get_cloud_instance
 
+class DiskIsNotEmptyError(Exception):
+    def __init__(self, disk):
+        self.disk = disk
+        pass
+
+    def __str__(self):
+        return f"{self.disk} is not empty, abort setup"
+
+class NoDiskFoundError(Exception):
+    def __init__(self):
+        pass
+
+    def __str__(self):
+        return "No data disk found, abort setup"
 
 def create_raid(devices):
+    if len(devices) == 0:
+        raise(NoDiskFoundError)
     scylla_path = Path("/var/lib/scylla")
     print(f"Devices: {devices}")
     if scylla_path.is_mount():
@@ -39,7 +55,7 @@ def check_persistent_disks_are_empty(disks):
         part = run(f'lsblk -dpnr -o PTTYPE /dev/{disk}', shell=True, check=True, capture_output=True, encoding='utf-8').stdout.strip()
         fs = run(f'lsblk -dpnr -o FSTYPE /dev/{disk}', shell=True, check=True, capture_output=True, encoding='utf-8').stdout.strip()
         if part != '' or fs != '':
-            raise Exception(f"/dev/{disk} is not empty, abort formatting")
+            raise DiskIsNotEmptyError(f'/dev/{disk}')
 
 
 def get_disk_devices(instance, device_type):
@@ -92,12 +108,11 @@ if __name__ == "__main__":
 
     instance = get_cloud_instance()
 
-    if not args.data_device or args.data_device == "auto":
-        disk_devices = get_default_devices(instance)
-    else:
-        disk_devices = get_disk_devices(instance, args.data_device)
-
-    if len(disk_devices) == 0:
-        print('No data disks found')
-    else:
+    try:
+        if not args.data_device or args.data_device == "auto":
+            disk_devices = get_default_devices(instance)
+        else:
+            disk_devices = get_disk_devices(instance, args.data_device)
         create_raid(disk_devices)
+    except (DiskIsNotEmptyError, NoDiskFoundError) as e:
+        print(e)

--- a/common/scylla_image_setup
+++ b/common/scylla_image_setup
@@ -27,22 +27,21 @@ if __name__ == '__main__':
         run('/opt/scylladb/scripts/scylla_cpuscaling_setup', shell=True, check=True)
     cloud_instance = get_cloud_instance()
     run('/opt/scylladb/scylla-machine-image/scylla_configure.py', shell=True, check=True)
-    if not os.path.ismount('/var/lib/scylla'):
-        print('Failed to initialize RAID volume, exiting setup')
-        sys.exit(1)
 
     run('/opt/scylladb/scripts/scylla_sysconfig_setup --nic eth0 --setup-nic --ami', shell=True, check=True)
-    if cloud_instance.is_supported_instance_class():
-        # We run io_setup only when ehpemeral disks are available
-        if is_gce():
-            nr_disks = cloud_instance.nvmeDiskCount
-            if nr_disks > 0:
-                cloud_instance.io_setup()
-        else:
-            cloud_instance.io_setup()
     if os.path.ismount('/var/lib/scylla'):
-        run('/opt/scylladb/scripts/scylla_coredump_setup --dump-to-raiddir', shell=True, check=True)
+        if cloud_instance.is_supported_instance_class():
+            # We run io_setup only when ehpemeral disks are available
+            if is_gce():
+                nr_disks = cloud_instance.nvmeDiskCount
+                if nr_disks > 0:
+                    cloud_instance.io_setup()
+            else:
+                cloud_instance.io_setup()
+            run('/opt/scylladb/scripts/scylla_coredump_setup --dump-to-raiddir', shell=True, check=True)
     else:
         run('/opt/scylladb/scripts/scylla_coredump_setup', shell=True, check=True)
     run('/opt/scylladb/scripts/scylla_swap_setup --swap-directory /', shell=True, check=True)
+    if not os.path.ismount('/var/lib/scylla'):
+        print('Failed to initialize RAID volume!')
     pathlib.Path('/etc/scylla/machine_image_configured').touch()

--- a/common/scylla_login
+++ b/common/scylla_login
@@ -51,7 +51,7 @@ For a list of optimized instance types and more EC2 instructions see '%s'"
 '''[1:-1]
 MSG_UNSUPPORTED_INSTANCE_TYPE_NO_DISKS = '''
     {red}{type} is not eligible for optimized automatic tuning!{nocolor}
-To continue startup ScyllaDB on this instance, you need to attach additional disks, then run 'sudo scylla_io_setup' then 'systemctl start scylla-server'.
+To continue startup ScyllaDB on this instance, you need to attach additional disks, run 'sudo scylla_create_devices', 'sudo scylla_io_setup' then 'sudo systemctl start scylla-server'.
 For a list of optimized instance types and more EC2 instructions see '%s'"
 
 '''[1:-1]


### PR DESCRIPTION
We currently not able to run scylla on root disk only environment, even
with development mode.
Because we specified "RequiredBy=scylla-server.service" on
scylla-image-setup.service, and scylla-image-setup.service fails when
additional disks not found.
To fix this, we need to finish scylla_image_setup even additional disks
not detected, it should fails at scylla-server.service instead (same as
EBS mode).

Fixes #256