### PR TITLE
Move scylla_coredump_setup to image building time

### DIFF
--- a/common/scylla_image_setup
+++ b/common/scylla_image_setup
@@ -8,7 +8,7 @@ import os
 import sys
 import pathlib
 sys.path.append('/opt/scylladb/scripts')
-from scylla_util import is_redhat_variant
+from scylla_util import is_redhat_variant, systemd_unit
 from lib.scylla_cloud import get_cloud_instance, is_gce
 from subprocess import run
 
@@ -29,9 +29,9 @@ if __name__ == '__main__':
                     cloud_instance.io_setup()
             else:
                 cloud_instance.io_setup()
-            run('/opt/scylladb/scripts/scylla_coredump_setup --dump-to-raiddir', shell=True, check=True)
-    else:
-        run('/opt/scylladb/scripts/scylla_coredump_setup', shell=True, check=True)
+            systemd_unit.reload()
+            systemd_unit('var-lib-systemd-coredump.mount').enable()
+            systemd_unit('var-lib-systemd-coredump.mount').start()
     if not os.path.ismount('/var/lib/scylla'):
         print('Failed to initialize RAID volume!')
     pathlib.Path('/etc/scylla/machine_image_configured').touch()

--- a/packer/scylla_install_image
+++ b/packer/scylla_install_image
@@ -161,6 +161,27 @@ if __name__ == '__main__':
 
     run('/opt/scylladb/scripts/scylla_sysconfig_setup --ami --set-clocksource {}'.format(sysconfig_opt))
     run('/opt/scylladb/scripts/scylla_swap_setup --swap-size-bytes {}'.format(half_of_diskfree()))
+    run('/opt/scylladb/scripts/scylla_coredump_setup')
+    dot_mount = '''
+[Unit]
+Description=Save coredump to scylla data directory
+Conflicts=umount.target
+Before=scylla-server.service
+After=local-fs.target
+DefaultDependencies=no
+
+[Mount]
+What=/var/lib/scylla/coredump
+Where=/var/lib/systemd/coredump
+Type=none
+Options=bind
+
+[Install]
+WantedBy=multi-user.target
+'''[1:-1]
+    with open('/etc/systemd/system/var-lib-systemd-coredump.mount', 'w') as f:
+        f.write(dot_mount)
+    os.makedirs('/var/lib/scylla/coredump', exist_ok=True)
 
     os.remove('{}/.ssh/authorized_keys'.format(homedir))
     os.remove('/var/lib/scylla-housekeeping/housekeeping.uuid')


### PR DESCRIPTION
Similar with #285, we can move scylla_coredump_setup to image building time except enabling bind-mount RAID volume to /var/lib/systemd/coredump.

Fixes #299