### PR TITLE
Drop all dependencies to scylla_util library

### DIFF
--- a/common/scylla_ec2_check
+++ b/common/scylla_ec2_check
@@ -19,9 +19,7 @@ import os
 import sys
 import re
 import argparse
-sys.path.append('/opt/scylladb/scripts')
-from scylla_util import is_valid_nic, colorprint
-from lib.scylla_cloud import is_ec2, aws_instance
+from lib.scylla_cloud import is_ec2, aws_instance, colorprint
 from subprocess import run
 
 if __name__ == '__main__':
@@ -32,7 +30,7 @@ if __name__ == '__main__':
                         help='specify NIC')
     args = parser.parse_args()
 
-    if not is_valid_nic(args.nic):
+    if not os.path.exists(f'/sys/class/net/{args.nic}'):
         print('NIC {} doesn\'t exist.'.format(args.nic))
         sys.exit(1)
 

--- a/common/scylla_image_setup
+++ b/common/scylla_image_setup
@@ -17,14 +17,13 @@
 import os
 import sys
 import pathlib
-sys.path.append('/opt/scylladb/scripts')
-from scylla_util import is_redhat_variant
+import distro
 from lib.scylla_cloud import get_cloud_instance, is_gce
 from subprocess import run
 
 if __name__ == '__main__':
     # On Ubuntu, we configure CPU scaling while AMI building time
-    if is_redhat_variant():
+    if distro.id() == 'centos':
         run('/opt/scylladb/scripts/scylla_cpuscaling_setup', shell=True, check=True)
     cloud_instance = get_cloud_instance()
     run('/opt/scylladb/scylla-machine-image/scylla_configure.py', shell=True, check=True)

--- a/common/scylla_login
+++ b/common/scylla_login
@@ -17,9 +17,7 @@
 
 import os
 import sys
-sys.path.append('/opt/scylladb/scripts')
-from scylla_util import colorprint, systemd_unit
-from lib.scylla_cloud import get_cloud_instance
+from lib.scylla_cloud import get_cloud_instance, colorprint
 from subprocess import run
 
 MSG_HEADER = '''
@@ -129,8 +127,7 @@ if __name__ == '__main__':
     else:
         skip_scylla_server = False
         if not os.path.exists('/etc/scylla/machine_image_configured'):
-            setup = systemd_unit('scylla-image-setup.service')
-            res = setup.is_active()
+            res = run('systemctl is-active scylla-image-setup.service', shell=True, check=True, capture_output=True, encoding='utf-8').stdout.strip()
             if res == 'activating':
                 colorprint(MSG_SETUP_ACTIVATING)
                 skip_scylla_server = True
@@ -138,8 +135,7 @@ if __name__ == '__main__':
                 colorprint(MSG_SETUP_FAILED)
                 skip_scylla_server = True
         if not skip_scylla_server:
-            server = systemd_unit('scylla-server.service')
-            res = server.is_active()
+            res = run('systemctl is-active scylla-server.service', shell=True, check=True, capture_output=True, encoding='utf-8').stdout.strip()
             if res == 'activating':
                 colorprint(MSG_SCYLLA_ACTIVATING)
             elif res == 'failed':

--- a/lib/scylla_cloud.py
+++ b/lib/scylla_cloud.py
@@ -795,3 +795,12 @@ def get_cloud_instance():
         return azure_instance()
     else:
         raise Exception("Unknown cloud provider! Only AWS/GCP/Azure supported.")
+
+
+CONCOLORS = {'green': '\033[1;32m', 'red': '\033[1;31m', 'nocolor': '\033[0m'}
+
+
+def colorprint(msg, **kwargs):
+    fmt = dict(CONCOLORS)
+    fmt.update(kwargs)
+    print(msg.format(**fmt))


### PR DESCRIPTION
We recently moved all cloud related code from scylla repository to
scylla-machine-image, to remove cross-dependencies between two repositories.
However, we still have cross-dependencies problem because moved code
uses scylla_util library which is on scylla repository.
This is still not easy to maintain, and also difficult to implement
testcase because the code won't work without scylla repository.

To resolve this, drop all dependencies to scylla_util library.