### PR TITLE
Fix CentOS image build

### DIFF
--- a/packer/build_image.sh
+++ b/packer/build_image.sh
@@ -271,6 +271,7 @@ export PACKER_LOG_PATH
   -var scylla_tools_version="$SCYLLA_TOOLS_VERSION" \
   -var scylla_python3_version="$SCYLLA_PYTHON3_VERSION" \
   -var ami_regions="$AMI_REGIONS" \
+  -var arch="$(arch)" \
   "${PACKER_ARGS[@]}" \
   "$REALDIR"/scylla.json
 

--- a/packer/build_image.sh
+++ b/packer/build_image.sh
@@ -272,6 +272,7 @@ export PACKER_LOG_PATH
   -var scylla_python3_version="$SCYLLA_PYTHON3_VERSION" \
   -var ami_regions="$AMI_REGIONS" \
   -var arch="$(arch)" \
+  -var product="$PRODUCT" \
   "${PACKER_ARGS[@]}" \
   "$REALDIR"/scylla.json
 


### PR DESCRIPTION
On latest master CentOS image build is broken because we added "arch" and "product" variables on Packer.
To fix it we need to add them to build_image.sh too.