### PR TITLE
scylla_install_image:install systemd-coredump before Scylla

### DIFF
--- a/packer/scylla_install_image
+++ b/packer/scylla_install_image
@@ -103,9 +103,10 @@ if __name__ == '__main__':
             sys.exit(1)
 
         run('apt-get update --allow-insecure-repositories -y')
-        run('apt-get upgrade -y')
+        run('apt-get full-upgrade -y')
         run('apt-get purge -y apport fuse')
-        run('apt-get install -y --allow-unauthenticated {0}-machine-image {0}-server-dbg systemd-coredump'.format(args.product))
+        run('apt-get install -y systemd-coredump')
+        run('apt-get install -y --auto-remove --allow-unauthenticated {0}-machine-image {0}-server-dbg'.format(args.product))
 
         os.remove('/etc/apt/sources.list.d/scylla_install.list')
         if args.repo_for_update:


### PR DESCRIPTION
recently during cloud image build i getting sporadic failures with the following message:
```
14:07:33  ␛[1;31m==> azure: E: Unable to locate package systemd-coredump␛[0m
14:07:34  ␛[1;31m==> azure: Traceback (most recent call last):␛[0m
14:07:34  ␛[1;31m==> azure:   File "/home/azureuser/scylla_install_image", line 108, in <module>␛[0m
14:07:34  ␛[1;31m==> azure:     run('apt-get install -y --allow-unauthenticated {0}-machine-image {0}-server-dbg systemd-coredump'.format(args.product))␛[0m
14:07:34  ␛[1;31m==> azure:   File "/home/azureuser/scylla_install_image", line 28, in run␛[0m
14:07:34  ␛[1;31m==> azure:     return subprocess.check_call(cmd, shell=shell, env=my_env)␛[0m
14:07:34  ␛[1;31m==> azure:   File "/usr/lib/python3.8/subprocess.py", line 364, in check_call␛[0m
14:07:34  ␛[1;31m==> azure:     raise CalledProcessError(retcode, cmd)␛[0m
14:07:34  ␛[1;31m==> azure: subprocess.CalledProcessError: Command '['apt-get', 'install', '-y', '--allow-unauthenticated', 'scylla-machine-image', 'scylla-server-dbg', 'systemd-coredump']' returned non-zero exit status 100.␛[0m
14:07:34  ␛[1;32m==> azure: Provisioning step had errors: Running the cleanup provisioner, if present...␛[0m
```

Installing systemd-coredump before machine image seems to solve the problem (with this fix, i didn't get such failure for about 5-6 builds) 
Ref: https://answers.launchpad.net/ubuntu/+source/systemd/+question/695171