### PR TITLE
azure: fix is recommended instance method

### DIFF
--- a/lib/scylla_cloud.py
+++ b/lib/scylla_cloud.py
@@ -484,7 +484,7 @@ class azure_instance:
         return False
 
     def is_recommended_instance(self):
-        if self.is_unsupported_instance_class() and self.is_supported_instance_class():
+        if self.is_supported_instance_class():
             return True
         return False
 


### PR DESCRIPTION
method `self.is_unsupported_instance_class()` always was returning `False` making `is_recommended_instance` always return `False` causing error in io_setup