### PR TITLE
refactor `scylla_post_start.py` to share user_data code

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,7 @@ jobs:
             pip install distro
             cd ./tests
             python -m unittest test_scylla_configure.py
+            python -m unittest test_scylla_post_start.py
             python -m unittest test_aws_instance.py
             python -m unittest test_gcp_instance.py
             python -m unittest test_azure_instance.py

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,16 +23,8 @@ jobs:
       - name: unittest
 
         run: |
-            pip install pyyaml==5.3
-            pip install httpretty
-            pip install psutil
-            pip install distro
-            cd ./tests
-            python -m unittest test_scylla_configure.py
-            python -m unittest test_scylla_post_start.py
-            python -m unittest test_aws_instance.py
-            python -m unittest test_gcp_instance.py
-            python -m unittest test_azure_instance.py
+            pip install -r test-requirements.txt
+            pytest ./tests
 
       - name: Build RPM (Centos:7)
         run: docker run -v `pwd`:/scylla-machine-image -w /scylla-machine-image  --rm centos:7.2.1511 bash -c './dist/redhat/build_rpm.sh -t centos7'

--- a/common/scylla_configure.py
+++ b/common/scylla_configure.py
@@ -5,7 +5,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import base64
-import json
 import subprocess
 import yaml
 import time
@@ -13,13 +12,13 @@ import logging
 from textwrap import dedent
 from datetime import datetime
 from lib.log import setup_logging
+from lib.user_data import UserData
 from pathlib import Path
-from email import message_from_string
 
 LOGGER = logging.getLogger(__name__)
 
 
-class ScyllaMachineImageConfigurator:
+class ScyllaMachineImageConfigurator(UserData):
     CONF_DEFAULTS = {
         'scylla_yaml': {
             'cluster_name': "scylladb-cluster-%s" % int(time.time()),
@@ -53,15 +52,7 @@ class ScyllaMachineImageConfigurator:
         self.scylla_yaml_path = Path(scylla_yaml_path)
         self.scylla_yaml_example_path = Path(scylla_yaml_path + ".example")
         self._scylla_yaml = {}
-        self._instance_user_data = None
-        self._cloud_instance = None
-
-    @property
-    def cloud_instance(self):
-        if not self._cloud_instance:
-            from lib.scylla_cloud import get_cloud_instance
-            self._cloud_instance = get_cloud_instance()
-        return self._cloud_instance
+        super().__init__()
 
     @property
     def scylla_yaml(self):
@@ -79,33 +70,6 @@ class ScyllaMachineImageConfigurator:
                 # See '/etc/scylla/scylla.yaml.example' with the full list of supported configuration
                 # options and their descriptions.\n"""[1:]))
             return yaml.dump(data=self.scylla_yaml, stream=scylla_yaml_file)
-
-    @property
-    def instance_user_data(self):
-        if self._instance_user_data is None:
-            try:
-                raw_user_data = self.cloud_instance.user_data.strip()
-                LOGGER.info("Got user-data: %s", raw_user_data)
-
-                # Try reading mime multipart message, and extract
-                # scylla-machine-image configuration out of it
-                message = message_from_string(raw_user_data)
-                if message.is_multipart():
-                    for part in message.walk():
-                        if part.get_content_type() in ('x-scylla/json', 'x-scylla/yaml'):
-                            # we'll pick here the last seen json or yaml file,
-                            # if multiple of them exists the last one wins, we are not merging them together
-                            raw_user_data = part.get_payload()
-
-                # try parse yaml, and fallback to parsing json
-                self._instance_user_data = {}
-                if raw_user_data:
-                    self._instance_user_data = yaml.safe_load(raw_user_data)
-                LOGGER.debug("parsed user-data: %s", self._instance_user_data)
-            except Exception as e:
-                LOGGER.warning("Error getting user data: %s. Will use defaults!", e)
-                self._instance_user_data = {}
-        return self._instance_user_data
 
     def updated_ami_conf_defaults(self):
         private_ip = self.cloud_instance.private_ipv4()

--- a/common/scylla_post_start.py
+++ b/common/scylla_post_start.py
@@ -5,43 +5,18 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import base64
-import json
 import logging
 import pathlib
 import subprocess
-import sys
 
 from lib.log import setup_logging
+from lib.user_data import UserData
 
 LOGGER = logging.getLogger(__name__)
 DISABLE_FILE_PATH = '/etc/scylla/machine_image_post_start_configured'
 
 
-class ScyllaMachineImagePostStart:
-
-    def __init__(self):
-        self._instance_user_data = None
-        self._cloud_instance = None
-
-    @property
-    def cloud_instance(self):
-        if not self._cloud_instance:
-            from lib.scylla_cloud import get_cloud_instance
-            self._cloud_instance = get_cloud_instance()
-        return self._cloud_instance
-
-    @property
-    def instance_user_data(self):
-        if self._instance_user_data is None:
-            try:
-                raw_user_data = self.cloud_instance.user_data
-                LOGGER.info(f"Got user-data: {raw_user_data}")
-                self._instance_user_data = json.loads(raw_user_data) if raw_user_data.strip() else {}
-                LOGGER.debug(f"JSON parsed user-data: {self._instance_user_data}")
-            except Exception as e:
-                LOGGER.warning(f"Error getting user data: {e}")
-        return self._instance_user_data
-
+class ScyllaMachineImagePostStart(UserData):
     def run_post_start_script(self):
         post_start_script = self.instance_user_data.get("post_start_script")
         if post_start_script:

--- a/dist/debian/debian/rules
+++ b/dist/debian/debian/rules
@@ -8,7 +8,7 @@ override_dh_auto_clean:
 
 override_dh_auto_install:
 	install -d -m755 $(CURDIR)/debian/tmp/opt/scylladb/scylla-machine-image/lib
-	install -m644 lib/log.py lib/scylla_cloud.py $(CURDIR)/debian/tmp/opt/scylladb/scylla-machine-image/lib
+	install -m644 lib/log.py lib/scylla_cloud.py lib/user_data.py $(CURDIR)/debian/tmp/opt/scylladb/scylla-machine-image/lib
 	install -m755 common/scylla_configure.py common/scylla_post_start.py common/scylla_create_devices $(CURDIR)/debian/tmp/opt/scylladb/scylla-machine-image
 	./tools/relocate_python_scripts.py \
 		--installroot $(CURDIR)/debian/tmp/opt/scylladb/scylla-machine-image/ \

--- a/dist/redhat/scylla-machine-image.spec
+++ b/dist/redhat/scylla-machine-image.spec
@@ -33,7 +33,7 @@ install -m644 common/scylla-image-setup.service common/scylla-image-post-start.s
 install -d -m755 $RPM_BUILD_ROOT/opt/scylladb
 install -d -m755 $RPM_BUILD_ROOT/opt/scylladb/scylla-machine-image
 install -d -m755 $RPM_BUILD_ROOT/opt/scylladb/scylla-machine-image/lib
-install -m644 lib/log.py lib/scylla_cloud.py $RPM_BUILD_ROOT/opt/scylladb/scylla-machine-image/lib
+install -m644 lib/log.py lib/scylla_cloud.py lib/user_data.py $RPM_BUILD_ROOT/opt/scylladb/scylla-machine-image/lib
 install -m755 common/scylla_configure.py common/scylla_post_start.py common/scylla_create_devices \
         $RPM_BUILD_ROOT/opt/scylladb/scylla-machine-image/
 ./tools/relocate_python_scripts.py \

--- a/lib/scylla_cloud.py
+++ b/lib/scylla_cloud.py
@@ -32,7 +32,7 @@ def curl(url, headers=None, method=None, byte=False, timeout=3, max_retries=5, r
                     return res.read()
                 else:
                     return res.read().decode('utf-8')
-        except urllib.error.URLError:
+        except (urllib.error.URLError, socket.timeout):
             time.sleep(retry_interval)
             retries += 1
             if retries >= max_retries:
@@ -683,7 +683,7 @@ class aws_instance(cloud_instance):
         try:
             curl(cls.META_DATA_BASE_URL + "api/token", headers={"X-aws-ec2-metadata-token-ttl-seconds": cls.METADATA_TOKEN_TTL}, method="PUT")
             return True
-        except (urllib.error.URLError, urllib.error.HTTPError):
+        except (urllib.error.URLError, urllib.error.HTTPError, socket.timeout):
             return False
 
     @property

--- a/lib/user_data.py
+++ b/lib/user_data.py
@@ -1,0 +1,50 @@
+#
+# Copyright 2022 ScyllaDB
+#
+# SPDX-License-Identifier: Apache-2.0
+import logging
+from email import message_from_string
+
+import yaml
+
+LOGGER = logging.getLogger(__name__)
+
+
+class UserData:
+    def __init__(self, *arg, **kwargs):
+        self._instance_user_data = None
+        self._cloud_instance = None
+
+    @property
+    def cloud_instance(self):
+        if not self._cloud_instance:
+            from lib.scylla_cloud import get_cloud_instance
+            self._cloud_instance = get_cloud_instance()
+        return self._cloud_instance
+
+    @property
+    def instance_user_data(self):
+        if self._instance_user_data is None:
+            try:
+                raw_user_data = self.cloud_instance.user_data.strip()
+                LOGGER.info("Got user-data: %s", raw_user_data)
+
+                # Try reading mime multipart message, and extract
+                # scylla-machine-image configuration out of it
+                message = message_from_string(raw_user_data)
+                if message.is_multipart():
+                    for part in message.walk():
+                        if part.get_content_type() in ('x-scylla/json', 'x-scylla/yaml'):
+                            # we'll pick here the last seen json or yaml file,
+                            # if multiple of them exists the last one wins, we are not merging them together
+                            raw_user_data = part.get_payload()
+
+                # try parse yaml, and fallback to parsing json
+                self._instance_user_data = {}
+                if raw_user_data:
+                    self._instance_user_data = yaml.safe_load(raw_user_data)
+                LOGGER.debug("parsed user-data: %s", self._instance_user_data)
+            except Exception as e:
+                LOGGER.warning("Error getting user data: %s. Will use defaults!", e)
+                self._instance_user_data = {}
+        return self._instance_user_data

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,5 @@
+distro==1.7.0
+httpretty==1.1.4
+psutil==5.9.1
+pytest==7.1.2
+PyYAML==6.0

--- a/tests/test_aws_instance.py
+++ b/tests/test_aws_instance.py
@@ -9,7 +9,6 @@ from collections import namedtuple
 
 sys.path.append(str(Path(__file__).parent.parent))
 from lib.scylla_cloud import aws_instance
-import lib.scylla_cloud
 
 LOGGER = logging.getLogger(__name__)
 

--- a/tests/test_aws_instance.py
+++ b/tests/test_aws_instance.py
@@ -2,11 +2,12 @@ import sys
 import logging
 import httpretty
 import unittest.mock
+from pathlib import Path
 from unittest import TestCase
 from subprocess import CalledProcessError
 from collections import namedtuple
 
-sys.path.append('..')
+sys.path.append(str(Path(__file__).parent.parent))
 from lib.scylla_cloud import aws_instance
 import lib.scylla_cloud
 

--- a/tests/test_aws_instance.py
+++ b/tests/test_aws_instance.py
@@ -8,6 +8,7 @@ from subprocess import CalledProcessError
 from collections import namedtuple
 
 sys.path.append(str(Path(__file__).parent.parent))
+import lib.scylla_cloud
 from lib.scylla_cloud import aws_instance
 
 LOGGER = logging.getLogger(__name__)
@@ -210,7 +211,15 @@ vpc-ipv6-cidr-blocks
 
     def test_is_not_aws_instance(self):
         httpretty.disable()
-        assert not aws_instance.is_aws_instance()
+        real_curl = lib.scylla_cloud.curl
+
+        def mocked_curl(*args, **kwargs):
+            kwargs['timeout'] = 0.1
+            kwargs['retry_interval'] = 0.001
+            return real_curl(*args, **kwargs)
+
+        with unittest.mock.patch('lib.scylla_cloud.curl', new=mocked_curl):
+            assert not aws_instance.is_aws_instance()
 
     def test_endpoint_snitch(self):
         self.httpretty_aws_metadata()

--- a/tests/test_azure_instance.py
+++ b/tests/test_azure_instance.py
@@ -9,8 +9,9 @@ from unittest import TestCase
 from subprocess import CalledProcessError
 from collections import namedtuple
 from socket import AddressFamily, SocketKind
+from pathlib import Path
 
-sys.path.append('..')
+sys.path.append(str(Path(__file__).parent.parent))
 from lib.scylla_cloud import azure_instance
 import lib.scylla_cloud
 

--- a/tests/test_azure_instance.py
+++ b/tests/test_azure_instance.py
@@ -2,18 +2,14 @@ import sys
 import logging
 import httpretty
 import unittest.mock
-import json
 import base64
 import re
 from unittest import TestCase
-from subprocess import CalledProcessError
 from collections import namedtuple
-from socket import AddressFamily, SocketKind
 from pathlib import Path
 
 sys.path.append(str(Path(__file__).parent.parent))
 from lib.scylla_cloud import azure_instance
-import lib.scylla_cloud
 
 LOGGER = logging.getLogger(__name__)
 

--- a/tests/test_azure_instance.py
+++ b/tests/test_azure_instance.py
@@ -9,6 +9,7 @@ from collections import namedtuple
 from pathlib import Path
 
 sys.path.append(str(Path(__file__).parent.parent))
+import lib.scylla_cloud
 from lib.scylla_cloud import azure_instance
 
 LOGGER = logging.getLogger(__name__)
@@ -101,7 +102,15 @@ network/
     # httpretty)
     def test_is_not_azure_instance(self):
         self.httpretty_no_azure_metadata()
-        assert not azure_instance.is_azure_instance()
+        real_curl = lib.scylla_cloud.curl
+
+        def mocked_curl(*args, **kwargs):
+            kwargs['timeout'] = 0.001
+            kwargs['retry_interval'] = 0.0001
+            return real_curl(*args, **kwargs)
+
+        with unittest.mock.patch('lib.scylla_cloud.curl', new=mocked_curl):
+            assert not azure_instance.is_azure_instance()
 
     def test_endpoint_snitch(self):
         self.httpretty_azure_metadata()

--- a/tests/test_gcp_instance.py
+++ b/tests/test_gcp_instance.py
@@ -7,8 +7,9 @@ from unittest import TestCase
 from subprocess import CalledProcessError
 from collections import namedtuple
 from socket import AddressFamily, SocketKind
+from pathlib import Path
 
-sys.path.append('..')
+sys.path.append(str(Path(__file__).parent.parent))
 from lib.scylla_cloud import gcp_instance
 import lib.scylla_cloud
 

--- a/tests/test_gcp_instance.py
+++ b/tests/test_gcp_instance.py
@@ -4,14 +4,12 @@ import httpretty
 import unittest.mock
 import json
 from unittest import TestCase
-from subprocess import CalledProcessError
 from collections import namedtuple
 from socket import AddressFamily, SocketKind
 from pathlib import Path
 
 sys.path.append(str(Path(__file__).parent.parent))
 from lib.scylla_cloud import gcp_instance
-import lib.scylla_cloud
 
 LOGGER = logging.getLogger(__name__)
 

--- a/tests/test_scylla_configure.py
+++ b/tests/test_scylla_configure.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from email.mime.multipart import MIMEMultipart
 from email.mime.base import MIMEBase
 
-sys.path.append('..')
+sys.path.append(str(Path(__file__).parent.parent))
 
 from lib.log import setup_logging
 from common.scylla_configure import ScyllaMachineImageConfigurator
@@ -56,7 +56,7 @@ class TestScyllaConfigurator(TestCase):
         self.temp_dir_path = Path(self.temp_dir.name)
         setup_logging(log_level=logging.DEBUG, log_dir_path=str(self.temp_dir_path))
         LOGGER.info("Test dir: %s", self.temp_dir_path)
-        shutil.copyfile("tests-data/scylla.yaml", str(self.temp_dir_path / "scylla.yaml"))
+        shutil.copyfile(Path(__file__).parent / "tests-data/scylla.yaml", str(self.temp_dir_path / "scylla.yaml"))
         self.private_ip = "172.16.16.1"
         self.configurator = ScyllaMachineImageConfigurator(scylla_yaml_path=str(self.temp_dir_path / "scylla.yaml"))
         self.test_cluster_name = "test-cluster"

--- a/tests/test_scylla_configure.py
+++ b/tests/test_scylla_configure.py
@@ -155,7 +155,7 @@ class TestScyllaConfigurator(TestCase):
         raw_user_data = json.dumps(
             dict(
                 post_configuration_script=base64.b64encode(bytes(script, "utf-8")).decode("utf-8"),
-                post_configuration_script_timeout=script_timeout - 2,
+                post_configuration_script_timeout=script_timeout - 4.5,
             )
         )
 

--- a/tests/test_scylla_post_start.py
+++ b/tests/test_scylla_post_start.py
@@ -1,0 +1,61 @@
+#
+# Copyright 2020 ScyllaDB
+#
+# SPDX-License-Identifier: Apache-2.0
+import sys
+import logging
+from unittest import TestCase
+from pathlib import Path
+import tempfile
+import base64
+import json
+
+sys.path.append('..')
+
+from lib.log import setup_logging
+from common.scylla_post_start import ScyllaMachineImagePostStart
+
+from test_scylla_configure import DummyCloudInstance, TestScyllaConfigurator
+LOGGER = logging.getLogger(__name__)
+
+
+def b64(s):
+    return base64.b64encode(s.encode()).decode()
+
+
+class TestScyllaPostStart(TestCase):
+
+    def setUp(self):
+        LOGGER.info("Setting up test dir")
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.temp_dir_path = Path(self.temp_dir.name)
+        setup_logging(log_level=logging.DEBUG, log_dir_path=str(self.temp_dir_path))
+        LOGGER.info("Test dir: %s", self.temp_dir_path)
+        self.post_start = ScyllaMachineImagePostStart()
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def run_scylla_post_start(self, user_data):
+        self.post_start._cloud_instance = DummyCloudInstance(user_data=user_data, private_ipv4='127.0.0.1')
+        self.post_start.run_post_start_script()
+
+    def test_no_user_data(self):
+        self.run_scylla_post_start('')
+
+    def test_empty_script(self):
+        self.run_scylla_post_start('{"post_start_script": ""}')
+
+    def test_base64_encoding(self):
+        self.run_scylla_post_start(json.dumps({"post_start_script": b64("echo start")}))
+
+    def test_base64_encoding_error(self):
+        with self.assertRaises(SystemExit):
+            self.run_scylla_post_start(
+                json.dumps({"post_start_script": b64("non-existing-command")}))
+
+    def test_mime_multipart(self):
+        scylla_user_data = {"post_start_script": b64("echo start")}
+        for data_type in ('json', 'yaml'):
+            msg = TestScyllaConfigurator.multipart_user_data(scylla_user_data, data_type)
+            self.run_scylla_post_start(user_data=str(msg))

--- a/tests/test_scylla_post_start.py
+++ b/tests/test_scylla_post_start.py
@@ -10,7 +10,7 @@ import tempfile
 import base64
 import json
 
-sys.path.append('..')
+sys.path.append(str(Path(__file__).parent.parent))
 
 from lib.log import setup_logging
 from common.scylla_post_start import ScyllaMachineImagePostStart


### PR DESCRIPTION
code reading `post_start_script` wasn't aware of the mine multipart
support that was add recently, refactored the code so the reading
of the user_data is share between `scylla_configure.py` and
`scylla_post_start.py`

also added unit test for `scylla_post_start.py` to verify
this is working