### PR TITLE
build_deb_image.sh: create image manifest with image ID

### DIFF
--- a/packer/scylla.json
+++ b/packer/scylla.json
@@ -172,6 +172,12 @@
       "type": "file"
     }
   ],
+  "post-processors": [
+    {
+      "type": "manifest",
+      "output": "scylla-image-manifest.json"
+    }
+  ],
   "variables": {
     "access_key": "",
     "image_prefix": "",


### PR DESCRIPTION
Today in scylla-pkg we search the log for the created AMI/Gce/Azure image.
There is an option when building image with packer to auto create a manifest with the relevant information , this will allow us to send the functions the value instead of looking for it

This is a preparation for https://github.com/scylladb/scylla-pkg/pull/2682