### PR TITLE
(gcp):Install latest LTS kernel during image build

### DIFF
--- a/packer/scylla.json
+++ b/packer/scylla.json
@@ -167,7 +167,10 @@
     {
       "type": "shell",
       "inline": [
-        "if [ {{build_name}} = aws -o {{build_name}} = azure ]; then sudo apt-get update; sudo DEBIAN_FRONTEND=noninteractive apt purge -y linux-aws* linux-headers-{{build_name}}* linux-image*{{build_name}}* linux-modules*-{{build_name}}*; sudo DEBIAN_FRONTEND=noninteractive apt-get install -y linux-{{build_name}}-lts-22.04; sudo reboot ; fi"
+        "sudo apt-get update",
+        "sudo DEBIAN_FRONTEND=noninteractive apt purge -y linux-{{build_name}}* linux-headers-{{build_name}}* linux-image*{{build_name}}* linux-modules*-{{build_name}}*",
+        "sudo DEBIAN_FRONTEND=noninteractive apt-get install -y linux-{{build_name}}-lts-22.04",
+        "sudo reboot"
       ],
       "expect_disconnect": true
     },


### PR DESCRIPTION
Similar to 42e05cacdedcbabf1d416e32eeb2cf317b9669f5 Dauring image creation we are running `apt-get full-upgrade` which also update the kernel (added as part of
    https://github.com/scylladb/scylla-machine-image/commit/90340275b80a3a54dcfc1e5ec660481ba167d1c3),

Since we want to use LTS kernel version only, adding the kernel removal package and installation before we run `scylla_install_image`