### PR TITLE
lib/scylla_cloud.py: remove diskCount vs cpu restrictions

### DIFF
--- a/lib/scylla_cloud.py
+++ b/lib/scylla_cloud.py
@@ -362,7 +362,7 @@ class gcp_instance(cloud_instance):
                 if diskCount >= 16 and self.cpu < 32:
                     logging.warning(
                         "This machine doesn't have enough CPUs for allocated number of NVMEs (at least 32 cpus for >=16 disks). Performance will suffer.")
-                    return False
+                    return True
                 if diskCount < 1:
                     logging.warning("No ephemeral disks were found.")
                     return False

--- a/tests/test_gcp_instance.py
+++ b/tests/test_gcp_instance.py
@@ -412,8 +412,6 @@ class TestGcpInstance(TestCase):
         with unittest.mock.patch('psutil.cpu_count', return_value=8),\
                 unittest.mock.patch('psutil.virtual_memory', return_value=svmem(33663647744)),\
                 unittest.mock.patch('psutil.disk_partitions', return_value=mock_disk_partitions),\
-                unittest.mock.patch('os.listdir', return_value=mock_listdevdir_n2_standard_8_24ssd),\
-                unittest.mock.patch('glob.glob', return_value=mock_glob_glob_dev_n2_standard_8_24ssd),\
                 unittest.mock.patch('lib.scylla_cloud.gcp_instance.get_file_size_by_seek', return_value=402653184000):
             ins = gcp_instance()
             # Requires more CPUs to use this number of SSDs


### PR DESCRIPTION
although it's not recommended by GCP, we need to remove the restriction for minimum cpu's when using 16 local disks or more. This is so we can support one of our cloud customer which is using this configuration

Closes: https://github.com/scylladb/scylla-enterprise/issues/2543