### PR TITLE
pre-allocate swapfile while building image

### DIFF
--- a/common/scylla_image_setup
+++ b/common/scylla_image_setup
@@ -42,7 +42,6 @@ if __name__ == '__main__':
             run('/opt/scylladb/scripts/scylla_coredump_setup --dump-to-raiddir', shell=True, check=True)
     else:
         run('/opt/scylladb/scripts/scylla_coredump_setup', shell=True, check=True)
-    run('/opt/scylladb/scripts/scylla_swap_setup --swap-directory /', shell=True, check=True)
     if not os.path.ismount('/var/lib/scylla'):
         print('Failed to initialize RAID volume!')
     pathlib.Path('/etc/scylla/machine_image_configured').touch()

--- a/packer/scylla_install_image
+++ b/packer/scylla_install_image
@@ -52,6 +52,10 @@ def is_centos():
 def arch():
     return platform.machine()
 
+def half_of_diskfree():
+    disk = os.statvfs('/')
+    return int((disk.f_bavail * disk.f_frsize) / 2)
+
 if __name__ == '__main__':
     if os.getuid() > 0:
         print('Requires root permission.')
@@ -166,6 +170,8 @@ if __name__ == '__main__':
         run('/opt/scylladb/scripts/scylla_cpuscaling_setup --force')
 
     run('/opt/scylladb/scripts/scylla_sysconfig_setup --ami --set-clocksource {}'.format(sysconfig_opt))
+    run('/opt/scylladb/scripts/scylla_swap_setup --swap-size-bytes {}'.format(half_of_diskfree()))
+
     os.remove('{}/.ssh/authorized_keys'.format(homedir))
     os.remove('/var/lib/scylla-housekeeping/housekeeping.uuid')
 


### PR DESCRIPTION
Swap creation on scylla-image-setup.service is too much time, it slows down
startup of scylla-server.service on our IaaS image.
To fix the issue, pre-allocate swapfile while building the image.

Use half of diskfree to swap size, since it is maximum size allowed on
scylla_swap_setup and should be enough for any instance types.

Fixes #285

----

Please merge this only after https://github.com/scylladb/scylla/pull/9971 merged.