### PR TITLE
[images]: remove services which we don't need and change our base OS to ubuntu-minimal

### DIFF
--- a/packer/build_image.sh
+++ b/packer/build_image.sh
@@ -257,11 +257,11 @@ if [ "$TARGET" = "aws" ]; then
     arch="$ARCH"
     case "$arch" in
       "x86_64")
-        SOURCE_AMI_FILTER="ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64*"
+        SOURCE_AMI_FILTER="ubuntu-minimal/images/hvm-ssd/ubuntu-jammy-22.04-amd64*"
         INSTANCE_TYPE="c4.xlarge"
         ;;
       "aarch64")
-        SOURCE_AMI_FILTER="ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64*"
+        SOURCE_AMI_FILTER="ubuntu-minimal/images/hvm-ssd/ubuntu-jammy-22.04-arm64*"
         INSTANCE_TYPE="a1.xlarge"
         ;;
       *)

--- a/packer/scylla_install_image
+++ b/packer/scylla_install_image
@@ -94,6 +94,7 @@ if __name__ == '__main__':
     run('apt-get purge -y snapd', shell=True, check=True)
     run('apt-get purge -y modemmanager', shell=True, check=True)
     run('apt-get purge -y accountsservice', shell=True, check=True)
+    run('apt-get purge -y acpid motd-news-config fwupd-signed', shell=True, check=True)
     run('apt-get purge -y udisks2', shell=True, check=True)
     # cannot remove policykit since add-apt-repository depends on that,
     # so just disable the service
@@ -123,6 +124,7 @@ if __name__ == '__main__':
         sysconfig_opt = '--disable-writeback-cache'
         swap_opt = '--swap-directory /mnt'
 
+    run('systemctl disable --now apt-daily-upgrade.timer apt-daily.timer dpkg-db-backup.timer motd-news.timer', shell=True, check=True)
     run('systemctl daemon-reload', shell=True, check=True)
     run('systemctl enable scylla-image-setup.service', shell=True, check=True)
     run('systemctl enable scylla-image-post-start.service', shell=True, check=True)


### PR DESCRIPTION
This PR contains the following commits: 

[[Images]: remove services which we don't need during image creation](https://github.com/scylladb/scylla-machine-image/commit/afd033cddea34f43dfd6dbfd119a367597ed0d3a)

[[images]:Switch images to be based on ubuntu-minimal](https://github.com/scylladb/scylla-machine-image/commit/3c10079e866611cf6d667d7ae992a11661f81e30)

Closes: https://github.com/scylladb/scylla-machine-image/issues/408