### PR TITLE
images:align images to new version convention

### DIFF
--- a/packer/build_deb_image.sh
+++ b/packer/build_deb_image.sh
@@ -254,11 +254,6 @@ else
 
 fi
 
-# Following the replace made on scylla-machine-image/pull/121 we need
-# to revert the replacement here since Azure doesn't support `~` on
-# image name.
-SCYLLA_VERSION=$(echo $SCYLLA_VERSION | sed 's/\(.*\)\~)*/\1./')
-
 if [ "$TARGET" = "aws" ]; then
     SSH_USERNAME=ubuntu
     SOURCE_AMI_OWNER=099720109477

--- a/packer/scylla.json
+++ b/packer/scylla.json
@@ -132,7 +132,7 @@
       "tenant_id": "{{user `tenant_id`}}",
       "subscription_id": "{{user `subscription_id`}}",
       "managed_image_resource_group_name": "scylla-images",
-      "managed_image_name": "{{user `image_prefix`}}ScyllaDB-{{user `scylla_version`}}-build-{{user `scylla_build_id`| clean_resource_name}}",
+      "managed_image_name": "{{user `image_prefix`}}ScyllaDB-{{user `scylla_version` | clean_resource_name}}-build-{{user `scylla_build_id`| clean_resource_name}}",
       "os_type": "Linux",
       "image_publisher": "Canonical",
       "image_offer": "0001-com-ubuntu-server-focal",


### PR DESCRIPTION
Following https://github.com/scylladb/scylla-machine-image/pull/371 removing old hacks we did for the old version convention