### PR TITLE
fix yaml user-data docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ scylla_yaml:
     - class_name: org.apache.cassandra.locator.SimpleSeedProvider
       parameters:
         - seeds: 10.0.219.209
-  post_configuration_script: "#! /bin/bash\nyum install cloud-init-cfn"
-  start_scylla_on_first_boot: true
+post_configuration_script: "#! /bin/bash\nyum install cloud-init-cfn"
+start_scylla_on_first_boot: true
 ```
 
 #### using mimemultipart
@@ -104,8 +104,8 @@ scylla_yaml:
     - class_name: org.apache.cassandra.locator.SimpleSeedProvider
       parameters:
         - seeds: 10.0.219.209
-  post_configuration_script: "#! /bin/bash\nyum install cloud-init-cfn"
-  start_scylla_on_first_boot: true
+post_configuration_script: "#! /bin/bash\nyum install cloud-init-cfn"
+start_scylla_on_first_boot: true
 
 --===============5438789820677534874==
 Content-Type: text/cloud-config; charset="us-ascii"

--- a/source/user_data_v3.rst
+++ b/source/user_data_v3.rst
@@ -102,8 +102,8 @@ using yaml
         - class_name: org.apache.cassandra.locator.SimpleSeedProvider
           parameters:
             - seeds: 10.0.219.209
-      post_configuration_script: "#! /bin/bash\nyum install cloud-init-cfn"
-      start_scylla_on_first_boot: true
+    post_configuration_script: "#! /bin/bash\nyum install cloud-init-cfn"
+    start_scylla_on_first_boot: true
 
 using mimemultipart
 ++++++++++++++++++++
@@ -132,8 +132,8 @@ https://cloudinit.readthedocs.io/en/latest/topics/format.html#mime-multi-part-ar
         - class_name: org.apache.cassandra.locator.SimpleSeedProvider
           parameters:
             - seeds: 10.0.219.209
-      post_configuration_script: "#! /bin/bash\nyum install cloud-init-cfn"
-      start_scylla_on_first_boot: true
+    post_configuration_script: "#! /bin/bash\nyum install cloud-init-cfn"
+    start_scylla_on_first_boot: true
 
     --===============5438789820677534874==
     Content-Type: text/cloud-config; charset="us-ascii"


### PR DESCRIPTION
the structure in the example was wrong, `start_scylla_on_first_boot`
and `post_configuration_script` shouldn't be under `scylla_yaml`
they should be it's siblings