### PR TITLE
image-setup: run iotune for instances with no pre-configured io

### DIFF
--- a/lib/scylla_cloud.py
+++ b/lib/scylla_cloud.py
@@ -357,9 +357,6 @@ class gcp_instance(cloud_instance):
             io.generate()
         except UnsupportedInstanceClassError:
             logging.error('This is not a recommended Google Cloud instance setup for auto local disk tuning.')
-        except PresetNotFoundError:
-            logging.error('Did not detect number of disks in Google Cloud instance setup for auto local disk tuning.')
-        io.save()
 
     @property
     def user_data(self):
@@ -581,9 +578,6 @@ class azure_instance(cloud_instance):
             io.generate()
         except UnsupportedInstanceClassError:
             logging.error('This is not a recommended Azure Cloud instance setup for auto local disk tuning.')
-        except PresetNotFoundError:
-            logging.error('Did not detect number of disks in Azure Cloud instance setup for auto local disk tuning.')
-        io.save()
 
     @property
     def user_data(self):
@@ -790,9 +784,6 @@ class aws_instance(cloud_instance):
             io.generate()
         except UnsupportedInstanceClassError:
             logging.error('This is not a recommended EC2 instance setup for auto local disk tuning.')
-        except PresetNotFoundError:
-            logging.error('This is a supported AWS instance type but there are no preconfigured IO scheduler parameters for it.')
-        io.save()
 
     @property
     def user_data(self):

--- a/lib/scylla_cloud_io_setup.py
+++ b/lib/scylla_cloud_io_setup.py
@@ -6,16 +6,16 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
+import subprocess
 import yaml
 import logging
 import sys
 from abc import ABCMeta, abstractmethod
 
+
 def UnsupportedInstanceClassError(Exception):
     pass
 
-def PresetNotFoundError(Exception):
-    pass
 
 class cloud_io_setup(metaclass=ABCMeta):
     @abstractmethod
@@ -226,8 +226,11 @@ class aws_io_setup(cloud_io_setup):
             self.disk_properties["write_iops"] = 239549 * nr_disks
             self.disk_properties["write_bandwidth"] = 2302438912 * nr_disks
 
-        if not "read_iops" in self.disk_properties:
-            raise PresetNotFoundError()
+        if "read_iops" in self.disk_properties:
+            self.save()
+        else:
+            logging.warning("This is a supported instance but with no pre-configured io, scylla_io_setup will be run")
+            subprocess.run('scylla_io_setup', shell=True, check=True, capture_output=True, timeout=300)
 
 
 class gcp_io_setup(cloud_io_setup):
@@ -274,8 +277,11 @@ class gcp_io_setup(cloud_io_setup):
             #below is google, above is our measured
             #self.disk_properties["write_bandwidth"] = 4680 * mbs
 
-        if not "read_iops" in self.disk_properties:
-            raise PresetNotFoundError()
+        if "read_iops" in self.disk_properties:
+            self.save()
+        else:
+            logging.warning("This is a supported instance but with no pre-configured io, scylla_io_setup will be run")
+            subprocess.run('scylla_io_setup', shell=True, check=True, capture_output=True, timeout=300)
 
 
 class azure_io_setup(cloud_io_setup):
@@ -324,5 +330,9 @@ class azure_io_setup(cloud_io_setup):
             self.disk_properties["read_bandwidth"] = 20000 * mbs
             self.disk_properties["write_iops"] = 2546511
             self.disk_properties["write_bandwidth"] = 11998 * mbs
-        if not "read_iops" in self.disk_properties:
-            raise PresetNotFoundError()
+
+        if "read_iops" in self.disk_properties:
+            self.save()
+        else:
+            logging.warning("This is a supported instance but with no pre-configured io, scylla_io_setup will be run")
+            subprocess.run('scylla_io_setup', shell=True, check=True, capture_output=True, timeout=300)


### PR DESCRIPTION
We need to make sure that instances with no pre-configured IO, will run
`iotune` during the boot (as part of scylla-image-setup service),

@tarzanek the `run_iotune` function added on scylla_cloud_io_setup is a copy-paste of the original function you added [1] but without the cpuset/smp flag condition - not sure it's required - please take a look,

I verified this change on r5d.xlarge and i4i.xlarge and it works as expected but the fallback skipped for r5.xlarge since it's not part of the supported instance list [1] - what was the original behavior? did this work for diskless instances like r5.xlarge as well?

[0] https://github.com/scylladb/scylla-enterprise/blob/af3da2d7ac8b83e1710c418b269c3c85bd1fdbe4/dist/common/scripts/scylla_io_setup#L113-L165

[1] 'i2', 'i3', 'i3en', 'c5d', 'm5d', 'm5ad', 'r5d', 'z1d', 'c6gd', 'm6gd', 'r6gd', 'x2gd', 'im4gn', 'is4gen', 'i4i'

Fix #376 