### PR TITLE
drop deperecated scylla_setup parameters

### DIFF
--- a/common/scylla_image_setup
+++ b/common/scylla_image_setup
@@ -17,7 +17,7 @@ if __name__ == '__main__':
     cloud_instance = get_cloud_instance()
     run('/opt/scylladb/scylla-machine-image/scylla_configure.py', shell=True, check=True)
 
-    run('/opt/scylladb/scripts/scylla_sysconfig_setup --nic eth0 --setup-nic --ami', shell=True, check=True)
+    run('/opt/scylladb/scripts/scylla_sysconfig_setup --nic eth0 --setup-nic', shell=True, check=True)
     if os.path.ismount('/var/lib/scylla'):
         if cloud_instance.is_supported_instance_class():
             # We run io_setup only when ehpemeral disks are available

--- a/packer/scylla_install_image
+++ b/packer/scylla_install_image
@@ -136,13 +136,13 @@ if __name__ == '__main__':
     run('systemctl daemon-reload', shell=True, check=True)
     run('systemctl enable scylla-image-setup.service', shell=True, check=True)
     run('systemctl enable scylla-image-post-start.service', shell=True, check=True)
-    run('/opt/scylladb/scripts/scylla_setup --no-coredump-setup --no-sysconfig-setup --no-raid-setup --no-io-setup --no-bootparam-setup --no-ec2-check --no-swap-setup --no-cpuscaling-setup', shell=True, check=True)
+    run('/opt/scylladb/scripts/scylla_setup --no-coredump-setup --no-sysconfig-setup --no-raid-setup --no-io-setup --no-ec2-check --no-swap-setup --no-cpuscaling-setup', shell=True, check=True)
 
     # On Ubuntu, 'cpufrequtils' never fails even CPU scaling is not supported,
     # so we want to enable it here
     run('/opt/scylladb/scripts/scylla_cpuscaling_setup --force', shell=True, check=True)
 
-    run(f'/opt/scylladb/scripts/scylla_sysconfig_setup --ami --set-clocksource {sysconfig_opt}', shell=True, check=True)
+    run(f'/opt/scylladb/scripts/scylla_sysconfig_setup --set-clocksource {sysconfig_opt}', shell=True, check=True)
     run(f'/opt/scylladb/scripts/scylla_swap_setup --swap-size-bytes {half_of_diskfree()} {swap_opt}', shell=True, check=True)
     run('/opt/scylladb/scripts/scylla_coredump_setup', shell=True, check=True)
     dot_mount = '''


### PR DESCRIPTION
Note that this is machine-image part of https://github.com/scylladb/scylladb/pull/12043

----

Since we dropped --no-bootparam-setup and --ami on scylla repo, we should drop it from machine-image too.

Related with #61