### PR TITLE
Add kernel version metadata file

### DIFF
--- a/packer/scylla.json
+++ b/packer/scylla.json
@@ -179,6 +179,12 @@
       "destination": "build/",
       "direction": "download",
       "type": "file"
+    },
+    {
+      "source": "/home/{{user `ssh_username`}}/{{user `product`}}-kernel-{{user `scylla_full_version`}}-{{user `arch`}}.txt",
+      "destination": "build/",
+      "direction": "download",
+      "type": "file"
     }
   ],
   "variables": {

--- a/packer/scylla_install_image
+++ b/packer/scylla_install_image
@@ -230,3 +230,9 @@ WantedBy=multi-user.target
         for pkg_name in pkgs:
             pkg_name_version = run(f"dpkg-query --showformat='${{Package}}=${{Version}}' --show {pkg_name}", capture_output=True, shell=True, check=True, encoding='utf-8').stdout
             f.write(f'{pkg_name_version}\n')
+    print('{}/{}-packages-{}-{}.txt generated.'.format(homedir, args.product, args.scylla_version, arch()))
+
+    kver = run('uname -r', shell=True, check=True, capture_output=True, encoding='utf-8').stdout.strip()
+    with open('{}/{}-kernel-{}-{}.txt'.format(homedir, args.product, args.scylla_version, arch()), 'w') as f:
+            f.write(f'kernel-version: {kver}\n')
+    print('{}/{}-kernel-{}-{}.txt generated.'.format(homedir, args.product, args.scylla_version, arch()))


### PR DESCRIPTION
To provide kernel version information of the machine image, add kernel version metadata file which works like scylla-packages.txt.

See scylladb/scylla-pkg#3118