### PR TITLE
aws_instance: change get_local_disks()/get_remote_disks() to return list

### DIFF
--- a/lib/scylla_cloud.py
+++ b/lib/scylla_cloud.py
@@ -729,11 +729,11 @@ class aws_instance(cloud_instance):
 
     def get_local_disks(self):
         """Returns all ephemeral disks. Include standard SSDs and NVMe"""
-        return set(self._disks["ephemeral"])
+        return self._disks["ephemeral"]
 
     def get_remote_disks(self):
         """Returns all EBS disks"""
-        return set(self._disks["ebs"])
+        return self._disks["ebs"]
 
     def public_ipv4(self):
         """Returns the public IPv4 address of this instance"""

--- a/tests/test_aws_instance.py
+++ b/tests/test_aws_instance.py
@@ -369,7 +369,7 @@ vpc-ipv6-cidr-blocks
             unittest.mock.patch('lib.scylla_cloud.run', side_effect=mock_multi_run_i3en_2xlarge),\
             unittest.mock.patch('builtins.open', unittest.mock.MagicMock(side_effect=mock_multi_open_i3en_2xlarge)):
             ins = aws_instance()
-            assert ins.get_local_disks() == {'nvme2n1', 'nvme1n1'}
+            assert ins.get_local_disks() == ['nvme2n1', 'nvme1n1']
 
     def test_get_remote_disks_i3en_2xlarge(self):
         self.httpretty_aws_metadata()
@@ -378,7 +378,7 @@ vpc-ipv6-cidr-blocks
             unittest.mock.patch('lib.scylla_cloud.run', side_effect=mock_multi_run_i3en_2xlarge),\
             unittest.mock.patch('builtins.open', unittest.mock.MagicMock(side_effect=mock_multi_open_i3en_2xlarge)):
             ins = aws_instance()
-            assert ins.get_remote_disks() == set()
+            assert ins.get_remote_disks() == []
 
 
     def test_non_root_nvmes_i3en_2xlarge_with_ebs(self):
@@ -426,7 +426,7 @@ vpc-ipv6-cidr-blocks
             unittest.mock.patch('lib.scylla_cloud.run', side_effect=mock_multi_run_i3en_2xlarge),\
             unittest.mock.patch('builtins.open', unittest.mock.MagicMock(side_effect=mock_multi_open_i3en_2xlarge_with_ebs)):
             ins = aws_instance()
-            assert ins.get_local_disks() == {'nvme3n1', 'nvme4n1'}
+            assert ins.get_local_disks() == ['nvme3n1', 'nvme4n1']
 
     def test_get_remote_disks_i3en_2xlarge_with_ebs(self):
         self.httpretty_aws_metadata(with_ebs=True)
@@ -435,7 +435,7 @@ vpc-ipv6-cidr-blocks
             unittest.mock.patch('lib.scylla_cloud.run', side_effect=mock_multi_run_i3en_2xlarge),\
             unittest.mock.patch('builtins.open', unittest.mock.MagicMock(side_effect=mock_multi_open_i3en_2xlarge_with_ebs)):
             ins = aws_instance()
-            assert ins.get_remote_disks() == {'nvme2n1', 'nvme1n1'}
+            assert ins.get_remote_disks() == ['nvme2n1', 'nvme1n1']
 
 
     def test_non_root_nvmes_i3_2xlarge(self):
@@ -510,7 +510,7 @@ vpc-ipv6-cidr-blocks
             unittest.mock.patch('lib.scylla_cloud.run', side_effect=mock_multi_run_i3_2xlarge),\
             unittest.mock.patch('builtins.open', unittest.mock.MagicMock(side_effect=mock_multi_open_i3_2xlarge)):
             ins = aws_instance()
-            assert ins.get_local_disks() == {'nvme0n1', 'nvme1n1'}
+            assert ins.get_local_disks() == ['nvme0n1', 'nvme1n1']
 
     def test_get_remote_disks_i3_2xlarge(self):
         self.httpretty_aws_metadata()
@@ -519,5 +519,5 @@ vpc-ipv6-cidr-blocks
             unittest.mock.patch('lib.scylla_cloud.run', side_effect=mock_multi_run_i3_2xlarge),\
             unittest.mock.patch('builtins.open', unittest.mock.MagicMock(side_effect=mock_multi_open_i3_2xlarge)):
             ins = aws_instance()
-            assert ins.get_remote_disks() == set()
+            assert ins.get_remote_disks() == []
 


### PR DESCRIPTION
aws_instance.get_local_disks() and aws_instance.get_remote_disks()
should return list instead of set, since we do so in gcp_instance and
azure_instance.

Fixes #315