### PR TITLE
prepare for Scylla 5.0

### DIFF
--- a/SCYLLA-VERSION-GEN
+++ b/SCYLLA-VERSION-GEN
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 PRODUCT=scylla
-VERSION=4.7.dev
+VERSION=5.0.dev
 
 if test -f version
 then


### PR DESCRIPTION
We decided to name the next version Scylla 5.0, in honor of
Raft based schema management.