### PR TITLE
fix(manifest):separate package name from version with `=`

### DIFF
--- a/packer/scylla_install_image
+++ b/packer/scylla_install_image
@@ -269,5 +269,5 @@ if __name__ == '__main__':
                 pkgs.append(d)
         with open('{}/{}-packages-{}-{}.txt'.format(homedir, args.product, args.scylla_version, arch()), 'w') as f:
             for pkg_name in pkgs:
-                pkg_name_version = subprocess.check_output("dpkg-query --showformat='${{Package}}-${{Version}}' --show {}".format(pkg_name), shell=True, encoding='utf-8')
+                pkg_name_version = subprocess.check_output("dpkg-query --showformat='${{Package}}=${{Version}}' --show {}".format(pkg_name), shell=True, encoding='utf-8')
                 f.write('{}\n'.format(pkg_name_version))


### PR DESCRIPTION
Today when we create the manifest we separate the package name and version by `-` , this fail the upgrade process since when we need to  install specific version apt-get expect us to separate package name and version with `=`

Fixing it