### PR TITLE
DRAFT: [images]: install auditd by default

### DIFF
--- a/packer/scylla_install_image
+++ b/packer/scylla_install_image
@@ -82,6 +82,7 @@ if __name__ == '__main__':
     run('apt-get full-upgrade -y', shell=True, check=True)
     run('apt-get purge -y apport python3-apport fuse', shell=True, check=True)
     run('apt-get install -y systemd-coredump', shell=True, check=True)
+    run('apt-get install -y auditd', shell=True, check=True)
     run(f'apt-get install -y --auto-remove --allow-unauthenticated {args.product}-machine-image {args.product}-server-dbg', shell=True, check=True)
 
     os.remove('/etc/apt/sources.list.d/scylla_install.list')


### PR DESCRIPTION
Related with scylladb/scylla-enterprise-machine-image#54