### PR TITLE
gce:Build image based on Centos-Stream-8 instead of centos8 

### DIFF
--- a/gce/image/scylla_gce.json
+++ b/gce/image/scylla_gce.json
@@ -2,8 +2,8 @@
   "builders": [
     {
       "type": "googlecompute",
-      "source_image_family": "centos-8",
-      "source_image": "centos-8-v20200618",
+      "source_image_family": "centos-stream-8",
+      "source_image": "centos-stream-8-v20220128",
       "ssh_username": "{{user `ssh_username`}}",
       "ssh_timeout": "6m",
       "project_id": "{{user `project_id`}}",


### PR DESCRIPTION
[](https://github.com/yaronkaikov)Since centos8 is EOL, we need to switch to centos-stream-8 to continue
supporting gce images (which are rpm based).