### PR TITLE
aws: install aws-cfn-bootstrap on AMI building time

### DIFF
--- a/aws/ami/files/scylla_install_ami
+++ b/aws/ami/files/scylla_install_ami
@@ -37,6 +37,11 @@ def run(cmd, shell=False):
         cmd = shlex.split(cmd)
     return subprocess.check_call(cmd, shell=shell, env=my_env)
 
+def out(cmd, shell=False):
+    if not shell:
+        cmd = shlex.split(cmd)
+    return subprocess.check_output(cmd, shell=shell, env=my_env).decode('utf-8')
+
 def get_kver(pattern):
     for k in glob.glob(pattern):
         return re.sub(r'^/boot/vmlinuz-(.+)$', r'\1', k)
@@ -104,6 +109,27 @@ if __name__ == '__main__':
         os.remove('/etc/apt/sources.list.d/scylla_install.list')
         if args.repo_for_update:
             run('curl -L -o /etc/apt/sources.list.d/scylla.list {REPO_FOR_UPDATE}'.format(REPO_FOR_UPDATE=args.repo_for_update))
+
+    # use easy_install instead of pip, because easy_install requires
+    # fewer dependencies, no need to install gcc, it makes our AMI smaller.
+    if distro == 'centos':
+        run('yum install -y epel-release')
+        run('yum install -y pystache python-daemon python-setuptools')
+        # Default install prefix on CentOS7 is /usr not /usr/local, but we need
+        # to align path for executable, so specify script-dir to /usr/local/bin
+        run('python -m easy_install --script-dir /usr/local/bin https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz')
+        pyver = ''
+    else:
+        # XXX: we want install dependencies from distro repo, but
+        # python-daemon-2.2 on Ubuntu 20.04 is too new for aws-cfn-bootstrap,
+        # so install python-daemon-2.1 from pypi
+        run('apt-get install -y python3-pystache python3-lockfile python3-setuptools')
+        run('python3 -m easy_install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz')
+        pyver = '3'
+    cfnpath = out('python{} -c "import cfnbootstrap as _; print(_.__path__[0])"'.format(pyver))
+    initpath = os.path.abspath('{}/../init/{}/cfn-hup'.format(cfnpath, 'redhat' if distro == 'centos' else 'ubuntu'))
+    shutil.copyfile(initpath, '/etc/init.d/cfn-hup')
+    os.chmod('/etc/init.d/cfn-hup', 0o755)
 
     run('systemctl daemon-reload')
     run('systemctl enable scylla-image-setup.service')

--- a/aws/cloudformation/scylla.yaml
+++ b/aws/cloudformation/scylla.yaml
@@ -159,11 +159,7 @@ Resources:
                 - ''
                 - - !Sub |
                     #!/bin/bash -ex
-
-                    sudo yum -y install epel-release
-                    sudo yum -y install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.amzn1.noarch.rpm
-                    ln -s /usr/local/lib/python2.7/site-packages/cfnbootstrap /usr/lib/python2.7/site-packages/cfnbootstrap
-                    /opt/aws/bin/cfn-signal --exit-code 0 --resource Node0 --region ${AWS::Region} --stack ${AWS::StackName}
+                    /usr/local/bin/cfn-signal --exit-code 0 --resource Node0 --region ${AWS::Region} --stack ${AWS::StackName}
             - '"}'
       NetworkInterfaces:
         - NetworkInterfaceId: !Ref Node0ETH0
@@ -233,11 +229,7 @@ Resources:
                 - ''
                 - - !Sub |
                     #!/bin/bash -ex
-
-                    sudo yum -y install epel-release
-                    sudo yum -y install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.amzn1.noarch.rpm
-                    ln -s /usr/local/lib/python2.7/site-packages/cfnbootstrap /usr/lib/python2.7/site-packages/cfnbootstrap
-                    /opt/aws/bin/cfn-signal --exit-code 0 --resource Node1 --region ${AWS::Region} --stack ${AWS::StackName}
+                    /usr/local/bin/cfn-signal --exit-code 0 --resource Node1 --region ${AWS::Region} --stack ${AWS::StackName}
             - '"}'
       NetworkInterfaces:
         - NetworkInterfaceId: !Ref Node1ETH0
@@ -307,11 +299,7 @@ Resources:
                 - ''
                 - - !Sub |
                     #!/bin/bash -ex
-
-                    sudo yum -y install epel-release
-                    sudo yum -y install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.amzn1.noarch.rpm
-                    ln -s /usr/local/lib/python2.7/site-packages/cfnbootstrap /usr/lib/python2.7/site-packages/cfnbootstrap
-                    /opt/aws/bin/cfn-signal --exit-code 0 --resource Node2 --region ${AWS::Region} --stack ${AWS::StackName}
+                    /usr/local/bin/cfn-signal --exit-code 0 --resource Node2 --region ${AWS::Region} --stack ${AWS::StackName}
             - '"}'
       NetworkInterfaces:
         - NetworkInterfaceId: !Ref Node2ETH0
@@ -381,11 +369,7 @@ Resources:
                 - ''
                 - - !Sub |
                     #!/bin/bash -ex
-
-                    sudo yum -y install epel-release
-                    sudo yum -y install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.amzn1.noarch.rpm
-                    ln -s /usr/local/lib/python2.7/site-packages/cfnbootstrap /usr/lib/python2.7/site-packages/cfnbootstrap
-                    /opt/aws/bin/cfn-signal --exit-code 0 --resource Node3 --region ${AWS::Region} --stack ${AWS::StackName}
+                    /usr/local/bin/cfn-signal --exit-code 0 --resource Node3 --region ${AWS::Region} --stack ${AWS::StackName}
             - '"}'
       NetworkInterfaces:
         - NetworkInterfaceId: !Ref Node3ETH0
@@ -455,11 +439,7 @@ Resources:
                 - ''
                 - - !Sub |
                     #!/bin/bash -ex
-
-                    sudo yum -y install epel-release
-                    sudo yum -y install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.amzn1.noarch.rpm
-                    ln -s /usr/local/lib/python2.7/site-packages/cfnbootstrap /usr/lib/python2.7/site-packages/cfnbootstrap
-                    /opt/aws/bin/cfn-signal --exit-code 0 --resource Node4 --region ${AWS::Region} --stack ${AWS::StackName}
+                    /usr/local/bin/cfn-signal --exit-code 0 --resource Node4 --region ${AWS::Region} --stack ${AWS::StackName}
             - '"}'
       NetworkInterfaces:
         - NetworkInterfaceId: !Ref Node4ETH0
@@ -529,11 +509,7 @@ Resources:
                 - ''
                 - - !Sub |
                     #!/bin/bash -ex
-
-                    sudo yum -y install epel-release
-                    sudo yum -y install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.amzn1.noarch.rpm
-                    ln -s /usr/local/lib/python2.7/site-packages/cfnbootstrap /usr/lib/python2.7/site-packages/cfnbootstrap
-                    /opt/aws/bin/cfn-signal --exit-code 0 --resource Node5 --region ${AWS::Region} --stack ${AWS::StackName}
+                    /usr/local/bin/cfn-signal --exit-code 0 --resource Node5 --region ${AWS::Region} --stack ${AWS::StackName}
             - '"}'
       NetworkInterfaces:
         - NetworkInterfaceId: !Ref Node5ETH0
@@ -603,11 +579,7 @@ Resources:
                 - ''
                 - - !Sub |
                     #!/bin/bash -ex
-
-                    sudo yum -y install epel-release
-                    sudo yum -y install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.amzn1.noarch.rpm
-                    ln -s /usr/local/lib/python2.7/site-packages/cfnbootstrap /usr/lib/python2.7/site-packages/cfnbootstrap
-                    /opt/aws/bin/cfn-signal --exit-code 0 --resource Node6 --region ${AWS::Region} --stack ${AWS::StackName}
+                    /usr/local/bin/cfn-signal --exit-code 0 --resource Node6 --region ${AWS::Region} --stack ${AWS::StackName}
             - '"}'
       NetworkInterfaces:
         - NetworkInterfaceId: !Ref Node6ETH0
@@ -677,11 +649,7 @@ Resources:
                 - ''
                 - - !Sub |
                     #!/bin/bash -ex
-
-                    sudo yum -y install epel-release
-                    sudo yum -y install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.amzn1.noarch.rpm
-                    ln -s /usr/local/lib/python2.7/site-packages/cfnbootstrap /usr/lib/python2.7/site-packages/cfnbootstrap
-                    /opt/aws/bin/cfn-signal --exit-code 0 --resource Node7 --region ${AWS::Region} --stack ${AWS::StackName}
+                    /usr/local/bin/cfn-signal --exit-code 0 --resource Node7 --region ${AWS::Region} --stack ${AWS::StackName}
             - '"}'
       NetworkInterfaces:
         - NetworkInterfaceId: !Ref Node7ETH0
@@ -751,11 +719,7 @@ Resources:
                 - ''
                 - - !Sub |
                     #!/bin/bash -ex
-
-                    sudo yum -y install epel-release
-                    sudo yum -y install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.amzn1.noarch.rpm
-                    ln -s /usr/local/lib/python2.7/site-packages/cfnbootstrap /usr/lib/python2.7/site-packages/cfnbootstrap
-                    /opt/aws/bin/cfn-signal --exit-code 0 --resource Node8 --region ${AWS::Region} --stack ${AWS::StackName}
+                    /usr/local/bin/cfn-signal --exit-code 0 --resource Node8 --region ${AWS::Region} --stack ${AWS::StackName}
             - '"}'
       NetworkInterfaces:
         - NetworkInterfaceId: !Ref Node8ETH0
@@ -825,11 +789,7 @@ Resources:
                 - ''
                 - - !Sub |
                     #!/bin/bash -ex
-
-                    sudo yum -y install epel-release
-                    sudo yum -y install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.amzn1.noarch.rpm
-                    ln -s /usr/local/lib/python2.7/site-packages/cfnbootstrap /usr/lib/python2.7/site-packages/cfnbootstrap
-                    /opt/aws/bin/cfn-signal --exit-code 0 --resource Node9 --region ${AWS::Region} --stack ${AWS::StackName}
+                    /usr/local/bin/cfn-signal --exit-code 0 --resource Node9 --region ${AWS::Region} --stack ${AWS::StackName}
             - '"}'
       NetworkInterfaces:
         - NetworkInterfaceId: !Ref Node9ETH0

--- a/aws/cloudformation/scylla.yaml.j2
+++ b/aws/cloudformation/scylla.yaml.j2
@@ -131,11 +131,7 @@ Resources:
                 - ''
                 - - !Sub |
                     #!/bin/bash -ex
-
-                    sudo yum -y install epel-release
-                    sudo yum -y install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.amzn1.noarch.rpm
-                    ln -s /usr/local/lib/python2.7/site-packages/cfnbootstrap /usr/lib/python2.7/site-packages/cfnbootstrap
-                    /opt/aws/bin/cfn-signal --exit-code 0 --resource Node{{ node_index }} --region ${AWS::Region} --stack ${AWS::StackName}
+                    /usr/local/bin/cfn-signal --exit-code 0 --resource Node{{ node_index }} --region ${AWS::Region} --stack ${AWS::StackName}
             - '"}'
 {%- else %}
       UserData: !Base64
@@ -150,12 +146,7 @@ Resources:
                 - ''
                 - - !Sub |
                     #!/bin/bash -ex
-
-                    sudo yum -y install epel-release
-                    sudo yum -y install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.amzn1.noarch.rpm
-                    ln -s /usr/local/lib/python2.7/site-packages/cfnbootstrap /usr/lib/python2.7/site-packages/cfnbootstrap
-
-                    trap '/opt/aws/bin/cfn-signal --exit-code 1 --resource Node{{ node_index }} --region ${AWS::Region} --stack ${AWS::StackName}' ERR
+                    trap '/usr/local/bin/cfn-signal --exit-code 1 --resource Node{{ node_index }} --region ${AWS::Region} --stack ${AWS::StackName}' ERR
 
                     export PUBLIC_IP=${Node2ElasticIP}
                     export PRIVATE_IP=$(curl http://169.254.169.254/latest/meta-data/local-ipv4)


### PR DESCRIPTION
Cherry-pick 1e3827b (move aws-cfn installation to the ami build stage and remove wrong yum lines)

Verified by build ami [0] > create EC2 instance based on the newly ami > check that `cfn-signal` command is available.

[0] https://jenkins.scylladb.com/view/scylla-4.5/job/scylla-4.5/job/releng-testing/job/ami/11/

Closes https://github.com/scylladb/scylla-machine-image/issues/311