### PR TITLE
packer: terminate ec2 instances following non-stable packer-build

### DIFF
--- a/packer/scylla.json
+++ b/packer/scylla.json
@@ -85,7 +85,8 @@
       "aws_polling": {
         "delay_seconds": "30",
         "max_attempts": "100"
-      }
+      },
+      "shutdown_behavior": "terminate"
     },
     {
       "name": "gce",


### PR DESCRIPTION
This commit changes the default post-behavior to make sure we have no packer leftovers

From packer amazon-ebs module page [0]:

> "Automatically terminate instances on shutdown in case Packer exits ungracefully. Possible values are stop and terminate. Defaults to stop."

[0] https://developer.hashicorp.com/packer/plugins/builders/amazon/ebs#shutdown_behavior

Ref https://github.com/scylladb/scylla-pkg/issues/3152