### PR TITLE
[Azure,Gce]:build image based on minimal ubuntu22.04

### DIFF
--- a/packer/build_image.sh
+++ b/packer/build_image.sh
@@ -285,7 +285,7 @@ if [ "$TARGET" = "aws" ]; then
     PACKER_ARGS+=(-var scylla_ami_description="${SCYLLA_AMI_DESCRIPTION:0:255}")
 elif [ "$TARGET" = "gce" ]; then
     SSH_USERNAME=ubuntu
-    SOURCE_IMAGE_FAMILY="ubuntu-2204-lts"
+    SOURCE_IMAGE_FAMILY="ubuntu-minimal-2204-lts"
 
     PACKER_ARGS+=(-var source_image_family="$SOURCE_IMAGE_FAMILY")
 elif [ "$TARGET" = "azure" ]; then

--- a/packer/scylla.json
+++ b/packer/scylla.json
@@ -139,8 +139,8 @@
       "managed_image_name": "{{user `image_name`| clean_resource_name}}",
       "os_type": "Linux",
       "image_publisher": "Canonical",
-      "image_offer": "0001-com-ubuntu-server-jammy",
-      "image_sku": "22_04-lts-gen2",
+      "image_offer": "0001-com-ubuntu-minimal-jammy",
+      "image_sku": "minimal-22_04-lts-gen2",
       "azure_tags": {
         "scylla_version": "{{user `scylla_full_version`}}",
         "scylla_machine_image_version": "{{user `scylla_machine_image_version`}}",


### PR DESCRIPTION
Similar to https://github.com/scylladb/scylla-machine-image/pull/413/commits/300537dbb11f962972742bf8fd5097fb6fffcae7,

moving both Azure and Gce to be based on minimal image