### PR TITLE
build_image.sh:remove unrelated `if` condition

### DIFF
--- a/packer/build_image.sh
+++ b/packer/build_image.sh
@@ -294,7 +294,6 @@ elif [ "$TARGET" = "azure" ]; then
 fi
 
 IMAGE_NAME="$PRODUCT-$VERSION-$ARCH-$(date '+%FT%T')"
-if [ "$BUILD_MODE" = "debug" ]; then
 if $DEBUG ; then
   IMAGE_NAME="debug-$IMAGE_NAME"
 fi


### PR DESCRIPTION
during e19ae1250374db1541133a839ccda791593a6e6c i got some leftover `if` condition from my debuging session, not sure how did i missed it

Fixing it