### PR TITLE
WIP: increase max_attempts value for waiting to AMI to be ready

### DIFF
--- a/packer/scylla.json
+++ b/packer/scylla.json
@@ -83,7 +83,7 @@
       "ami_regions": "{{user `ami_regions`}}",
       "aws_polling": {
         "delay_seconds": "30",
-        "max_attempts": "50"
+        "max_attempts": "100"
       }
     },
     {


### PR DESCRIPTION
During build AMI job the following error was displayed:
Build 'aws' errored after 31 minutes 49 seconds: Error waiting for AMI:
Failed with ResourceNotReady error.
Similar case: https://github.com/scylladb/scylla-machine-image/commit/2cbc678c556008484e3290a9dee5c2d2ddd078ee