### PR TITLE
scylla_image_setup: fix typo on run()

### DIFF
--- a/common/scylla_image_setup
+++ b/common/scylla_image_setup
@@ -28,8 +28,8 @@ if __name__ == '__main__':
             else:
                 cloud_instance.io_setup()
             run('systemctl daemon-reload', shell=True, check=True)
-            run('systemctl enable var-lib-systemd-coredump.mount' shell=True, check=True)
-            run('systemctl start var-lib-systemd-coredump.mount' shell=True, check=True)
+            run('systemctl enable var-lib-systemd-coredump.mount', shell=True, check=True)
+            run('systemctl start var-lib-systemd-coredump.mount', shell=True, check=True)
     if not os.path.ismount('/var/lib/scylla'):
         print('Failed to initialize RAID volume!')
     pathlib.Path('/etc/scylla/machine_image_configured').touch()


### PR DESCRIPTION
Added missing ",".

Signed-off-by: Takuya ASADA <syuu@scylladb.com>