### PR TITLE
XFS online discard: Disable fstrim.timer if active

### DIFF
--- a/common/scylla_image_setup
+++ b/common/scylla_image_setup
@@ -30,6 +30,9 @@ if __name__ == '__main__':
             run('systemctl daemon-reload', shell=True, check=True)
             run('systemctl enable var-lib-systemd-coredump.mount', shell=True, check=True)
             run('systemctl start var-lib-systemd-coredump.mount', shell=True, check=True)
+            # some distro has fstrim enabled by default, since we are using XFS with online discard, we don't need fstrim
+            run('systemctl is-active -q fstrim.timer && systemctl disable fstrim.timer', shell=True, check=True)
+
     if not os.path.ismount('/var/lib/scylla'):
         print('Failed to initialize RAID volume!')
     pathlib.Path('/etc/scylla/machine_image_configured').touch()


### PR DESCRIPTION
Some distro has fstrim enabled by default, since we
are using XFS with online discard, we don't need fstrim
running

Fixes: #341