### PR TITLE
AWS AMI: add `ami-regions` parameter control

### DIFF
--- a/packer/build_deb_image.sh
+++ b/packer/build_deb_image.sh
@@ -46,6 +46,7 @@ print_usage() {
     echo "  [--dry-run]           Validate template only (image is not built). Default: false"
     echo "  [--build-id]          Set unique build ID, will be part of GCE image name and as a label. Default: Date."
     echo "  [--branch]            Set the release branch for GCE label. Default: master"
+    echo "  [--ami-regions]       Set regions to copy the AMI when done building it (including permissions and tags)"
     echo "  [--operating-system]  Set the base OS for the image. Default: ubuntu20.04"
     echo "  --download-no-server  Download all deb needed excluding scylla from repo-for-install"
     echo "  [--debug]             Build debug image with special prefix for image name. Default: false."
@@ -96,6 +97,11 @@ while [ $# -gt 0 ]; do
         "--branch")
             BRANCH=$2
             echo "--branch parameter: BRANCH |$BRANCH|"
+            shift 2
+            ;;
+        "--ami-regions"):
+            AMI_REGIONS=$2
+            echo "--ami-regions prameter: AMI_REGIONS |$AMI_REGIONS|"
             shift 2
             ;;
         "--operating-system")
@@ -324,6 +330,7 @@ set -x
   -var scylla_build_id="$BUILD_ID" \
   -var operating_system="$OPERATING_SYSTEM" \
   -var branch="$BRANCH" \
+  -var ami_regions="$AMI_REGIONS" \
   "${PACKER_ARGS[@]}" \
   "$REALDIR"/scylla.json
 set +x

--- a/packer/build_image.sh
+++ b/packer/build_image.sh
@@ -40,6 +40,7 @@ print_usage() {
     echo "  --repo-for-install   repository for install, specify .repo/.list file URL"
     echo "  --repo-for-update    repository for update, specify .repo/.list file URL"
     echo "  --product            scylla or scylla-enterprise"
+    echo "  [--ami-regions]       Set regions to copy the AMI when done building it (including permissions and tags)"
     echo "  --dry-run            validate template only (image is not built)"
     echo "  --debug              Build on debug mode (cause a 'debug-image-' prefix to be added to the image name)"
     echo "  --build-id           Set unique build ID, will be part of GCE image name"
@@ -74,6 +75,11 @@ while [ $# -gt 0 ]; do
             ;;
         "--repo-for-update")
             INSTALL_ARGS="$INSTALL_ARGS --repo-for-update $2"
+            shift 2
+            ;;
+        "--ami-regions"):
+            AMI_REGIONS=$2
+            echo "--ami-regions prameter: AMI_REGIONS |$AMI_REGIONS|"
             shift 2
             ;;
         "--product")
@@ -262,6 +268,7 @@ export PACKER_LOG_PATH
   -var scylla_jmx_version="$SCYLLA_JMX_VERSION" \
   -var scylla_tools_version="$SCYLLA_TOOLS_VERSION" \
   -var scylla_python3_version="$SCYLLA_PYTHON3_VERSION" \
+  -var ami_regions="$AMI_REGIONS" \
   "${PACKER_ARGS[@]}" \
   "$REALDIR"/scylla.json
 

--- a/packer/scylla.json
+++ b/packer/scylla.json
@@ -67,7 +67,8 @@
           "ScyllaToolsVersion": "{{user `scylla_tools_version`}}",
           "ScyllaPython3Version": "{{user `scylla_python3_version`}}",
           "user_data_format_version": "2"
-      }
+      },
+      "ami_regions": "{{user `ami_regions`}}"
     },
     {
       "name": "gce",


### PR DESCRIPTION
The AMI builder of the packer can copy the newly created AMI as
part of the normal flow. This has the advantage of copying the
image along with the Tags and Permissions set without having to
have a dedicated script for doing so.
Here we add an optional `--ami-regions` parameter that takes a
comma separated list of regions and copy the AMI once it's build
has succeeded.

Signed-off-by: Eliran Sinvani <eliransin@scylladb.com>