### PR TITLE
(ami,azure):Install latest LTS kernel during image build 

### DIFF
--- a/packer/scylla.json
+++ b/packer/scylla.json
@@ -165,6 +165,13 @@
   ],
   "provisioners": [
     {
+      "type": "shell",
+      "inline": [
+        "if [ {{build_name}} = aws -o {{build_name}} = azure ]; then sudo apt-get update; sudo DEBIAN_FRONTEND=noninteractive apt purge -y linux-aws* linux-headers-{{build_name}}* linux-image*{{build_name}}* linux-modules*-{{build_name}}*; sudo DEBIAN_FRONTEND=noninteractive apt-get install -y linux-{{build_name}}-lts-22.04; sudo reboot ; fi"
+      ],
+      "expect_disconnect": true
+    },
+    {
       "destination": "/home/{{user `ssh_username`}}/",
       "source": "files/",
       "type": "file"


### PR DESCRIPTION
During image creation, we are running `apt-get full-upgrade which also updates the kernel (added as part of
https://github.com/scylladb/scylla-machine-image/commit/90340275b80a3a54dcfc1e5ec660481ba167d1c3),

Since we want to use the LTS kernel version only, adding the kernel removal package and installation before we run `scylla_install_image`

Currently only AWS and Azure have LTS kernel for 22.04, once GCP will
have it as well we should add it as well

Ref: https://github.com/scylladb/scylladb/issues/13560