### PR TITLE
[Azure]:make our image MS certified V.2

### DIFF
--- a/packer/scylla.json
+++ b/packer/scylla.json
@@ -139,8 +139,8 @@
       "managed_image_name": "{{user `image_name`| clean_resource_name}}",
       "os_type": "Linux",
       "image_publisher": "Canonical",
-      "image_offer": "0001-com-ubuntu-server-focal",
-      "image_sku": "20_04-lts-gen2",
+      "image_offer": "0001-com-ubuntu-server-jammy",
+      "image_sku": "22_04-lts-gen2",
       "azure_tags": {
         "scylla_version": "{{user `scylla_full_version`}}",
         "scylla_machine_image_version": "{{user `scylla_machine_image_version`}}",

--- a/packer/scylla_install_image
+++ b/packer/scylla_install_image
@@ -115,14 +115,20 @@ if __name__ == '__main__':
         setup_opt = '--ntp-domain amazon'
         sysconfig_opt = ''
         swap_opt = '--swap-directory /'
+        kernel_opt = ''
+        grub_variable = 'GRUB_CMDLINE_LINUX_DEFAULT'
     elif args.target_cloud == 'gce':
         setup_opt = ''
         sysconfig_opt = '--disable-writeback-cache'
         swap_opt = '--swap-directory /'
+        kernel_opt = ''
+        grub_variable = 'GRUB_CMDLINE_LINUX_DEFAULT'
     elif args.target_cloud == 'azure':
         setup_opt = ''
         sysconfig_opt = '--disable-writeback-cache'
         swap_opt = '--swap-directory /mnt'
+        kernel_opt = ' rootdelay=300'
+        grub_variable = 'GRUB_CMDLINE_LINUX'
 
     run('systemctl disable apt-daily-upgrade.timer apt-daily.timer dpkg-db-backup.timer motd-news.timer', shell=True, check=True)
     run('systemctl daemon-reload', shell=True, check=True)
@@ -163,7 +169,9 @@ WantedBy=multi-user.target
 
     with open('/etc/default/grub.d/50-cloudimg-settings.cfg') as f:
         grub = f.read()
-    grub = re.sub(r'^GRUB_CMDLINE_LINUX_DEFAULT="(.+)"$', r'GRUB_CMDLINE_LINUX_DEFAULT="\1 net.ifnames=0 clocksource=tsc tsc=reliable"', grub, flags=re.MULTILINE)
+    grub = re.sub(fr'^{grub_variable}="(.+)"$',
+                  fr'{grub_variable}="\1 net.ifnames=0 clocksource=tsc tsc=reliable {kernel_opt}"', grub,
+                  flags=re.MULTILINE)
     with open('/etc/default/grub.d/50-cloudimg-settings.cfg', 'w') as f:
         f.write(grub)
     run('update-grub2', shell=True, check=True)
@@ -211,6 +219,8 @@ WantedBy=multi-user.target
     if args.target_cloud == 'azure':
         with open('/etc/hosts', 'a') as f:
             f.write('\n\n169.254.169.254    metadata.azure.internal\n')
+        with open('/etc/ssh/sshd_config.d/50-cloudimg-settings.conf', 'w') as f:
+            f.write('ClientAliveInterval 180 \nHostKeyAlgorithms +ssh-rsa \nPubkeyAcceptedKeyTypes +ssh-rsa')
 
     # generate package manifest to scylla-packages.txt
     deps = run(f'apt-cache depends --recurse --no-recommends --no-suggests --no-conflicts --no-breaks --no-replaces --no-enhances --installed {args.product}', stdout=PIPE, stderr=STDOUT, shell=True, check=True, encoding='utf-8').stdout.splitlines()


### PR DESCRIPTION
Microsoft provides a certification test API that can be used to evaluate a given image's sanity. They also provide which test cases they run and expect us to comply with, as well as their recommendations for Azure Marketplace Images.

The following have been flagged within the VM self-test output for our
latest image:


"TestCaseName": "Swap Partition on OS Disk",
"Description": "Verifies that no Swap partitions are created on the OS disk.",
"Result": "Failed",
"ActualValue": "Swap space configured on the OS disk.",
Was fixed in #400
```
"TestCaseName": "Required Kernel Parameters",
"Description": "Verifies the following kernel parameters are set console=ttyS0, earlyprintk=ttyS0, rootdelay=300",
"Result": "Warning",
"ActualValue": "Missing Parameter: rootdelay=300\r\nMatched Parameter: console=ttyS0,earlyprintk=ttyS0",
---
"TestCaseName": "Client Alive Interval",
"Description": "It is recommended to set ClientAliveInterval to 180. On the application need, it can be set between 30 to 235. \nIf you are enabling the SSH for your end users this value must be set as explained.",
"Result": "Warning",
"ActualValue": "120",
```
fixed in this PR

Also fixing Azure image to be built based on Ubuntu:22.04 - 2e6de6537b3663c9ca73c46e14e326e8dbf07eac

Closes: scylladb/scylla-pkg#3172