### PR TITLE
Fix build errors when newer git it used (fatal: unsafe repository)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,4 +40,4 @@ jobs:
         run: docker run -v `pwd`:/scylla-machine-image -w /scylla-machine-image  --rm rockylinux bash -c './dist/redhat/build_rpm.sh -t centos8'
 
       - name: Build Ubuntu DEB
-        run: docker run -v `pwd`:/scylla-machine-image -w /scylla-machine-image  --rm ubuntu:20.04 bash -c './dist/debian/build_deb.sh'
+        run: docker run -v `pwd`:/scylla-machine-image -w /scylla-machine-image  --rm ubuntu:20.04 bash -c 'apt update -y; apt install -y git ; git config --global --add safe.directory "*"; ./dist/debian/build_deb.sh'


### PR DESCRIPTION
on newer git version we are getting the following error when
running a test under docker:
```
fatal: unsafe repository (REPO is owned by someone else)
```

https://github.com/actions/checkout/issues/760