### PR TITLE
scylla_install_image:add ssm-agent installation for arm

### DIFF
--- a/dist/debian/build_deb.sh
+++ b/dist/debian/build_deb.sh
@@ -81,6 +81,7 @@ pkg_install python3
 pkg_install python3-devel
 pkg_install python3-pip
 
+git config --global --add safe.directory "$BUILDDIR"/scylla-machine-image
 echo "Building in $PWD..."
 
 VERSION=$(./SCYLLA-VERSION-GEN)

--- a/packer/scylla_install_image
+++ b/packer/scylla_install_image
@@ -138,7 +138,11 @@ if __name__ == '__main__':
             pyver = '3'
 
             # install .deb version of ssm-agent since we dropped snapd version
-            run('curl -L -o /tmp/amazon-ssm-agent.deb https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/debian_amd64/amazon-ssm-agent.deb')
+            if arch() == 'x86_64':
+                run('curl -L -o /tmp/amazon-ssm-agent.deb https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/debian_amd64/amazon-ssm-agent.deb')
+            if arch() == 'aarch64':
+                run('curl -L -o /tmp/amazon-ssm-agent.deb https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/debian_arm64/amazon-ssm-agent.deb')
+
             run('dpkg -i /tmp/amazon-ssm-agent.deb')
             run('systemctl enable amazon-ssm-agent')
 


### PR DESCRIPTION
In 434795f snap installation was removed and we started to use ssm-agent deb
package. Since we are building AMI based on ARM as well. we need to
support both arch