### PR TITLE
SCYLLA-VERSION-GEN: use semver-compatible version

### DIFF
--- a/SCYLLA-VERSION-GEN
+++ b/SCYLLA-VERSION-GEN
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 PRODUCT=scylla
-VERSION=5.1.dev
+VERSION=5.1.0-dev
 
 if test -f version
 then

--- a/dist/debian/build_deb.sh
+++ b/dist/debian/build_deb.sh
@@ -93,9 +93,9 @@ PACKAGE_NAME="$PRODUCT-machine-image"
 rm -rf "$BUILDDIR"
 mkdir -p "$BUILDDIR"/scylla-machine-image
 
-git archive --format=tar.gz HEAD -o "$BUILDDIR"/"$PACKAGE_NAME"_"$SCYLLA_VERSION-$SCYLLA_RELEASE".orig.tar.gz
+git archive --format=tar.gz HEAD -o "$BUILDDIR"/"$PACKAGE_NAME"_"$SCYLLA_VERSION"-"$SCYLLA_RELEASE".orig.tar.gz
 cd "$BUILDDIR"/scylla-machine-image
-tar -C ./ -xpf ../"$PACKAGE_NAME"_"$SCYLLA_VERSION-$SCYLLA_RELEASE".orig.tar.gz
+tar -C ./ -xpf ../"$PACKAGE_NAME"_"$SCYLLA_VERSION"-"$SCYLLA_RELEASE".orig.tar.gz
 cd -
 ./dist/debian/debian_files_gen.py
 cd "$BUILDDIR"/scylla-machine-image

--- a/dist/debian/build_deb.sh
+++ b/dist/debian/build_deb.sh
@@ -84,7 +84,7 @@ pkg_install python3-pip
 echo "Building in $PWD..."
 
 VERSION=$(./SCYLLA-VERSION-GEN)
-SCYLLA_VERSION=$(cat build/SCYLLA-VERSION-FILE)
+SCYLLA_VERSION=$(sed 's/-/~/' build/SCYLLA-VERSION-FILE)
 SCYLLA_RELEASE=$(cat build/SCYLLA-RELEASE-FILE)
 PRODUCT=$(cat build/SCYLLA-PRODUCT-FILE)
 BUILDDIR=build/debian
@@ -93,9 +93,9 @@ PACKAGE_NAME="$PRODUCT-machine-image"
 rm -rf "$BUILDDIR"
 mkdir -p "$BUILDDIR"/scylla-machine-image
 
-git archive --format=tar.gz HEAD -o "$BUILDDIR"/"$PACKAGE_NAME"_"$VERSION".orig.tar.gz
+git archive --format=tar.gz HEAD -o "$BUILDDIR"/"$PACKAGE_NAME"_"$SCYLLA_VERSION-$SCYLLA_RELEASE".orig.tar.gz
 cd "$BUILDDIR"/scylla-machine-image
-tar -C ./ -xpf ../"$PACKAGE_NAME"_"$VERSION".orig.tar.gz
+tar -C ./ -xpf ../"$PACKAGE_NAME"_"$SCYLLA_VERSION-$SCYLLA_RELEASE".orig.tar.gz
 cd -
 ./dist/debian/debian_files_gen.py
 cd "$BUILDDIR"/scylla-machine-image

--- a/dist/debian/debian_files_gen.py
+++ b/dist/debian/debian_files_gen.py
@@ -27,7 +27,7 @@ with open('build/SCYLLA-PRODUCT-FILE') as f:
     product = f.read().strip()
 
 with open('build/SCYLLA-VERSION-FILE') as f:
-    version = f.read().strip().replace('.rc', '~rc').replace('_', '-')
+    version = f.read().strip().replace
 
 with open('build/SCYLLA-RELEASE-FILE') as f:
     release = f.read().strip()

--- a/dist/debian/debian_files_gen.py
+++ b/dist/debian/debian_files_gen.py
@@ -27,8 +27,7 @@ with open('build/SCYLLA-PRODUCT-FILE') as f:
     product = f.read().strip()
 
 with open('build/SCYLLA-VERSION-FILE') as f:
-    version = f.read().strip().replace
-
+    version = f.read().strip().replace('-', '~')
 with open('build/SCYLLA-RELEASE-FILE') as f:
     release = f.read().strip()
 

--- a/dist/redhat/build_rpm.sh
+++ b/dist/redhat/build_rpm.sh
@@ -75,7 +75,7 @@ cd -
 echo "Building in $PWD..."
 
 VERSION=$(./SCYLLA-VERSION-GEN)
-SCYLLA_VERSION=$(cat build/SCYLLA-VERSION-FILE)
+SCYLLA_VERSION=$(sed 's/-/~/' build/SCYLLA-VERSION-FILE)
 SCYLLA_RELEASE=$(cat build/SCYLLA-RELEASE-FILE)
 PRODUCT=$(cat build/SCYLLA-PRODUCT-FILE)
 
@@ -84,7 +84,7 @@ PACKAGE_NAME="$PRODUCT-machine-image"
 RPMBUILD=$(readlink -f build/)
 mkdir -pv ${RPMBUILD}/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
 
-git archive --format=tar --prefix=$PACKAGE_NAME-$SCYLLA_VERSION/ HEAD -o $RPMBUILD/SOURCES/$PACKAGE_NAME-$VERSION.tar
+git archive --format=tar --prefix=$PACKAGE_NAME-$SCYLLA_VERSION/ HEAD -o $RPMBUILD/SOURCES/$PACKAGE_NAME-$SCYLLA_VERSION-$SCYLLA_RELEASE.tar
 cp dist/redhat/scylla-machine-image.spec $RPMBUILD/SPECS/$PACKAGE_NAME.spec
 
 parameters=(


### PR DESCRIPTION
Scylla-operator require Scylla to have semantic versioning. (Ref: https://semver.org/)
release candidate versioning already being updated in machine-image (https://github.com/scylladb/scylla-machine-image/pull/359/commits/e36e5a7260684f72f845e148d0822569631f27bd)

Nightly builds should be also aligned with this change

Ref: https://github.com/scylladb/scylla/issues/9543