### PR TITLE
machine-image: change base image to Ubuntu 22.04

### DIFF
--- a/packer/build_image.sh
+++ b/packer/build_image.sh
@@ -8,7 +8,7 @@ DIR=$(dirname $(readlink -f "$0"))
 source "$DIR"/../SCYLLA-VERSION-GEN
 
 BUILD_ID=$(date -u '+%FT%H-%M-%S')
-OPERATING_SYSTEM="ubuntu20.04"
+OPERATING_SYSTEM="ubuntu22.04"
 EXIT_STATUS=0
 DRY_RUN=false
 DEBUG=false
@@ -28,7 +28,6 @@ print_usage() {
     echo "  [--scylla-build-sha-id] Scylla build SHA id form metadata file"
     echo "  [--branch]              Set the release branch for GCE label. Default: master"
     echo "  [--ami-regions]         Set regions to copy the AMI when done building it (including permissions and tags)"
-    echo "  [--operating-system]    Set the base OS for the image. Default: ubuntu20.04"
     echo "  [--build-tag]           Jenkins Build tag"
     echo "  --download-no-server    Download all deb needed excluding scylla from repo-for-install"
     echo "  [--debug]               Build debug image with special prefix for image name. Default: false."
@@ -95,11 +94,6 @@ while [ $# -gt 0 ]; do
         "--ami-regions"):
             AMI_REGIONS=$2
             echo "--ami-regions prameter: AMI_REGIONS |$AMI_REGIONS|"
-            shift 2
-            ;;
-        "--operating-system")
-            OPERATING_SYSTEM=$2
-            echo "--operating-system parameter: OPERATING_SYSTEM |$OPERATING_SYSTEM|"
             shift 2
             ;;
         "--log-file")
@@ -263,11 +257,11 @@ if [ "$TARGET" = "aws" ]; then
     arch="$ARCH"
     case "$arch" in
       "x86_64")
-        SOURCE_AMI_FILTER="ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64*"
+        SOURCE_AMI_FILTER="ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64*"
         INSTANCE_TYPE="c4.xlarge"
         ;;
       "aarch64")
-        SOURCE_AMI_FILTER="ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64*"
+        SOURCE_AMI_FILTER="ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64*"
         INSTANCE_TYPE="a1.xlarge"
         ;;
       *)
@@ -284,7 +278,7 @@ if [ "$TARGET" = "aws" ]; then
     PACKER_ARGS+=(-var scylla_ami_description="${SCYLLA_AMI_DESCRIPTION:0:255}")
 elif [ "$TARGET" = "gce" ]; then
     SSH_USERNAME=ubuntu
-    SOURCE_IMAGE_FAMILY="ubuntu-2004-lts"
+    SOURCE_IMAGE_FAMILY="ubuntu-2204-lts"
 
     PACKER_ARGS+=(-var source_image_family="$SOURCE_IMAGE_FAMILY")
 elif [ "$TARGET" = "azure" ]; then

--- a/packer/scylla_install_image
+++ b/packer/scylla_install_image
@@ -103,23 +103,13 @@ if __name__ == '__main__':
     run('apt-get autoremove --purge -y', shell=True, check=True)
 
     if args.target_cloud == 'aws':
-        # use easy_install instead of pip, because easy_install requires
-        # fewer dependencies, no need to install gcc, it makes our AMI smaller.
-        # XXX: we want install dependencies from distro repo, but
-        # python-daemon-2.2 on Ubuntu 20.04 is too new for aws-cfn-bootstrap,
-        # so install python-daemon-2.1 from pypi
-        run('apt-get install -y python3-pystache python3-lockfile python3-setuptools', shell=True, check=True)
-        run('python3 -m easy_install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz', shell=True, check=True)
+        run('apt-get install -y pip', shell=True, check=True)
+        run('pip install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-2.0-18.tar.gz', shell=True, check=True)
 
         # install .deb version of ssm-agent since we dropped snapd version
         run(f'curl -L -o /tmp/amazon-ssm-agent.deb https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/debian_{deb_arch()}/amazon-ssm-agent.deb', shell=True, check=True)
         run('dpkg -i /tmp/amazon-ssm-agent.deb', shell=True, check=True)
         run('systemctl enable amazon-ssm-agent', shell=True, check=True)
-
-        cfnpath = run('python3 -c "import cfnbootstrap as _; print(_.__path__[0])"', capture_output=True, shell=True, check=True, encoding='utf-8').stdout.strip()
-        initpath = os.path.abspath(f'{cfnpath}/../init/ubuntu/cfn-hup')
-        shutil.copyfile(initpath, '/etc/init.d/cfn-hup')
-        os.chmod('/etc/init.d/cfn-hup', 0o755)
 
         setup_opt = '--ntp-domain amazon'
         sysconfig_opt = ''


### PR DESCRIPTION
This commit bumps the image base-version to Ubuntu 22.04

**Note:** this change is currently blocked by cloudformation issue [0], if it will not going to fix soon, we'll need to use a workaround to adjust the python modules paths as suggested on [0]

[0] https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/issues/1304


Fix #390