### PR TITLE
fix(build_deb_image.sh): set arch var only for AWS

### DIFF
--- a/packer/build_deb_image.sh
+++ b/packer/build_deb_image.sh
@@ -282,6 +282,7 @@ if [ "$TARGET" = "aws" ]; then
     PACKER_ARGS+=(-var region="$REGION")
     PACKER_ARGS+=(-var instance_type="$INSTANCE_TYPE")
     PACKER_ARGS+=(-var source_ami="${AMI[$(arch)]}")
+    PACKER_ARGS+=(-var arch="$(arch)")
     PACKER_ARGS+=(-var scylla_ami_description="${SCYLLA_AMI_DESCRIPTION:0:255}")
 elif [ "$TARGET" = "gce" ]; then
     SSH_USERNAME=ubuntu
@@ -331,7 +332,6 @@ set -x
   -var operating_system="$OPERATING_SYSTEM" \
   -var branch="$BRANCH" \
   -var ami_regions="$AMI_REGIONS" \
-  -var arch="$(arch)" \
   "${PACKER_ARGS[@]}" \
   "$REALDIR"/scylla.json
 set +x


### PR DESCRIPTION
In 63ab4ae3a1e950a5c32fd8b7c532772b8bb76b25 i have added another variable to packer with the arch type. By mistake it was added to all cloud providers rather then only AWS

Fixing it