### PR TITLE
lib/scylla_cloud.py: change retry logic of curl() to exponential backoff

### DIFF
--- a/lib/scylla_cloud.py
+++ b/lib/scylla_cloud.py
@@ -18,6 +18,7 @@ import glob
 import distro
 import base64
 import datetime
+import random
 from subprocess import run, CalledProcessError
 from abc import ABCMeta, abstractmethod
 
@@ -69,8 +70,10 @@ def curl(url, headers=None, method=None, byte=False, timeout=3, max_retries=5, r
                     return res.read()
                 else:
                     return res.read().decode('utf-8')
-        except (urllib.error.URLError, socket.timeout):
-            time.sleep(retry_interval)
+        except (urllib.error.URLError, socket.timeout) as e:
+            exp_retry_interval = (retry_interval ** retries) + random.random()
+            logging.error(f'Failed to access {url}: {e.reason}, retrying in {exp_retry_interval}')
+            time.sleep(exp_retry_interval)
             retries += 1
             if retries >= max_retries:
                 raise


### PR DESCRIPTION
Since IaaS services recommended to use exponential backoff logic when retries to call metadata services, we should do it in our scripts.

Referenced implementation in https://developers.google.com/analytics/devguides/reporting/core/v3/errors?hl=en

see https://docs.aws.amazon.com/general/latest/gr/api-retries.html

Related with scylladb/scylladb#13442