### PR TITLE
fix(scylla_install_image):create manifast based on product name

### DIFF
--- a/packer/build_deb_image.sh
+++ b/packer/build_deb_image.sh
@@ -332,6 +332,7 @@ set -x
   -var branch="$BRANCH" \
   -var ami_regions="$AMI_REGIONS" \
   -var arch="$(arch)" \
+  -var product="$PRODUCT" \
   "${PACKER_ARGS[@]}" \
   "$REALDIR"/scylla.json
 set +x

--- a/packer/scylla.json
+++ b/packer/scylla.json
@@ -150,7 +150,7 @@
       "type": "shell"
     },
     {
-      "source": "/home/{{user `ssh_username`}}/scylla-packages-{{user `arch`}}.txt",
+      "source": "/home/{{user `ssh_username`}}/{{user `product`}}-packages-{{user `arch`}}.txt",
       "destination": "build/",
       "direction": "download",
       "type": "file"

--- a/packer/scylla_install_image
+++ b/packer/scylla_install_image
@@ -252,16 +252,16 @@ if __name__ == '__main__':
     # generate package manifest to scylla-packages.txt
     if distro == 'centos':
         run('yum install -y yum-utils')
-        packages = subprocess.check_output('repoquery --requires --resolve --recursive --installed scylla', stderr=subprocess.STDOUT, shell=True)
-        with open('{}/scylla-packages-{}.txt'.format(homedir, arch()), 'w') as f:
+        packages = subprocess.check_output('repoquery --requires --resolve --recursive --installed {0}'.format(args.product), stderr=subprocess.STDOUT, shell=True)
+        with open('{}/{}-packages-{}.txt'.format(homedir, args.product, arch()), 'w') as f:
             f.write(packages)
     else:
-        deps = subprocess.check_output('apt-cache depends --recurse --no-recommends --no-suggests --no-conflicts --no-breaks --no-replaces --no-enhances --installed scylla', stderr=subprocess.STDOUT, shell=True, encoding='utf-8').splitlines()
+        deps = subprocess.check_output('apt-cache depends --recurse --no-recommends --no-suggests --no-conflicts --no-breaks --no-replaces --no-enhances --installed {0}'.format(args.product), stderr=subprocess.STDOUT, shell=True, encoding='utf-8').splitlines()
         pkgs=[]
         for d in deps:
             if re.match(r'^\w', d) and not re.match(r'.+:i386$', d) and d not in pkgs:
                 pkgs.append(d)
-        with open('{}/scylla-packages-{}.txt'.format(homedir, arch()), 'w') as f:
+        with open('{}/{}-packages-{}.txt'.format(homedir, args.product, arch()), 'w') as f:
             for pkg_name in pkgs:
                 pkg_name_version = subprocess.check_output("dpkg-query --showformat='${{Package}}-${{Version}}' --show {}".format(pkg_name), shell=True, encoding='utf-8')
                 f.write('{}\n'.format(pkg_name_version))


### PR DESCRIPTION
Following the work in https://github.com/scylladb/scylla-machine-image/pull/97/commits/e2243830305066756138943f291b85565f72709c
manifest creation is failing in enterprise since we use `scylla` as hard coded rather then product name

Fixing it