### PR TITLE
ubuntu: move from apt-key command to gpg

### DIFF
--- a/packer/build_deb_image.sh
+++ b/packer/build_deb_image.sh
@@ -15,6 +15,8 @@ EXIT_STATUS=0
 DRY_RUN=false
 DEBUG=false
 TARGET=
+APT_KEYS_DIR='/etc/apt/keyrings'
+APT_KEY='d0a112e067426ab2'
 
 if [ -L "$0" ]; then
     if [ "$PDIRNAME" = "aws" ] || [ "$PDIRNAME" = "gce" ] || [ "$PDIRNAME" = "azure" ]; then
@@ -196,10 +198,13 @@ check_deb_exists () {
 }
 
 import_gpg_key () {
+  echo "Importing apt key ($APT_KEY)"
   TMPREPO=$(mktemp -u -p /etc/apt/sources.list.d/ --suffix .list)
-  sudo curl -o $TMPREPO $REPO_FOR_INSTALL
-  sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys d0a112e067426ab2
-  sudo apt-get update --allow-insecure-repositories -y
+  sudo curl -sSo $TMPREPO $REPO_FOR_INSTALL
+  sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys $APT_KEY
+  sudo mkdir -p $APT_KEYS_DIR
+  sudo gpg --homedir /tmp --no-default-keyring --keyring $APT_KEYS_DIR/scylladb.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys $APT_KEY
+  sudo apt-get update -y
 }
 
 if [ -z "$TARGET" ]; then

--- a/packer/scylla_install_image
+++ b/packer/scylla_install_image
@@ -19,6 +19,7 @@ from subprocess import run, PIPE, STDOUT
 
 my_env = os.environ.copy()
 my_env['DEBIAN_FRONTEND']='noninteractive'
+apt_keys_dir = '/etc/apt/keyrings'
 
 def get_kver(pattern):
     for k in glob.glob(pattern):
@@ -65,6 +66,9 @@ if __name__ == '__main__':
         sys.exit(1)
 
     run('apt-key adv --keyserver keyserver.ubuntu.com --recv-keys d0a112e067426ab2', shell=True, check=True)
+    run(f'mkdir -p {apt_keys_dir}; gpg --homedir /tmp --no-default-keyring --keyring {apt_keys_dir}/scylladb.gpg '
+        f'--keyserver hkp://keyserver.ubuntu.com:80 --recv-keys d0a112e067426ab2', shell=True, check=True)
+
     if args.repo_for_install:
         run(f'curl -L -o /etc/apt/sources.list.d/scylla_install.list {args.repo_for_install}', shell=True, check=True)
     elif args.localdeb:


### PR DESCRIPTION
As part of the apt-key deprecation [0], we need to use gpg to consume the
repo key and change the repo file (scylla.list) to explicitly point
to the key,

This is a chick-and-egg change because the repo file should be changed
on pkg repo and once it changed, the gpg command (added on this commit)
is required,

For this reason, we'll start with adding the gpg and later we'll remove the apt-key refs

In this change I also add the `sS` flag to the curl command to make it silent but print errors if there are such,
In addition, I removed the `--allow-insecure-repositories` which AFAIK is not require so better to avoid such a flag


Ref https://github.com/scylladb/scylladb/issues/11186

[0] https://wiki.debian.org/DebianRepository/UseThirdParty