### PR TITLE
build_deb_image.sh: Update to latest Ubuntu 20.04LTS AMI

### DIFF
--- a/packer/build_deb_image.sh
+++ b/packer/build_deb_image.sh
@@ -252,7 +252,7 @@ SCYLLA_VERSION=$(echo $SCYLLA_VERSION | sed 's/\(.*\)\~)*/\1./')
 if [ "$TARGET" = "aws" ]; then
     SSH_USERNAME=ubuntu
     declare -A AMI
-    AMI=(["x86_64"]=ami-0074ee617a234808d ["aarch64"]=ami-0763a1094de643002)
+    AMI=(["x86_64"]=ami-04505e74c0741db8d ["aarch64"]=ami-0b49a4a6e8e22fa16)
     REGION=us-east-1
 
     arch="$(uname -m)"


### PR DESCRIPTION
To use latest EC2 instance type, we need to update source AMI to latest
one.

This is needed for https://github.com/scylladb/scylla/pull/9730
to run AMI in new instance type.