### PR TITLE
ami: Workaround for NIC driver failure on kernel-ml 5.16.x

### DIFF
--- a/aws/ami/files/elrepo-archive.repo
+++ b/aws/ami/files/elrepo-archive.repo
@@ -1,0 +1,5 @@
+[kernel-ml-archive]
+name=kernel-ml-archive
+baseurl=http://linux-mirrors.fnal.gov/linux/elrepo/archive/kernel/el7/x86_64/
+enabled=1
+gpgcheck=0

--- a/aws/ami/files/scylla_install_ami
+++ b/aws/ami/files/scylla_install_ami
@@ -113,9 +113,11 @@ if __name__ == '__main__':
     # So we have to use different kernel here.
     if platform.machine() == 'x86_64':
         run('yum -y install grubby')
-        run('rpm --import https://www.elrepo.org/RPM-GPG-KEY-elrepo.org')
-        run('rpm -Uvh http://www.elrepo.org/elrepo-release-7.0-3.el7.elrepo.noarch.rpm')
-        run('yum -y --enablerepo=elrepo-kernel install kernel-ml')
+        # this is for pinning kernel-ml describes later
+        run('cp elrepo-archive.repo /etc/yum.repos.d/')
+        # kernel-ml 5.16.3 does not able to initialize ENA device correctly,
+        # force installing 5.15.8 this is known to be good
+        run('yum -y install kernel-ml-5.15.8 kernel-ml-devel-5.15.8')
         mlkver = get_kver('/boot/vmlinuz-*el7.elrepo.x86_64')
         run('dracut --add-drivers "xen-blkfront xen-netfront ixgbevf ena nvme" --force /boot/initramfs-{mlkver}.img {mlkver}'.format(mlkver=mlkver))
         run('grubby --grub2 --set-default /boot/vmlinuz-{mlkver}'.format(mlkver=mlkver))


### PR DESCRIPTION
This is fix for branch-4.4

----

On kernel-ml 5.16.x, the kernel fails to initialize ENA driver (NIC),
not able to login to the instance since network is offline.
As workaround fix, pin down kernel version to 5.15.8 until we find root
cause of the problem.

fixes #332