### PR TITLE
print subprocess error message when capture_output=True

### DIFF
--- a/common/scylla_create_devices
+++ b/common/scylla_create_devices
@@ -8,7 +8,7 @@ import argparse
 import sys
 from pathlib import Path
 from subprocess import run
-from lib.scylla_cloud import is_ec2, is_gce, is_azure, get_cloud_instance
+from lib.scylla_cloud import is_ec2, is_gce, is_azure, get_cloud_instance, out
 
 class DiskIsNotEmptyError(Exception):
     def __init__(self, disk):
@@ -39,8 +39,8 @@ def create_raid(devices, raid_level=0):
 
 def check_persistent_disks_are_empty(disks):
     for disk in disks:
-        part = run(f'lsblk -dpnr -o PTTYPE /dev/{disk}', shell=True, check=True, capture_output=True, encoding='utf-8').stdout.strip()
-        fs = run(f'lsblk -dpnr -o FSTYPE /dev/{disk}', shell=True, check=True, capture_output=True, encoding='utf-8').stdout.strip()
+        part = out(f'lsblk -dpnr -o PTTYPE /dev/{disk}')
+        fs = out(f'lsblk -dpnr -o FSTYPE /dev/{disk}')
         if part != '' or fs != '':
             raise DiskIsNotEmptyError(f'/dev/{disk}')
 

--- a/common/scylla_ec2_check
+++ b/common/scylla_ec2_check
@@ -9,7 +9,7 @@ import os
 import sys
 import re
 import argparse
-from lib.scylla_cloud import is_ec2, aws_instance, colorprint
+from lib.scylla_cloud import is_ec2, aws_instance, colorprint, out
 from subprocess import run
 
 if __name__ == '__main__':
@@ -27,7 +27,7 @@ if __name__ == '__main__':
     aws = aws_instance()
     instance_class = aws.instance_class()
     en = aws.get_en_interface_type()
-    match = re.search(r'^driver: (\S+)$', run('ethtool -i {}'.format(args.nic), shell=True, check=True, capture_output=True, encoding='utf-8').stdout.strip(), flags=re.MULTILINE)
+    match = re.search(r'^driver: (\S+)$', out(f'ethtool -i {args.nic}'), flags=re.MULTILINE)
     driver = match.group(1)
 
     if not en:

--- a/common/scylla_login
+++ b/common/scylla_login
@@ -7,7 +7,7 @@
 
 import os
 import sys
-from lib.scylla_cloud import get_cloud_instance, colorprint
+from lib.scylla_cloud import get_cloud_instance, colorprint, out
 from subprocess import run
 
 MSG_HEADER = '''
@@ -103,7 +103,7 @@ $ nodetool status
 '''[1:-1]
 
 if __name__ == '__main__':
-    colorprint(MSG_HEADER.format(scylla_version=run("scylla --version", shell=True, check=True, capture_output=True, encoding='utf-8').stdout.strip()))
+    colorprint(MSG_HEADER.format(scylla_version=out("scylla --version")))
     cloud_instance = get_cloud_instance()
     if not cloud_instance.is_supported_instance_class():
         non_root_disks = cloud_instance.get_local_disks() + cloud_instance.get_remote_disks()
@@ -117,7 +117,7 @@ if __name__ == '__main__':
     else:
         skip_scylla_server = False
         if not os.path.exists('/etc/scylla/machine_image_configured'):
-            res = run('systemctl is-active scylla-image-setup.service', shell=True, capture_output=True, encoding='utf-8').stdout.strip()
+            res = out('systemctl is-active scylla-image-setup.service', ignore_error=True)
             if res == 'activating':
                 colorprint(MSG_SETUP_ACTIVATING)
                 skip_scylla_server = True
@@ -125,7 +125,7 @@ if __name__ == '__main__':
                 colorprint(MSG_SETUP_FAILED)
                 skip_scylla_server = True
         if not skip_scylla_server:
-            res = run('systemctl is-active scylla-server.service', shell=True, capture_output=True, encoding='utf-8').stdout.strip()
+            res = out('systemctl is-active scylla-server.service', ignore_error=True)
             if res == 'activating':
                 colorprint(MSG_SCYLLA_ACTIVATING)
             elif res == 'failed':


### PR DESCRIPTION
We currently does not able to get any error message from subprocess when we specified capture_output=True on subprocess.run().
This is because CalledProcessError does not print stdout/stderr when it raised, and we don't catch the exception, we just let python to cause Traceback.
Result of that, we only able to know exit status and failed command but
not able to get stdout/stderr.

To resolve this, add wrapper function "out()" for capture output, and
print stdout/stderr with error message inside the function.

This is scylla-machine-image version of https://github.com/scylladb/scylla/pull/10391