### PR TITLE
scylla_create_device: Add support --raid-level parameter

### DIFF
--- a/common/scylla_create_devices
+++ b/common/scylla_create_devices
@@ -38,7 +38,7 @@ class NoDiskFoundError(Exception):
     def __str__(self):
         return "No data disk found, abort setup"
 
-def create_raid(devices):
+def create_raid(devices, raid_level=0):
     if len(devices) == 0:
         raise(NoDiskFoundError)
     scylla_path = Path("/var/lib/scylla")
@@ -47,7 +47,7 @@ def create_raid(devices):
         print(f"{scylla_path} is already mounted. Will not run 'scylla_raid_setup'!")
         sys.exit(0)
     run(["/opt/scylladb/scripts/scylla_raid_setup", "--raiddev", "/dev/md0", "--disks", ",".join(devices),
-         "--root", "/var/lib/scylla", "--volume-role", "all", "--update-fstab"], check=True)
+         "--root", "/var/lib/scylla", "--raid-level", f"{raid_level}", "--volume-role", "all", "--update-fstab"], check=True)
 
 
 def check_persistent_disks_are_empty(disks):
@@ -104,6 +104,9 @@ if __name__ == "__main__":
     parser.add_argument('--data-device', dest='data_device', action='store',
                         choices=["auto", "attached", "instance_store"],
                         help='Define type of device to use for scylla data: attached|instance_store')
+    parser.add_argument('--raid-level', dest='raid_level', action='store',
+                        choices=[0, 5], default=0, type=int,
+                        help='Define raid level to use: RAID0 or RAID5')
     args = parser.parse_args()
 
     instance = get_cloud_instance()
@@ -113,6 +116,6 @@ if __name__ == "__main__":
             disk_devices = get_default_devices(instance)
         else:
             disk_devices = get_disk_devices(instance, args.data_device)
-        create_raid(disk_devices)
+        create_raid(disk_devices, args.raid_level)
     except (DiskIsNotEmptyError, NoDiskFoundError) as e:
         print(e)


### PR DESCRIPTION
With commit https://github.com/scylladb/scylla/commit/42fd73d0332d034809c6cd228785bff82e1845aa
support RAID 5 was added to scylla.
Added appropriate parameter to scylla_configure and
scylla_create_device --raid-level parameter
for configure scylla ami

Issue: https://github.com/scylladb/scylla-machine-image/issues/265