### PR TITLE
[build_deb_image]:fix wrong arch parameter

### DIFF
--- a/packer/build_deb_image.sh
+++ b/packer/build_deb_image.sh
@@ -344,7 +344,7 @@ set -x
   -var operating_system="$OPERATING_SYSTEM" \
   -var branch="$BRANCH" \
   -var ami_regions="$AMI_REGIONS" \
-  -var arch="$(arch)" \
+  -var arch="$ARCH" \
   -var product="$PRODUCT" \
   "${PACKER_ARGS[@]}" \
   "$REALDIR"/scylla.json


### PR DESCRIPTION
Following 4513c7c5473683dad7dd20048fa04e87f903f811, during the work on scylla-pkg side, i realized i was using the wrong `arch` parameter

Fixing it