### PR TITLE
fix(machine-image-setup): remove redundant call to io setup

### DIFF
--- a/common/scylla_cloud_io_setup
+++ b/common/scylla_cloud_io_setup
@@ -355,6 +355,5 @@ if __name__ == '__main__':
         io = azure_io_setup(cloud_instance)
     try:
         io.generate()
-        io.save()
     except UnsupportedInstanceClassError as e:
         sys.exit(1)


### PR DESCRIPTION
The io setup flow is done early in the code as part of the `self.save()` or by running
the scylla_io_setup script in case of an instance with no pre-configured io

Fix #402

/cc @syuu1228 