### PR TITLE
scylla_cloud.py: import missing 'glob' module

### DIFF
--- a/lib/scylla_cloud.py
+++ b/lib/scylla_cloud.py
@@ -24,6 +24,7 @@ import urllib.parse
 import urllib.request
 import psutil
 import socket
+import glob
 from subprocess import run, DEVNULL
 
 # @param headers dict of k:v


### PR DESCRIPTION
This fixes "NameError: name 'glob' is not defined" error.

Fixes #294