### PR TITLE
scylla_install_image:install python2 package during installation

### DIFF
--- a/packer/scylla_install_image
+++ b/packer/scylla_install_image
@@ -81,6 +81,7 @@ if __name__ == '__main__':
     run('apt-get update --allow-insecure-repositories -y', shell=True, check=True)
     run('apt-get full-upgrade -y', shell=True, check=True)
     run('apt-get purge -y apport fuse', shell=True, check=True)
+    run('apt-get install -y python2', shell=True, check=True)
     run('apt-get install -y systemd-coredump', shell=True, check=True)
     run(f'apt-get install -y --auto-remove --allow-unauthenticated {args.product}-machine-image {args.product}-server-dbg', shell=True, check=True)
 


### PR DESCRIPTION
Following the changes https://github.com/scylladb/scylla-tools-java/pull/306 , python2 package is no longer installed during image creation, causing `cqlsh` not to work since python3 is not supported yet

Closes: https://github.com/scylladb/scylla-pkg/issues/3094