### PR TITLE
ubuntu: drop more unneeded packages 

### DIFF
--- a/packer/scylla_install_image
+++ b/packer/scylla_install_image
@@ -90,6 +90,7 @@ if __name__ == '__main__':
     run('apt-get purge -y snapd', shell=True, check=True)
     run('apt-get purge -y modemmanager', shell=True, check=True)
     run('apt-get purge -y accountsservice', shell=True, check=True)
+    run('apt-get purge -y udisks2', shell=True, check=True)
     # drop packages does not needed anymore
     run('apt-get autoremove --purge -y', shell=True, check=True)
 

--- a/packer/scylla_install_image
+++ b/packer/scylla_install_image
@@ -89,6 +89,7 @@ if __name__ == '__main__':
     # remove snapd
     run('apt-get purge -y snapd', shell=True, check=True)
     run('apt-get purge -y modemmanager', shell=True, check=True)
+    run('apt-get purge -y accountsservice', shell=True, check=True)
     # drop packages does not needed anymore
     run('apt-get autoremove --purge -y', shell=True, check=True)
 

--- a/packer/scylla_install_image
+++ b/packer/scylla_install_image
@@ -76,7 +76,7 @@ if __name__ == '__main__':
 
     run('apt-get update --allow-insecure-repositories -y', shell=True, check=True)
     run('apt-get full-upgrade -y', shell=True, check=True)
-    run('apt-get purge -y apport fuse', shell=True, check=True)
+    run('apt-get purge -y apport python3-apport fuse', shell=True, check=True)
     run('apt-get install -y systemd-coredump', shell=True, check=True)
     run(f'apt-get install -y --auto-remove --allow-unauthenticated {args.product}-machine-image {args.product}-server-dbg', shell=True, check=True)
 

--- a/packer/scylla_install_image
+++ b/packer/scylla_install_image
@@ -91,6 +91,10 @@ if __name__ == '__main__':
     run('apt-get purge -y modemmanager', shell=True, check=True)
     run('apt-get purge -y accountsservice', shell=True, check=True)
     run('apt-get purge -y udisks2', shell=True, check=True)
+    # cannot remove policykit since add-apt-repository depends on that,
+    # so just disable the service
+    run('systemctl disable polkit.service', shell=True, check=True)
+
     # drop packages does not needed anymore
     run('apt-get autoremove --purge -y', shell=True, check=True)
 


### PR DESCRIPTION
This remove more unneeded packages on Ubuntu image, includes:
- accountsservice
- udisks2
And also disable polkit.service by default since it almost unneeded but some CLI commands requires that, so let D-Bus to autostart the service when the API invoked.