### PR TITLE
make scylla-server.service stopped state when scylla_on_first_boot=false

### DIFF
--- a/common/scylla_configure.py
+++ b/common/scylla_configure.py
@@ -60,8 +60,6 @@ class ScyllaMachineImageConfigurator:
         'raid_level': 0  # Default raid level is 0, supported raid 0, 5
     }
 
-    DISABLE_START_FILE_PATH = Path("/etc/scylla/ami_disabled")
-
     def __init__(self, scylla_yaml_path="/etc/scylla/scylla.yaml"):
         self.scylla_yaml_path = Path(scylla_yaml_path)
         self.scylla_yaml_example_path = Path(scylla_yaml_path + ".example")
@@ -159,7 +157,7 @@ class ScyllaMachineImageConfigurator:
         default_start_scylla_on_first_boot = self.CONF_DEFAULTS["start_scylla_on_first_boot"]
         if not self.instance_user_data.get("start_scylla_on_first_boot", default_start_scylla_on_first_boot):
             LOGGER.info("Disabling Scylla start on first boot")
-            self.DISABLE_START_FILE_PATH.touch()
+            subprocess.run("/usr/bin/systemctl stop scylla-server.service", shell=True, check=True)
 
     def create_devices(self):
         device_type = self.instance_user_data.get("data_device", self.CONF_DEFAULTS['data_device'])

--- a/tests/test_scylla_configure.py
+++ b/tests/test_scylla_configure.py
@@ -89,7 +89,6 @@ class TestScyllaConfigurator(TestCase):
     def test_empty_user_data(self):
         self.run_scylla_configure(**self.default_instance_metadata())
         self.check_yaml_files_exist()
-        assert not self.configurator.DISABLE_START_FILE_PATH.exists(), "ami_disabled not created"
         with self.configurator.scylla_yaml_path.open() as scylla_yaml_file:
             LOGGER.info("Checking that defaults are set as expected...")
             scylla_yaml = yaml.load(scylla_yaml_file, Loader=yaml.SafeLoader)
@@ -179,10 +178,9 @@ class TestScyllaConfigurator(TestCase):
                 start_scylla_on_first_boot=False,
             )
         )
-        self.configurator.DISABLE_START_FILE_PATH = self.temp_dir_path / "ami_disabled"
         self.run_scylla_configure(user_data=raw_user_data, private_ipv4=self.private_ip)
-        self.configurator.start_scylla_on_first_boot()
-        assert self.configurator.DISABLE_START_FILE_PATH.exists(), "ami_disabled not created"
+        with unittest.mock.patch("subprocess.run") as mocked_run:
+            self.configurator.start_scylla_on_first_boot()
 
     def test_default_raid0(self):
         self.run_scylla_configure(**self.default_instance_metadata())


### PR DESCRIPTION
Currently, when scylla_on_first_boot set to false, scylla-server.service
becomes failed state by returning non-zero in scylla_prepare script.
But systemd may automatically tries to start scylla-server.service again
when daemon is reloaded or any other services is manipulated.

Instead, we should make scylla-server.service stopped state, by running
systemctl stop scylla-server.service.

Fixes #234