### PR TITLE
[ami]:Add to scylla-packages manifast file arch prefix

### DIFF
--- a/packer/build_deb_image.sh
+++ b/packer/build_deb_image.sh
@@ -331,6 +331,7 @@ set -x
   -var operating_system="$OPERATING_SYSTEM" \
   -var branch="$BRANCH" \
   -var ami_regions="$AMI_REGIONS" \
+  -var arch="$(arch)" \
   "${PACKER_ARGS[@]}" \
   "$REALDIR"/scylla.json
 set +x

--- a/packer/scylla.json
+++ b/packer/scylla.json
@@ -150,7 +150,7 @@
       "type": "shell"
     },
     {
-      "source": "/home/{{user `ssh_username`}}/scylla-packages.txt",
+      "source": "/home/{{user `ssh_username`}}/scylla-packages-{{user `arch`}}.txt",
       "destination": "build/",
       "direction": "download",
       "type": "file"

--- a/packer/scylla_install_image
+++ b/packer/scylla_install_image
@@ -49,6 +49,9 @@ def get_kver(pattern):
 def is_centos():
     return os.path.exists('/etc/redhat-release')
 
+def arch():
+    return platform.machine()
+
 if __name__ == '__main__':
     if os.getuid() > 0:
         print('Requires root permission.')
@@ -250,7 +253,7 @@ if __name__ == '__main__':
     if distro == 'centos':
         run('yum install -y yum-utils')
         packages = subprocess.check_output('repoquery --requires --resolve --recursive --installed scylla', stderr=subprocess.STDOUT, shell=True)
-        with open('{}/scylla-packages.txt'.format(homedir), 'w') as f:
+        with open('{}/scylla-packages-{}.txt'.format(homedir, arch()), 'w') as f:
             f.write(packages)
     else:
         deps = subprocess.check_output('apt-cache depends --recurse --no-recommends --no-suggests --no-conflicts --no-breaks --no-replaces --no-enhances --installed scylla', stderr=subprocess.STDOUT, shell=True, encoding='utf-8').splitlines()
@@ -258,7 +261,7 @@ if __name__ == '__main__':
         for d in deps:
             if re.match(r'^\w', d) and not re.match(r'.+:i386$', d) and d not in pkgs:
                 pkgs.append(d)
-        with open('{}/scylla-packages.txt'.format(homedir), 'w') as f:
+        with open('{}/scylla-packages-{}.txt'.format(homedir, arch()), 'w') as f:
             for pkg_name in pkgs:
                 pkg_name_version = subprocess.check_output("dpkg-query --showformat='${{Package}}-${{Version}}' --show {}".format(pkg_name), shell=True, encoding='utf-8')
                 f.write('{}\n'.format(pkg_name_version))


### PR DESCRIPTION
Since today we are creating AMI for both `x86` and `arm` we should have
2 manifast files to upload.

Adding arch prefix so they will not override each other

This is a preparation for https://github.com/scylladb/scylla-pkg/issues/1869