### PR TITLE
gce: enable multi-queue SCSI

### DIFF
--- a/packer/scylla.json
+++ b/packer/scylla.json
@@ -103,6 +103,7 @@
       "image_family": "scylla",
       "image_name": "{{user `image_name`| clean_resource_name}}",
       "image_description": "Official ScyllaDB image v-{{user `scylla_version`| clean_resource_name}}",
+      "image_guest_os_features": ["VIRTIO_SCSI_MULTIQUEUE", "SEV_CAPABLE", "UEFI_COMPATIBLE", "GVNIC"],
       "use_internal_ip": false,
       "preemptible": true,
       "omit_external_ip": false,

--- a/packer/scylla_install_image
+++ b/packer/scylla_install_image
@@ -115,14 +115,17 @@ if __name__ == '__main__':
         setup_opt = '--ntp-domain amazon'
         sysconfig_opt = ''
         swap_opt = '--swap-directory /'
+        kernel_opt = ''
     elif args.target_cloud == 'gce':
         setup_opt = ''
         sysconfig_opt = '--disable-writeback-cache'
         swap_opt = '--swap-directory /'
+        kernel_opt = ' scsi_mod.use_blk_mq=Y'
     elif args.target_cloud == 'azure':
         setup_opt = ''
         sysconfig_opt = '--disable-writeback-cache'
         swap_opt = '--swap-directory /mnt'
+        kernel_opt = ''
 
     run('systemctl disable apt-daily-upgrade.timer apt-daily.timer dpkg-db-backup.timer motd-news.timer', shell=True, check=True)
     run('systemctl daemon-reload', shell=True, check=True)
@@ -163,7 +166,7 @@ WantedBy=multi-user.target
 
     with open('/etc/default/grub.d/50-cloudimg-settings.cfg') as f:
         grub = f.read()
-    grub = re.sub(r'^GRUB_CMDLINE_LINUX_DEFAULT="(.+)"$', r'GRUB_CMDLINE_LINUX_DEFAULT="\1 net.ifnames=0 clocksource=tsc tsc=reliable"', grub, flags=re.MULTILINE)
+    grub = re.sub(r'^GRUB_CMDLINE_LINUX_DEFAULT="(.+)"$', fr'GRUB_CMDLINE_LINUX_DEFAULT="\1 net.ifnames=0 clocksource=tsc tsc=reliable{kernel_opt}"', grub, flags=re.MULTILINE)
     with open('/etc/default/grub.d/50-cloudimg-settings.cfg', 'w') as f:
         f.write(grub)
     run('update-grub2', shell=True, check=True)


### PR DESCRIPTION
To getting better performance on GCP instances with SCSI local disks, google cloud document recommends to enable VIRTIO_SCSI_MULTIQUEUE flag on guestOsFeatures and following kernel parameter "scsi_mod.use_blk_mq=Y".

Fixes #418