### PR TITLE
Limit deeper C-states to reduce latency

### DIFF
--- a/packer/scylla_install_image
+++ b/packer/scylla_install_image
@@ -168,7 +168,7 @@ WantedBy=multi-user.target
     with open('/etc/default/grub.d/50-cloudimg-settings.cfg') as f:
         grub = f.read()
     grub = re.sub(fr'^{grub_variable}="(.+)"$',
-                  fr'{grub_variable}="\1 net.ifnames=0 clocksource=tsc tsc=reliable {kernel_opt}"', grub,
+                  fr'{grub_variable}="\1 net.ifnames=0 clocksource=tsc tsc=reliable intel_idle.max_cstate=1 processor.max_cstate=1 {kernel_opt}"', grub,
                   flags=re.MULTILINE)
     with open('/etc/default/grub.d/50-cloudimg-settings.cfg', 'w') as f:
         f.write(grub)


### PR DESCRIPTION
Since we want maximum performance and low latency, we need to disable deeper C-states on instances.

Fixes #425