### PR TITLE
[ami]:modify arm based ami

### DIFF
--- a/packer/build_deb_image.sh
+++ b/packer/build_deb_image.sh
@@ -261,7 +261,7 @@ SCYLLA_VERSION=$(echo $SCYLLA_VERSION | sed 's/\(.*\)\~)*/\1./')
 if [ "$TARGET" = "aws" ]; then
     SSH_USERNAME=ubuntu
     declare -A AMI
-    AMI=(["x86_64"]=ami-04505e74c0741db8d ["aarch64"]=ami-0b49a4a6e8e22fa16)
+    AMI=(["x86_64"]=ami-04505e74c0741db8d ["aarch64"]=ami-0ae74ae9c43584639)
     REGION=us-east-1
 
     arch="$(uname -m)"


### PR DESCRIPTION
During artifacts-ami-test-arm in 4.6 we got the following error:
```
Launch Failed
The instance configuration for this AWS Marketplace product is not supported. Please see the AWS Marketplace site for more information about supported instance types, regions, and operating systems.
```
@benipeled pointed out that we are using a worng based ami for arm.

Fixes: 	https://github.com/scylladb/scylla-pkg/issues/2659