### PR TITLE
[Azure]: save OS disk during image creation

### DIFF
--- a/packer/scylla.json
+++ b/packer/scylla.json
@@ -156,8 +156,11 @@
         "build_tag": "{{user `build_tag`| clean_resource_name}}",
         "build_mode": "{{user `build_mode`| clean_resource_name}}"
       },
-      "location": "{{user `region`}}",
-      "vm_size": "{{user `vm_size`}}"
+      "vm_size": "{{user `vm_size`}}",
+      "build_resource_group_name": "scylla-images",
+      "keep_os_disk": true,
+      "virtual_network_name": "scylla-images",
+      "private_virtual_network_with_public_ip": true
     }
   ],
   "provisioners": [


### PR DESCRIPTION
Due to a lack of resources in our main region EASTUS, we need to copy our images to different regions. In order to do it we need to keep the OS_disk during our main azure image creation.

So instead of creating a temp resource group for every build, I have created one for building purposes only.

Also keeping the original OS disk so we can later copy those images to different regions.

While doing it, I saw it also solves the retry for deleting resources we saw during Azure builds

Refs:  https://github.com/scylladb/scylla-pkg/issues/3165
