### PR TITLE
build_deb_image.sh:remove default tag for branch name

### DIFF
--- a/packer/build_deb_image.sh
+++ b/packer/build_deb_image.sh
@@ -8,7 +8,6 @@ REALDIR=$(dirname $(readlink -f "$0"))
 source "$REALDIR"/../SCYLLA-VERSION-GEN
 
 BUILD_ID=$(date -u '+%FT%H-%M-%S')
-BRANCH="master"
 OPERATING_SYSTEM="ubuntu20.04"
 DIR=$(dirname $(realpath -se $0))
 PDIRNAME=$(basename $(realpath -se $DIR/..))


### PR DESCRIPTION
When QA running jobs which are relaying on recent AMI, the first run `hydra list-ami-branch -r eu-west-1 master:all`

The query looks for AMI with tag name `BRANCH=master`. when building local AMI for debug if no `--branch <name>` is provided we have a default of `master` , removing the default so QA will get the only relevant images

Closes: https://github.com/scylladb/scylla-pkg/issues/2856