### PR TITLE
build_deb_images.sh: use the unified script to build all images

### DIFF
--- a/packer/ami_variables.json
+++ b/packer/ami_variables.json
@@ -1,0 +1,7 @@
+{
+	"subnet_id": "subnet-ec4a72c4",
+	"security_group_id": "sg-c5e1f7a0",
+	"region": "us-east-1",
+	"associate_public_ip_address": "true",
+	"instance_type": "c4.xlarge"
+} 

--- a/packer/azure_variables.json
+++ b/packer/azure_variables.json
@@ -1,0 +1,9 @@
+{
+  "client_id": "",
+  "client_secret": "",
+  "tenant_id": "",
+  "subscription_id": "",
+  "security_group_id": "",
+  "region": "EAST US",
+  "vm_size": "Standard_D4_v4"
+}

--- a/packer/build_with_docker.sh
+++ b/packer/build_with_docker.sh
@@ -17,7 +17,7 @@ fi
 
 docker build -f $REALDIR/Dockerfile_deb . -t scylladb/packer-builder-deb
 
-DOCKER_ID=$(docker run -e AWS_SECRET_ACCESS_KEY -e AWS_ACCESS_KEY_ID -d  -v $HOME/.aws:/root/.aws -v `pwd`/../..:/scylla-machine-image scylladb/packer-builder-deb /bin/bash -c "cd /scylla-machine-image/; ./packer/build_deb_image.sh --target $TARGET $*")
+DOCKER_ID=$(docker run -e AWS_SECRET_ACCESS_KEY -e AWS_ACCESS_KEY_ID -d  -v $HOME/.aws:/root/.aws -v `pwd`/../..:/scylla-machine-image scylladb/packer-builder-deb /bin/bash -c "cd /scylla-machine-image/; ./packer/build_image.sh --target $TARGET $*")
 
 kill_it() {
     if [[ -n "$DOCKER_ID" ]]; then

--- a/packer/gce_variables.json
+++ b/packer/gce_variables.json
@@ -1,0 +1,7 @@
+{
+    "project_id": "scylla-images",
+    "region": "europe-west1",
+    "zone": "europe-west1-b",
+    "image_storage_location": "europe-west1",
+    "instance_type": "n2-standard-2"
+}

--- a/packer/scylla.json
+++ b/packer/scylla.json
@@ -164,7 +164,7 @@
     },
     {
       "destination": "/home/{{user `ssh_username`}}/",
-      "source": "../../packer/scylla_install_image",
+      "source": "scylla_install_image",
       "type": "file"
     },
     {

--- a/packer/user_data.txt
+++ b/packer/user_data.txt
@@ -1,0 +1,2 @@
+#!/bin/sh
+sed -i 's/Defaults    requiretty/#Defaults    requiretty/g' /etc/sudoers


### PR DESCRIPTION
On scylladb/scylla-machine-image@a7eac3d Takuya "merged" a few similar scripts that use packer to buile images (AMI, GCE, Azure) into one.

Let's set pkg to use the merged script.

Closes: https://github.com/scylladb/scylla-pkg/issues/2374

Should be merge together with: https://github.com/scylladb/scylla-pkg/pull/2976