### PR TITLE
scylla_cloud.py:Add support for i4i instance type

### DIFF
--- a/lib/scylla_cloud.py
+++ b/lib/scylla_cloud.py
@@ -700,7 +700,7 @@ class aws_instance(cloud_instance):
         return self._type.split(".")[0]
 
     def is_supported_instance_class(self):
-        if self.instance_class() in ['i2', 'i3', 'i3en', 'c5d', 'm5d', 'm5ad', 'r5d', 'z1d', 'c6gd', 'm6gd', 'r6gd', 'x2gd', 'im4gn', 'is4gen']:
+        if self.instance_class() in ['i2', 'i3', 'i3en', 'c5d', 'm5d', 'm5ad', 'r5d', 'z1d', 'c6gd', 'm6gd', 'r6gd', 'x2gd', 'im4gn', 'is4gen', 'i4i']:
             return True
         return False
 
@@ -709,7 +709,7 @@ class aws_instance(cloud_instance):
         instance_size = self.instance_size()
         if instance_class in ['c3', 'c4', 'd2', 'i2', 'r3']:
             return 'ixgbevf'
-        if instance_class in ['a1', 'c5', 'c5a', 'c5d', 'c5n', 'c6g', 'c6gd', 'f1', 'g3', 'g4', 'h1', 'i3', 'i3en', 'inf1', 'm5', 'm5a', 'm5ad', 'm5d', 'm5dn', 'm5n', 'm6g', 'm6gd', 'p2', 'p3', 'r4', 'r5', 'r5a', 'r5ad', 'r5b', 'r5d', 'r5dn', 'r5n', 't3', 't3a', 'u-6tb1', 'u-9tb1', 'u-12tb1', 'u-18tn1', 'u-24tb1', 'x1', 'x1e', 'z1d', 'c6g', 'c6gd', 'm6g', 'm6gd', 't4g', 'r6g', 'r6gd', 'x2gd', 'im4gn', 'is4gen']:
+        if instance_class in ['a1', 'c5', 'c5a', 'c5d', 'c5n', 'c6g', 'c6gd', 'f1', 'g3', 'g4', 'h1', 'i3', 'i3en', 'inf1', 'm5', 'm5a', 'm5ad', 'm5d', 'm5dn', 'm5n', 'm6g', 'm6gd', 'p2', 'p3', 'r4', 'r5', 'r5a', 'r5ad', 'r5b', 'r5d', 'r5dn', 'r5n', 't3', 't3a', 'u-6tb1', 'u-9tb1', 'u-12tb1', 'u-18tn1', 'u-24tb1', 'x1', 'x1e', 'z1d', 'c6g', 'c6gd', 'm6g', 'm6gd', 't4g', 'r6g', 'r6gd', 'x2gd', 'im4gn', 'is4gen', 'i4i']:
             return 'ena'
         if instance_class == 'm4':
             if instance_size == '16xlarge':

--- a/lib/scylla_cloud_io_setup.py
+++ b/lib/scylla_cloud_io_setup.py
@@ -185,6 +185,47 @@ class aws_io_setup(cloud_io_setup):
             self.disk_properties["read_bandwidth"] = 1656354602 * nr_disks
             self.disk_properties["write_iops"] = 92233 * nr_disks
             self.disk_properties["write_bandwidth"] = 1028010325 * nr_disks
+        elif self.idata.instancetype == "i4i.large":
+            self.disk_properties["read_iops"] = 54987 * nr_disks
+            self.disk_properties["read_bandwidth"] = 378494048 * nr_disks
+            self.disk_properties["write_iops"] = 30459 * nr_disks
+            self.disk_properties["write_bandwidth"] = 279713216 * nr_disks
+        elif self.idata.instancetype == "i4i.xlarge":
+            self.disk_properties["read_iops"] = 109954 * nr_disks
+            self.disk_properties["read_bandwidth"] = 763580096 * nr_disks
+            self.disk_properties["write_iops"] = 61008 * nr_disks
+            self.disk_properties["write_bandwidth"] = 561926784 * nr_disks
+        elif self.idata.instancetype == "i4i.2xlarge":
+            self.disk_properties["read_iops"] = 218786 * nr_disks
+            self.disk_properties["read_bandwidth"] = 1542559872 * nr_disks
+            self.disk_properties["write_iops"] = 121499 * nr_disks
+            self.disk_properties["write_bandwidth"] = 1130867072 * nr_disks
+        elif self.idata.instancetype == "i4i.4xlarge":
+            self.disk_properties["read_iops"] = 385400 * nr_disks
+            self.disk_properties["read_bandwidth"] = 3087631104 * nr_disks
+            self.disk_properties["write_iops"] = 240628 * nr_disks
+            self.disk_properties["write_bandwidth"] = 2289281280 * nr_disks
+        elif self.idata.instancetype == "i4i.8xlarge":
+            self.disk_properties["read_iops"] = 384561 * nr_disks
+            self.disk_properties["read_bandwidth"] = 3115819008 * nr_disks
+            self.disk_properties["write_iops"] = 239980 * nr_disks
+            self.disk_properties["write_bandwidth"] = 2289285120 * nr_disks
+        elif self.idata.instancetype == "i4i.16xlarge":
+            self.disk_properties["read_iops"] = 374273 * nr_disks
+            self.disk_properties["read_bandwidth"] = 3088962816 * nr_disks
+            self.disk_properties["write_iops"] = 240185 * nr_disks
+            self.disk_properties["write_bandwidth"] = 2292813568 * nr_disks
+        elif self.idata.instancetype == "i4i.32xlarge":
+            self.disk_properties["read_iops"] = 374273 * nr_disks
+            self.disk_properties["read_bandwidth"] = 3095612416 * nr_disks
+            self.disk_properties["write_iops"] = 239413 * nr_disks
+            self.disk_properties["write_bandwidth"] = 2296702976 * nr_disks
+        elif self.idata.instancetype == "i4i.metal":
+            self.disk_properties["read_iops"] = 379565 * nr_disks
+            self.disk_properties["read_bandwidth"] = 3088599296 * nr_disks
+            self.disk_properties["write_iops"] = 239549 * nr_disks
+            self.disk_properties["write_bandwidth"] = 2302438912 * nr_disks
+
         if not "read_iops" in self.disk_properties:
             raise PresetNotFoundError()
 


### PR DESCRIPTION
Now that new `i4i` instance types are available, let's add them to our
supported instance types