### PR TITLE
revert converting scylla_cloud_io_setup to python library

### DIFF
--- a/common/scylla_cloud_io_setup
+++ b/common/scylla_cloud_io_setup
@@ -10,6 +10,7 @@ import yaml
 import logging
 import sys
 from abc import ABCMeta, abstractmethod
+from lib.scylla_cloud import cloud_instance, is_ec2, is_gce, is_azure
 
 def UnsupportedInstanceClassError(Exception):
     pass
@@ -39,6 +40,7 @@ class aws_io_setup(cloud_io_setup):
 
     def generate(self):
         if not self.idata.is_supported_instance_class():
+            logging.error('This is not a recommended EC2 instance setup for auto local disk tuning.')
             raise UnsupportedInstanceClassError()
         self.disk_properties["mountpoint"] = '/var/lib/scylla'
         nr_disks = len(self.idata.get_local_disks())
@@ -186,6 +188,7 @@ class aws_io_setup(cloud_io_setup):
             self.disk_properties["write_iops"] = 92233 * nr_disks
             self.disk_properties["write_bandwidth"] = 1028010325 * nr_disks
         if not "read_iops" in self.disk_properties:
+            logging.error('This is a supported AWS instance type but there are no preconfigured IO scheduler parameters for it.')
             raise PresetNotFoundError()
 
 
@@ -196,6 +199,7 @@ class gcp_io_setup(cloud_io_setup):
 
     def generate(self):
         if not self.idata.is_supported_instance_class():
+            logging.error('This is not a recommended Google Cloud instance setup for auto local disk tuning.')
             raise UnsupportedInstanceClassError()
         self.disk_properties = {}
         self.disk_properties["mountpoint"] = '/var/lib/scylla'
@@ -234,6 +238,7 @@ class gcp_io_setup(cloud_io_setup):
             #self.disk_properties["write_bandwidth"] = 4680 * mbs
 
         if not "read_iops" in self.disk_properties:
+            logging.error('Did not detect number of disks in Google Cloud instance setup for auto local disk tuning.')
             raise PresetNotFoundError()
 
 
@@ -244,6 +249,7 @@ class azure_io_setup(cloud_io_setup):
 
     def generate(self):
         if not self.idata.is_supported_instance_class():
+            logging.error('This is not a recommended Azure Cloud instance setup for auto local disk tuning.')
             raise UnsupportedInstanceClassError()
 
         self.disk_properties = {}
@@ -284,4 +290,22 @@ class azure_io_setup(cloud_io_setup):
             self.disk_properties["write_iops"] = 2546511
             self.disk_properties["write_bandwidth"] = 11998 * mbs
         if not "read_iops" in self.disk_properties:
+            logging.error('Did not detect number of disks in Azure Cloud instance setup for auto local disk tuning.')
             raise PresetNotFoundError()
+
+if __name__ == '__main__':
+    if not os.path.ismount('/var/lib/scylla'):
+       logging.error('RAID volume not mounted')
+       sys.exit(1)
+    cloud_instance = get_cloud_instance()
+    if is_ec2():
+        io = aws_io_setup(cloud_instance)
+    elif is_gce():
+        io = gcp_io_setup(cloud_instance)
+    elif is_azure():
+        io = azure_io_setup(cloud_instance)
+    try:
+        io.generate()
+        io.save()
+    except (UnsupportedInstanceClassError, PresetNotFoundError) as e:
+        sys.exit(1)

--- a/dist/debian/debian/rules
+++ b/dist/debian/debian/rules
@@ -8,14 +8,14 @@ override_dh_auto_clean:
 
 override_dh_auto_install:
 	install -d -m755 $(CURDIR)/debian/tmp/opt/scylladb/scylla-machine-image/lib
-	install -m644 lib/log.py lib/scylla_cloud.py lib/scylla_cloud_io_setup.py $(CURDIR)/debian/tmp/opt/scylladb/scylla-machine-image/lib
+	install -m644 lib/log.py lib/scylla_cloud.py $(CURDIR)/debian/tmp/opt/scylladb/scylla-machine-image/lib
 	install -m755 common/scylla_configure.py common/scylla_post_start.py common/scylla_create_devices $(CURDIR)/debian/tmp/opt/scylladb/scylla-machine-image
 	./tools/relocate_python_scripts.py \
 		--installroot $(CURDIR)/debian/tmp/opt/scylladb/scylla-machine-image/ \
 		--with-python3 $(CURDIR)/debian/tmp/opt/scylladb/python3/bin/python3 \
 	common/scylla_image_setup common/scylla_login common/scylla_configure.py \
 	common/scylla_create_devices common/scylla_post_start.py \
-	common/scylla_ec2_check
+	common/scylla_cloud_io_setup common/scylla_ec2_check
 
 override_dh_installinit:
 	dh_installinit --no-start --name scylla-image-setup

--- a/dist/redhat/scylla-machine-image.spec
+++ b/dist/redhat/scylla-machine-image.spec
@@ -33,7 +33,7 @@ install -m644 common/scylla-image-setup.service common/scylla-image-post-start.s
 install -d -m755 $RPM_BUILD_ROOT/opt/scylladb
 install -d -m755 $RPM_BUILD_ROOT/opt/scylladb/scylla-machine-image
 install -d -m755 $RPM_BUILD_ROOT/opt/scylladb/scylla-machine-image/lib
-install -m644 lib/log.py lib/scylla_cloud.py lib/scylla_cloud_io_setup.py $RPM_BUILD_ROOT/opt/scylladb/scylla-machine-image/lib
+install -m644 lib/log.py lib/scylla_cloud.py $RPM_BUILD_ROOT/opt/scylladb/scylla-machine-image/lib
 install -m755 common/scylla_configure.py common/scylla_post_start.py common/scylla_create_devices \
         $RPM_BUILD_ROOT/opt/scylladb/scylla-machine-image/
 ./tools/relocate_python_scripts.py \
@@ -41,7 +41,7 @@ install -m755 common/scylla_configure.py common/scylla_post_start.py common/scyl
     --with-python3 ${RPM_BUILD_ROOT}/opt/scylladb/python3/bin/python3 \
     common/scylla_image_setup common/scylla_login common/scylla_configure.py \
     common/scylla_create_devices common/scylla_post_start.py \
-    common/scylla_ec2_check
+    common/scylla_cloud_io_setup common/scylla_ec2_check
 
 %pre
 /usr/sbin/groupadd scylla 2> /dev/null || :

--- a/lib/scylla_cloud.py
+++ b/lib/scylla_cloud.py
@@ -19,7 +19,6 @@ import distro
 import base64
 from subprocess import run, DEVNULL
 from abc import ABCMeta, abstractmethod
-from lib.scylla_cloud_io_setup import aws_io_setup, gcp_io_setup, azure_io_setup
 
 # @param headers dict of k:v
 def curl(url, headers=None, byte=False, timeout=3, max_retries=5, retry_interval=5):
@@ -351,14 +350,7 @@ class gcp_instance(cloud_instance):
         pass
 
     def io_setup(self):
-        io = gcp_io_setup(self)
-        try:
-            io.generate()
-        except UnsupportedInstanceClassError:
-            logging.error('This is not a recommended Google Cloud instance setup for auto local disk tuning.')
-        except PresetNotFoundError:
-            logging.error('Did not detect number of disks in Google Cloud instance setup for auto local disk tuning.')
-        io.save()
+        run('/opt/scylladb/scylla-machine-image/scylla_cloud_io_setup', check=True, shell=True)
 
     @property
     def user_data(self):
@@ -575,14 +567,7 @@ class azure_instance(cloud_instance):
         pass
 
     def io_setup(self):
-        io = azure_io_setup(self)
-        try:
-            io.generate()
-        except UnsupportedInstanceClassError:
-            logging.error('This is not a recommended Azure Cloud instance setup for auto local disk tuning.')
-        except PresetNotFoundError:
-            logging.error('Did not detect number of disks in Azure Cloud instance setup for auto local disk tuning.')
-        io.save()
+        run('/opt/scylladb/scylla-machine-image/scylla_cloud_io_setup', check=True, shell=True)
 
     @property
     def user_data(self):
@@ -770,14 +755,8 @@ class aws_instance(cloud_instance):
         return run('/opt/scylladb/scylla-machine-image/scylla_ec2_check --nic eth0', shell=True)
 
     def io_setup(self):
-        io = aws_io_setup(self)
-        try:
-            io.generate()
-        except UnsupportedInstanceClassError:
-            logging.error('This is not a recommended EC2 instance setup for auto local disk tuning.')
-        except PresetNotFoundError:
-            logging.error('This is a supported AWS instance type but there are no preconfigured IO scheduler parameters for it.')
-        io.save()
+        run('/opt/scylladb/scylla-machine-image/scylla_cloud_io_setup', check=True, shell=True)
+
 
     @property
     def user_data(self):


### PR DESCRIPTION
The decision converting scylla_cloud_io_setup to python library was mistake,
since there are some users who wants to construct IaaS image by themselves,
not using our official image.
They will need to invoke scylla_cloud_io_setup from shell, not python.