### PR TITLE
[ami]:increase amount of time for waiting to AMI to be ready

### DIFF
--- a/packer/scylla.json
+++ b/packer/scylla.json
@@ -80,7 +80,11 @@
           "arch": "{{user `arch`| clean_resource_name}}",
           "build_tag": "{{user `build_tag`| clean_resource_name}}"
       },
-      "ami_regions": "{{user `ami_regions`}}"
+      "ami_regions": "{{user `ami_regions`}}",
+      "aws_polling": {
+        "delay_seconds": "30",
+        "max_attempts": "50"
+      }
     },
     {
       "name": "gce",


### PR DESCRIPTION
During my debug sessions i saw the following message:
```
09:34:04  ␛[1;32m==> aws: Waiting for AMI to become ready...␛[0m
10:04:13  ␛[1;31m==> aws: Error waiting for AMI: Failed with ResourceNotReady error, which can have a variety of causes. For help troubleshooting, check our docs: https://www.packer.io/docs/builders/amazon.html#resourcenotready-error
10:04:13  ==> aws: original error: ResourceNotReady: exceeded wait attempts␛[0m
```
So the AMI job fails but if we check AWS console after few more minutes
we see that the AMI was successfully have been created.

Let's increase the amount of time packer waits to avoid this