### PR TITLE
Disable EOL scylla repositories in k8s node setup image

### DIFF
--- a/k8s/Dockerfile
+++ b/k8s/Dockerfile
@@ -1,4 +1,14 @@
+# This node setup image uses old ScyllaDB version as a base because disk setup scripts inside allowed to
+# provide locations of raid, mount etc. Newer images have them hardcoded and they don't match host paths within the container.
+#
+# Using older version of ScyllaDB image is ok'ish from security point of view,
+# because we do run `yum update` as one of the steps so we get all the OS/packages bug fixes.
+#
+# !!! This setup is considered **deprecated** and will be removed soon in favor of different, safer solution. !!!
 FROM docker.io/scylladb/scylla:4.1.6 as base
+
+# Disable scylla repo, as 4.1 is already EOL.
+RUN yum-config-manager --disable scylla --disable scylla-generic --disable scylladb-scylla-3rdparty
 
 # Install scripts dependencies.
 RUN yum -y install epel-release && \
@@ -11,7 +21,7 @@ RUN pip3 install pyyaml psutil
 
 ARG cloud_provider
 
-COPY $cloud_provider/scylla_create_devices /opt/scylladb/scylla-machine-image/scylla_create_devices
+COPY "k8s/${cloud_provider}_scylla_create_devices" /opt/scylladb/scylla-machine-image/scylla_create_devices
 COPY k8s/scylla_k8s_node_setup /opt/scylladb/scylla-machine-image/scylla_k8s_node_setup
 
 ENTRYPOINT ["/opt/scylladb/scylla-machine-image/scylla_k8s_node_setup"]

--- a/k8s/aws_scylla_create_devices
+++ b/k8s/aws_scylla_create_devices
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+#
+# Copyright 2020 ScyllaDB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import re
+import os
+import sys
+import time
+import subprocess
+import urllib.request
+import urllib.error
+from pathlib import Path
+
+
+raid_script = "/opt/scylladb/scripts/scylla_raid_setup"
+raid_device = "/dev/md%d"
+scylla_root = ""
+
+def scylla_directory(role):
+    if role == "all":
+        return scylla_root
+    else:
+        return os.path.join(scylla_root, role)
+
+
+def curl_instance_data(url):
+    max_retries = 5
+    retries = 0
+    while True:
+        try:
+            req = urllib.request.Request(url)
+            return urllib.request.urlopen(req).read().decode("utf-8")
+        except urllib.error.HTTPError:
+            print("Failed to grab %s..." % url)
+            time.sleep(5)
+            retries += 1
+            if retries >= max_retries:
+                raise
+
+
+def find_disk(disks, line):
+    for disk in disks:
+        if line.find(disk) == -1:
+            return False
+    return True
+
+
+def config_array(disks, role, mdidx):
+    # Is it already constructed
+    disks.sort()
+    md_state_path = Path("/proc/mdstat")
+    with open(md_state_path) as mdstate:
+        for l in mdstate:
+            if find_disk(disks, l):
+                dev = re.search(r"^md\w+", l).group()
+                print("Found existing RAID %s, will mount it" % dev)
+                subprocess.check_call(["mount", "-o", "noatime",
+                                       "/dev/%s" % dev,
+                                       scylla_directory(role)])
+                return
+    print("RAID Array containing %s not found. Creating..." % str(disks))
+    disk_devs = ['/dev/%s' % x for x in disks]
+    subprocess.run([raid_script, "--raiddev",
+                    raid_device % mdidx, "--disks", ",".join(disk_devs),
+                    "--root", scylla_root,
+                    "--volume-role", role,
+                    "--update-fstab"], check=True)
+
+
+def xenify(devname):
+    dev = curl_instance_data('http://169.254.169.254/latest/meta-data/block-device-mapping/' + devname)
+    return dev.replace("sd", "xvd")
+
+
+def device_exists(dev):
+    return os.path.exists("/dev/%s" % dev)
+
+
+def device_is_busy(dev):
+    try:
+        fd = os.open(dev, os.O_RDWR | os.O_EXCL)
+        os.close(fd)
+        return False
+    except OSError:
+        return True
+
+
+# While testing this, I found the following issue at AWS:
+#
+# $ ls /dev/nvme*
+# /dev/nvme0  /dev/nvme0n1  /dev/nvme1  /dev/nvme1n1
+#
+# $ curl http://169.254.169.254/latest/meta-data/block-device-mapping/
+# ami
+# ebs2
+# ephemeral0
+# root
+#
+# As one can see, only one of the ephemeral devices were listed.
+#
+# I saw this happening only on i3 machines, if EBS were listed before
+# ephemeral during creation time. However, in that scenario, I saw it
+# happening every time I tested.
+#
+# More info at:
+# https://forums.aws.amazon.com/thread.jspa?threadID=250553
+#
+# So for nvme devices, we'll just scan the device list and see what we
+# find. Since the goal is to differentiate between ephemeral and
+# non-ephemeral anyway, and NVMe are always ephemeral, this is
+# acceptable
+def get_disk_bundles():
+    # define preferred disk roles. We'll see soon if we can respect them.
+    role = {
+        "ebs": "unused",
+        "ephemeral": "all"
+    }
+
+    # Find disk assignments
+    devmap = curl_instance_data('http://169.254.169.254/latest/meta-data/block-device-mapping/')
+    typemap = {}
+    devname = re.compile("^\D+")
+    nvme_re = re.compile(r"nvme\d+n\d+$")
+    nvmes_present = list(filter(nvme_re.match, os.listdir("/dev")))
+    nvmes_free = [nvme for nvme in nvmes_present if not device_is_busy(os.path.join('/dev/', nvme))]
+
+    if nvmes_free:
+        typemap["ephemeral"] = nvmes_free
+
+    for dev in devmap.splitlines():
+        if dev == "ami" or dev == "root":
+            continue
+
+        t = devname.match(dev).group()
+        if role[t] == "unused":
+            continue
+
+        if t == "ephemeral" and nvmes_present:
+            continue
+
+        if t not in typemap:
+            typemap[t] = []
+        if not device_exists(xenify(dev)):
+            continue
+        typemap[t] += [xenify(dev)]
+
+    # One of the desired types not found: The other type has it all
+    if "ebs" not in typemap and "ephemeral" not in typemap:
+        sys.stderr.write("No disks found\n")
+        sys.exit(0)
+    elif "ebs" not in typemap:
+        role["ephemeral"] = "all"
+    elif "ephemeral" not in typemap:
+        role["ebs"] = "all"
+
+    # Could happen even if properly invoked through ds2 if one of the
+    # types is not present, and the other is set to "unused"
+    if role["ebs"] == role["ephemeral"]:
+        err_msg = "Exception when parsing config. Both EBS and ephemeral are set to the same role (%s)"
+        raise Exception(err_msg % (role["ebs"]))
+
+    # If one type configured for all, the other for a specified role, and both present:
+    # That's valid and sane: respect that and mount one on top of the other. We just need
+    # make sure that the root is mounted first.
+    order = list(typemap.keys())
+    order.sort()
+
+    mdidx = 0
+    for t in order:
+        config_array(typemap[t], role[t], mdidx)
+        mdidx += 1
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Disk creation script for Scylla.')
+    parser.add_argument('--scylla-data-root', dest='scylla_data_root', action='store',
+                        help='location of Scylla root data directory', default="/var/lib/scylla")
+    args = parser.parse_args()
+
+    scylla_root = args.scylla_data_root
+
+    get_disk_bundles()

--- a/k8s/build_image.sh
+++ b/k8s/build_image.sh
@@ -7,7 +7,7 @@
 CLOUD_PROVIDER=
 
 print_usage() {
-    echo "build_image.sh -c [aws|gce|azure]"
+    echo "build_image.sh -c [aws]"
     echo "  -c cloud provider"
     exit 1
 }
@@ -27,7 +27,7 @@ fi
 
 echo "Building in $PWD..."
 
-VERSION=$(./SCYLLA-VERSION-GEN)
-PACKAGE_NAME="scylladb/scylla-machine-image-k8s-$CLOUD_PROVIDER:$VERSION"
+VERSION="k8s-${CLOUD_PROVIDER}-node-setup-0.0.2"
+IMAGE_REF="scylladb/scylla-machine-image:${VERSION}"
 
-docker build . -f k8s/Dockerfile --build-arg cloud_provider=$CLOUD_PROVIDER -t $PACKAGE_NAME
+docker build -f k8s/Dockerfile --build-arg "cloud_provider=${CLOUD_PROVIDER}" -t "${IMAGE_REF}" .


### PR DESCRIPTION
K8s node setup image which was created 2 years ago was used in scylla-operator EKS example. This image was supposed to set up a RAID array, create XFS filesystem and mount it in desired location using helper scripts taken from this repository and from scylla image. 
Image was based on Scylla 4.1 which some time ago ended it's life and it's repository was removed. 
This cause failures for k8s image users becasue repository added in base image is no longer there. 

```
Loaded plugins: fastestmirror, ovl
Determining fastest mirrors
 * base: download.cf.centos.org
 * epel: d2lzkl7pfhq30w.cloudfront.net
 * extras: download.cf.centos.org
 * updates: download.cf.centos.org
http://downloads.scylladb.com/rpm/unstable/centos/branch-4.1/2020-08-31T00%3A50%3A11Z/scylla/x86_64/repodata/repomd.xml: [Errno 14] HTTP Error 404 - Not Found
Trying other mirror.
To address this issue please refer to the below wiki article 

https://wiki.centos.org/yum-errors

If above article doesn't help to resolve this issue please use https://bugs.centos.org/.



 One of the configured repositories failed (Scylla for Centos 7 - x86_64),
 and yum doesn't have enough cached data to continue. At this point the only
 safe thing yum can do is fail. There are a few ways to work "fix" this:

     1. Contact the upstream for the repository and get them to fix the problem.

     2. Reconfigure the baseurl/etc. for the repository, to point to a working
        upstream. This is most often useful if you are using a newer
        distribution release than is supported by the repository (and the
        packages for the previous distribution release still work).

     3. Run the command with the repository temporarily disabled
            yum --disablerepo=scylla ...

     4. Disable the repository permanently, so yum won't use it by default. Yum
        will then just ignore the repository until you permanently enable it
        again or use --enablerepo for temporary usage:

            yum-config-manager --disable scylla
        or
            subscription-manager repos --disable=scylla

     5. Configure the failing repository to be skipped, if it is unavailable.
        Note that yum will try to contact the repo. when it runs most commands,
        so will have to try and fail each time (and thus. yum will be be much
        slower). If it is a very temporary problem though, this is often a nice
        compromise:

            yum-config-manager --save --setopt=scylla.skip_if_unavailable=true

failure: repodata/repomd.xml from scylla: [Errno 256] No more mirrors to try.
http://downloads.scylladb.com/rpm/unstable/centos/branch-4.1/2020-08-31T00:50:11Z/scylla/x86_64/repodata/repomd.xml: [Errno 14] HTTP Error 404 - Not Found
Traceback (most recent call last):
  File "/opt/scylladb/scripts/libexec/scylla_raid_setup", line 86, in <module>
    run('yum install -y mdadm xfsprogs')
  File "/opt/scylladb/scripts/scylla_util.py", line 340, in run
    return subprocess.check_call(cmd, shell=shell, stdout=stdout, stderr=stderr, env=scylla_env)
  File "/opt/scylladb/python3/lib64/python3.7/subprocess.py", line 363, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['yum', 'install', '-y', 'mdadm', 'xfsprogs']' returned non-zero exit status 1.
RAID Array containing ['nvme0n1', 'nvme1n1'] not found. Creating...
Traceback (most recent call last):
  File "/opt/scylladb/scylla-machine-image/scylla_create_devices", line 194, in <module>
    get_disk_bundles()
  File "/opt/scylladb/scylla-machine-image/scylla_create_devices", line 183, in get_disk_bundles
    config_array(typemap[t], role[t], mdidx)
  File "/opt/scylladb/scylla-machine-image/scylla_create_devices", line 80, in config_array
    "--update-fstab"], check=True)
  File "/opt/scylladb/python3/lib64/python3.7/subprocess.py", line 512, in run
    output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '['/opt/scylladb/scripts/scylla_raid_setup', '--raiddev', '/dev/md0', '--disks', '/dev/nvme0n1,/dev/nvme1n1', '--root', '/mnt/hostfs/mnt/raid-disks/disk0', '--volume-role', 'all', '--update-fstab']' returned non-zero exit status 1.
Traceback (most recent call last):
  File "/opt/scylladb/scylla-machine-image/scylla_k8s_node_setup", line 65, in <module>
    run('/opt/scylladb/scylla-machine-image/scylla_create_devices --scylla-data-root {}'.format(root_disk))
  File "/opt/scylladb/scripts/scylla_util.py", line 340, in run
    return subprocess.check_call(cmd, shell=shell, stdout=stdout, stderr=stderr, env=scylla_env)
  File "/usr/lib64/python3.6/subprocess.py", line 311, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['/opt/scylladb/scylla-machine-image/scylla_create_devices', '--scylla-data-root', '/mnt/hostfs/mnt/raid-disks/disk0']' returned non-zero exit status 1.
```

Because `scylla_create_devices` script was moved and changed to the point it's no longer working with k8s node setup, an old version was brought back into the k8s directory just for AWS. 
GCE image is not used anywhere, hence I fixed it just for AWS.

This image is going to be removed soon, as different solution for disk setup is coming to scylla-operator.
This PR is just a hot-fix to users and QA which used this image in the past and now are stuck.

Xref: https://github.com/scylladb/scylla-operator/issues/1218