### PR TITLE
[Azure]:fix coredump installation failure

### DIFF
--- a/packer/scylla.json
+++ b/packer/scylla.json
@@ -169,7 +169,7 @@
     },
     {
       "inline": [
-        "if [ {{build_name}} = aws ]; then sudo /usr/bin/cloud-init status --wait; fi",
+        "sudo /usr/bin/cloud-init status --wait",
         "sudo /home/{{user `ssh_username`}}/scylla_install_image --target-cloud {{build_name}} --scylla-version {{user `scylla_full_version`}} {{user `install_args`}}"
       ],
       "type": "shell"


### PR DESCRIPTION
Error message:
```
15:46:12  �[1;31m==> azure: E: Unable to locate package systemd-coredump�[0m
15:46:13  �[1;31m==> azure: Traceback (most recent call last):�[0m
15:46:13  �[1;31m==> azure:   File "/home/azureuser/scylla_install_image", line 80, in <module>�[0m
15:46:13  �[1;31m==> azure:     run('apt-get install -y systemd-coredump', shell=True, check=True)�[0m
15:46:13  �[1;31m==> azure:   File "/usr/lib/python3.8/subprocess.py", line 516, in run�[0m
15:46:13  �[1;31m==> azure:     raise CalledProcessError(retcode, process.args,�[0m
15:46:13  �[1;31m==> azure: subprocess.CalledProcessError: Command 'apt-get install -y systemd-coredump' returned non-zero exit status 100.�[0m
15:46:13  �[1;32m==> azure: Provisioning step had errors: Running the cleanup provisioner, if present...�[0m
```

Closes: https://github.com/scylladb/scylla-pkg/issues/3011