### PR TITLE
azure: show login prompt correctly

### DIFF
--- a/packer/scylla.json
+++ b/packer/scylla.json
@@ -192,6 +192,12 @@
       "destination": "build/",
       "direction": "download",
       "type": "file"
+    },
+    {
+        "inline": [
+            "if [ {{build_name}} = gce -o {{build_name}} = azure ]; then sudo userdel -r -f {{user `ssh_username`}}; fi"
+        ],
+        "type": "shell"
     }
   ],
   "variables": {


### PR DESCRIPTION
Currently, Azure image does not show Scylla login prompt when logging in to ssh, since /etc/skel/.profile does not copied to ~/.profile. To fix this, we need to copy the file while build the Azure image.