### PR TITLE
[ami]:Add parameter to select which arch to use

### DIFF
--- a/packer/build_deb_image.sh
+++ b/packer/build_deb_image.sh
@@ -15,6 +15,7 @@ EXIT_STATUS=0
 DRY_RUN=false
 DEBUG=false
 TARGET=
+ARCH="$(uname -m)"
 APT_KEYS_DIR='/etc/apt/keyrings'
 APT_KEY='d0a112e067426ab2'
 
@@ -45,6 +46,7 @@ print_usage() {
     echo "  [--debug]               Build debug image with special prefix for image name. Default: false."
     echo "  [--log-file]            Path for log. Default build/ami.log on current dir. Default: build/packer.log"
     echo "  --target                Target cloud (aws/gce/azure), mandatory when using this script directly, and not by soft links"
+    echo "  --arch                  Set the image build architecture. Valid options: x86_64 | aarch64 . if use didn't pass this parameter it will use local node architecture"
     exit 1
 }
 LOCALDEB=0
@@ -151,6 +153,10 @@ while [ $# -gt 0 ]; do
                 print_usage
                 ;;
             esac
+            ;;
+        "--arch")
+            ARCH="$2"
+            shift 2
             ;;
         *)
             echo "ERROR: Illegal option: $1"
@@ -265,7 +271,7 @@ if [ "$TARGET" = "aws" ]; then
     SOURCE_AMI_OWNER=099720109477
     REGION=us-east-1
 
-    arch="$(uname -m)"
+    arch="$ARCH"
     case "$arch" in
       "x86_64")
         SOURCE_AMI_FILTER="ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64*"


### PR DESCRIPTION
Today we based our ami arch based on the local machine the process is running in. meaning that for building both x86 and arm AMI image (for same commit) we need to run on 2 different machines. Adding `arch` param so we can manually select which arch we want to build with.

default will remain the same (based on local machine)