### PR TITLE
Build ami scripts: Make default product really take effect

### DIFF
--- a/packer/build_deb_image.sh
+++ b/packer/build_deb_image.sh
@@ -17,7 +17,6 @@
 REALDIR=$(dirname $(readlink -f "$0"))
 source "$REALDIR"/../SCYLLA-VERSION-GEN
 
-PRODUCT=$(cat build/SCYLLA-PRODUCT-FILE)
 BUILD_ID=$(date -u '+%FT%H-%M-%S')
 BRANCH="master"
 OPERATING_SYSTEM="ubuntu20.04"
@@ -87,7 +86,6 @@ while [ $# -gt 0 ]; do
         "--product")
             PRODUCT=$2
             echo "--product parameter: PRODUCT |$PRODUCT|"
-            INSTALL_ARGS="$INSTALL_ARGS --product $2"
             shift 2
             ;;
         "--build-id")
@@ -151,6 +149,11 @@ while [ $# -gt 0 ]; do
             ;;
     esac
 done
+
+if [ -z "$PRODUCT" ]; then
+    PRODUCT=$(cat build/SCYLLA-PRODUCT-FILE)
+fi
+INSTALL_ARGS="$INSTALL_ARGS --product $PRODUCT"
 
 echo "INSTALL_ARGS: |$INSTALL_ARGS|"
 

--- a/packer/build_image.sh
+++ b/packer/build_image.sh
@@ -17,7 +17,6 @@
 REALDIR=$(dirname $(readlink -f "$0"))
 source "$REALDIR"/../SCYLLA-VERSION-GEN
 
-PRODUCT=$(cat build/SCYLLA-PRODUCT-FILE)
 BUILD_ID=$(date -u '+%FT%H-%M-%S')
 DIR=$(dirname $(realpath -se $0))
 PDIRNAME=$(basename $(realpath -se $DIR/..))
@@ -79,7 +78,6 @@ while [ $# -gt 0 ]; do
             ;;
         "--product")
             PRODUCT=$2
-            INSTALL_ARGS="$INSTALL_ARGS --product $2"
             shift 2
             ;;
         "--build-id")
@@ -126,6 +124,11 @@ while [ $# -gt 0 ]; do
             ;;
     esac
 done
+
+if [ -z "$PRODUCT" ]; then
+    PRODUCT=$(cat build/SCYLLA-PRODUCT-FILE)
+fi
+INSTALL_ARGS="$INSTALL_ARGS --product $PRODUCT"
 
 get_version_from_local_rpm () {
     RPM=$1


### PR DESCRIPTION
In the current scripts, if product is not given, even though it
is defaulted to whatever is in `build/SCYLLA-PRODUCT-FILE`, it
will not propagate to the packer vars (through `--install-args`).
This is a problem if the default is different than the one set in
`packer/scylla_install_image`.
This change will make the default always propagate to the packer
whether it is the default or a user set value.