### PR TITLE
cloudformation:Add support arm based machines

### DIFF
--- a/aws/cloudformation/scylla.yaml.j2
+++ b/aws/cloudformation/scylla.yaml.j2
@@ -75,6 +75,7 @@ Parameters:
       - 'true'
     Default: 'false'
 
+{% if 'x86_64' in arch %}
   InstanceType:
     Type: String
     Default: i3.large
@@ -94,6 +95,20 @@ Parameters:
       - i3en.12xlarge
       - i3en.24xlarge
       - i3en.metal
+{% elif 'aarch64' in arch %}
+  InstanceType:
+    Type: String
+    Default: im4gn.xlarge
+    AllowedValues:
+      - im4gn.xlarge
+      - im4gn.2xlarge
+      - im4gn.4xlarge
+      - im4gn.8xlarge
+      - im4gn.16xlarge
+      - is4gen.xlarge
+      - is4gen.2xlarge
+      - is4gen.4xlarge
+{% endif %}
     ConstraintDescription: must be a valid EC2 instance type.
 
   AvailabilityZone:


### PR DESCRIPTION
This is a preparation for https://github.com/scylladb/scylla-pkg/issues/2616. In order to support AMI promote for arm based arch, we need to generate the cloudformation yaml file based on the relevant instance types

Adding a condition based on parameter that we will pass during the template generating process
    
Thanks to @benipeled for the providing the quick solution