### PR TITLE
scylla_configure.py: support Ec2MultiRegionSnitch

### DIFF
--- a/common/scylla_configure.py
+++ b/common/scylla_configure.py
@@ -107,10 +107,22 @@ class ScyllaMachineImageConfigurator:
         return self._instance_user_data
 
     def updated_ami_conf_defaults(self):
-        private_ip = self.cloud_instance.private_ipv4()
-        self.CONF_DEFAULTS["scylla_yaml"]["listen_address"] = private_ip
-        self.CONF_DEFAULTS["scylla_yaml"]["broadcast_rpc_address"] = private_ip
-        self.CONF_DEFAULTS["scylla_yaml"]["seed_provider"][0]['parameters'][0]['seeds'] = private_ip
+        if self.cloud_instance.ENDPOINT_SNITCH == "Ec2MultiRegionSnitch":
+            try:
+                public_ip = self.cloud_instance.public_ipv4()
+            except:
+                LOGGER.error("Failed to retrieve public ip!")
+                sys.exit(1)
+            private_ip = self.cloud_instance.private_ipv4()
+            self.CONF_DEFAULTS["scylla_yaml"]["listen_address"] = private_ip
+            self.CONF_DEFAULTS["scylla_yaml"]["broadcast_address"] = public_ip
+            self.CONF_DEFAULTS["scylla_yaml"]["broadcast_rpc_address"] = public_ip
+            self.CONF_DEFAULTS["scylla_yaml"]["seed_provider"][0]['parameters'][0]['seeds'] = public_ip
+        else:
+            private_ip = self.cloud_instance.private_ipv4()
+            self.CONF_DEFAULTS["scylla_yaml"]["listen_address"] = private_ip
+            self.CONF_DEFAULTS["scylla_yaml"]["broadcast_rpc_address"] = private_ip
+            self.CONF_DEFAULTS["scylla_yaml"]["seed_provider"][0]['parameters'][0]['seeds'] = private_ip
         self.CONF_DEFAULTS["scylla_yaml"]["endpoint_snitch"] = self.cloud_instance.ENDPOINT_SNITCH
 
     def configure_scylla_yaml(self):


### PR DESCRIPTION
To support Ec2MultiRegionSnitch on EC2, we need to use public ip for
broadcast_address and seeds.

See scylladb/scylla#9386