### PR TITLE
build.yml: workaround git permission bug for checkout dir

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Unittest and Build RPMs
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup python
         uses: actions/setup-python@v2
         with:


### PR DESCRIPTION
It seems that a new permission bug was intreduced from git version 2.35.1
Until we have a proper fix, adding this workaround (Ref: https://github.com/actions/checkout/issues/760)