### PR TITLE
generate debug log when exception occurred

### DIFF
--- a/common/scylla_configure.py
+++ b/common/scylla_configure.py
@@ -9,8 +9,10 @@ import subprocess
 import yaml
 import time
 import logging
+import sys
 from textwrap import dedent
 from datetime import datetime
+from lib.scylla_cloud import scylla_excepthook
 from lib.log import setup_logging
 from lib.user_data import UserData
 from pathlib import Path
@@ -118,6 +120,7 @@ class ScyllaMachineImageConfigurator(UserData):
                 LOGGER.info("Running post configuration script:\n%s", decoded_script)
                 subprocess.run(decoded_script, check=True, shell=True, timeout=int(script_timeout))
             except Exception as e:
+                scylla_excepthook(*sys.exc_info())
                 LOGGER.error("Post configuration script failed: %s", e)
 
     def start_scylla_on_first_boot(self):
@@ -134,6 +137,7 @@ class ScyllaMachineImageConfigurator(UserData):
             LOGGER.info(f"Create scylla data devices as {device_type}")
             subprocess.run(cmd_create_devices, shell=True, check=True)
         except Exception as e:
+            scylla_excepthook(*sys.exc_info())
             LOGGER.error("Failed to create devices: %s", e)
 
     def configure(self):

--- a/common/scylla_post_start.py
+++ b/common/scylla_post_start.py
@@ -8,9 +8,11 @@ import base64
 import logging
 import pathlib
 import subprocess
+import sys
 
 from lib.log import setup_logging
 from lib.user_data import UserData
+from lib.scylla_cloud import scylla_excepthook
 
 LOGGER = logging.getLogger(__name__)
 DISABLE_FILE_PATH = '/etc/scylla/machine_image_post_start_configured'
@@ -26,6 +28,7 @@ class ScyllaMachineImagePostStart(UserData):
                 subprocess.run(decoded_script, check=True, shell=True, timeout=600)
                 return True
             except Exception as e:
+                scylla_excepthook(*sys.exc_info())
                 LOGGER.error(f"Post start script failed: {e}")
 
 

--- a/dist/redhat/build_rpm.sh
+++ b/dist/redhat/build_rpm.sh
@@ -63,14 +63,6 @@ fi
 pkg_install rpm-build
 pkg_install git
 pkg_install python3
-pkg_install python3-devel
-pkg_install python3-pip
-
-echo "Running unit tests"
-cd tests
-sudo pip3 install pyyaml==5.3
-python3 -m unittest test_scylla_configure.py
-cd -
 
 echo "Building in $PWD..."
 

--- a/lib/scylla_cloud.py
+++ b/lib/scylla_cloud.py
@@ -39,6 +39,25 @@ Command '{cmd}' returned non-zero exit status: {e.returncode}
     return res.stdout.strip()
 
 
+import sys
+import traceback
+import traceback_with_variables
+import logging
+
+
+def scylla_excepthook(etype, value, tb):
+    os.makedirs('/var/tmp/scylla', mode=0o755, exist_ok=True)
+    traceback.print_exception(etype, value, tb)
+    exc_logger = logging.getLogger(__name__)
+    exc_logger.setLevel(logging.DEBUG)
+    exc_logger_file = f'/var/tmp/scylla/{os.path.basename(sys.argv[0])}-{os.getpid()}-debug.log'
+    exc_logger.addHandler(logging.FileHandler(exc_logger_file))
+    traceback_with_variables.print_exc(e=value, file_=traceback_with_variables.LoggerAsFile(exc_logger))
+    print(f'Debug log created: {exc_logger_file}')
+
+sys.excepthook = scylla_excepthook
+
+
 # @param headers dict of k:v
 def curl(url, headers=None, method=None, byte=False, timeout=3, max_retries=5, retry_interval=5):
     retries = 0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,3 +3,4 @@ httpretty==1.1.4
 psutil==5.9.1
 pytest==7.1.2
 PyYAML==6.0
+traceback-with-variables==2.0.4


### PR DESCRIPTION
Using traceback_with_variables module, generate more detail traceback
with variables into debug log.
This will help fixing bugs which is hard to reproduce.

This is scylla-machine-image version of https://github.com/scylladb/scylla/pull/10472.
Please merge this only after https://github.com/scylladb/scylla/pull/10472 get merged, otherwise we will fail to load traceback_with_variables.