### PR TITLE
aws: find latest image for source AMI

### DIFF
--- a/packer/build_deb_image.sh
+++ b/packer/build_deb_image.sh
@@ -272,16 +272,17 @@ SCYLLA_VERSION=$(echo $SCYLLA_VERSION | sed 's/\(.*\)\~)*/\1./')
 
 if [ "$TARGET" = "aws" ]; then
     SSH_USERNAME=ubuntu
-    declare -A AMI
-    AMI=(["x86_64"]=ami-04505e74c0741db8d ["aarch64"]=ami-0ae74ae9c43584639)
+    SOURCE_AMI_OWNER=099720109477
     REGION=us-east-1
 
     arch="$(uname -m)"
     case "$arch" in
       "x86_64")
+        SOURCE_AMI_FILTER="ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64*"
         INSTANCE_TYPE="c4.xlarge"
         ;;
       "aarch64")
+        SOURCE_AMI_FILTER="ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64*"
         INSTANCE_TYPE="a1.xlarge"
         ;;
       *)
@@ -293,7 +294,8 @@ if [ "$TARGET" = "aws" ]; then
 
     PACKER_ARGS+=(-var region="$REGION")
     PACKER_ARGS+=(-var instance_type="$INSTANCE_TYPE")
-    PACKER_ARGS+=(-var source_ami="${AMI[$(arch)]}")
+    PACKER_ARGS+=(-var source_ami_filter="$SOURCE_AMI_FILTER")
+    PACKER_ARGS+=(-var source_ami_owner="$SOURCE_AMI_OWNER")
     PACKER_ARGS+=(-var scylla_ami_description="${SCYLLA_AMI_DESCRIPTION:0:255}")
 elif [ "$TARGET" = "gce" ]; then
     SSH_USERNAME=ubuntu

--- a/packer/build_image.sh
+++ b/packer/build_image.sh
@@ -211,16 +211,17 @@ fi
 
 if [ "$TARGET" = "aws" ]; then
     SSH_USERNAME=centos
-    declare -A AMI
-    AMI=(["x86_64"]=ami-00e87074e52e6c9f9 ["aarch64"]=ami-0b802bd2b502aa382)
+    SOURCE_AMI_OWNER=125523088429
     REGION=us-east-1
 
     arch="$(uname -m)"
     case "$arch" in
       "x86_64")
+        SOURCE_AMI_FILTER="CentOS 7.* x86_64"
         INSTANCE_TYPE="c4.xlarge"
         ;;
       "aarch64")
+        SOURCE_AMI_FILTER="CentOS 7.* aarch64"
         INSTANCE_TYPE="a1.xlarge"
         ;;
       *)
@@ -232,7 +233,8 @@ if [ "$TARGET" = "aws" ]; then
 
     PACKER_ARGS+=(-var region="$REGION")
     PACKER_ARGS+=(-var instance_type="$INSTANCE_TYPE")
-    PACKER_ARGS+=(-var source_ami="${AMI[$(arch)]}")
+    PACKER_ARGS+=(-var source_ami_filter="$SOURCE_AMI_FILTER")
+    PACKER_ARGS+=(-var source_ami_owner="$SOURCE_AMI_OWNER")
     PACKER_ARGS+=(-var scylla_ami_description="${SCYLLA_AMI_DESCRIPTION:0:255}")
 elif [ "$TARGET" = "gce" ]; then
     SSH_USERNAME=centos

--- a/packer/scylla.json
+++ b/packer/scylla.json
@@ -53,7 +53,13 @@
       "region": "{{user `region`}}",
       "secret_key": "{{user `secret_key`}}",
       "security_group_id": "{{user `security_group_id`}}",
-      "source_ami": "{{user `source_ami`}}",
+      "source_ami_filter": {
+          "filters": {
+              "name": "{{user `source_ami_filter`}}"
+          },
+          "owners": ["{{user `source_ami_owner`}}"],
+          "most_recent": true
+      },
       "ssh_timeout": "5m",
       "ssh_username": "{{user `ssh_username`}}",
       "ssh_clear_authorized_keys": true,


### PR DESCRIPTION
We currently hardcoded source AMI ID, it may outdated if we keep using old one.
To automatically use latest image for source AMI, drop source_ami and
switch to source_ami_filter to find latest image by name pattern and owner id.