### PR TITLE
scylla_install_image:add Scylla version to manifest filename

### DIFF
--- a/packer/scylla.json
+++ b/packer/scylla.json
@@ -145,12 +145,12 @@
         "if [ {{build_name}} = aws ]; then sudo /usr/bin/cloud-init status --wait; fi",
         "if [ -f /etc/debian_version ]; then sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.8 1; fi",
         "if [ {{build_name}} = gce ] && [ -f /etc/redhat-release ]; then sudo alternatives --set python /usr/bin/python3; fi",
-        "sudo /home/{{user `ssh_username`}}/scylla_install_image --target-cloud {{build_name}} {{user `install_args`}}"
+        "sudo /home/{{user `ssh_username`}}/scylla_install_image --target-cloud {{build_name}} --scylla-version {{user `scylla_version`}} {{user `install_args`}}"
       ],
       "type": "shell"
     },
     {
-      "source": "/home/{{user `ssh_username`}}/{{user `product`}}-packages-{{user `arch`}}.txt",
+      "source": "/home/{{user `ssh_username`}}/{{user `product`}}-packages-{{user `scylla_version`}}-{{user `arch`}}.txt",
       "destination": "build/",
       "direction": "download",
       "type": "file"

--- a/packer/scylla_install_image
+++ b/packer/scylla_install_image
@@ -70,6 +70,8 @@ if __name__ == '__main__':
     parser.add_argument('--repo-for-update',
                         help='repository for update, specify .repo/.list file URL')
     parser.add_argument('--target-cloud', choices=['aws', 'gce', 'azure'], help='specify target cloud')
+    parser.add_argument('--scylla-version',
+                        help='Scylla version to be added to manifest file')
     args = parser.parse_args()
 
     if args.repo:
@@ -253,7 +255,7 @@ if __name__ == '__main__':
     if distro == 'centos':
         run('yum install -y yum-utils')
         packages = subprocess.check_output('repoquery --requires --resolve --recursive --installed {0}'.format(args.product), stderr=subprocess.STDOUT, shell=True)
-        with open('{}/{}-packages-{}.txt'.format(homedir, args.product, arch()), 'w') as f:
+        with open('{}/{}-packages-{}-{}.txt'.format(homedir, args.product, args.scylla_version, arch()), 'w') as f:
             f.write(packages)
     else:
         deps = subprocess.check_output('apt-cache depends --recurse --no-recommends --no-suggests --no-conflicts --no-breaks --no-replaces --no-enhances --installed {0}'.format(args.product), stderr=subprocess.STDOUT, shell=True, encoding='utf-8').splitlines()
@@ -261,7 +263,7 @@ if __name__ == '__main__':
         for d in deps:
             if re.match(r'^\w', d) and not re.match(r'.+:i386$', d) and d not in pkgs:
                 pkgs.append(d)
-        with open('{}/{}-packages-{}.txt'.format(homedir, args.product, arch()), 'w') as f:
+        with open('{}/{}-packages-{}-{}.txt'.format(homedir, args.product, args.scylla_version, arch()), 'w') as f:
             for pkg_name in pkgs:
                 pkg_name_version = subprocess.check_output("dpkg-query --showformat='${{Package}}-${{Version}}' --show {}".format(pkg_name), shell=True, encoding='utf-8')
                 f.write('{}\n'.format(pkg_name_version))


### PR DESCRIPTION
Later in the process of building the AMI we need to upload to S3 for future use.
Adding into manifest filename the current Scylla version