### PR TITLE
gce: increase disk size to 30GB

### DIFF
--- a/packer/scylla.json
+++ b/packer/scylla.json
@@ -87,7 +87,7 @@
       "use_internal_ip": false,
       "preemptible": true,
       "omit_external_ip": false,
-      "disk_size": 20,
+      "disk_size": 30,
       "image_labels":  {
           "scylla_version": "{{user `scylla_version`| clean_resource_name}}",
           "scylla_machine_image_version": "{{user `scylla_machine_image_version`| clean_resource_name}}",


### PR DESCRIPTION
Since we configure almost same settings on all IaaS images, we should
use same default root disk size on all images.

However, only GCE image specifies 20GB disk size, we should increase it
to 30GB (AWS and Azure default).

Note: we don't set default size on Azure build, but default disk size on
Azure is 30GB.