### PR TITLE
scylla.json: fix kernel removal for Azure

### DIFF
--- a/packer/scylla.json
+++ b/packer/scylla.json
@@ -167,7 +167,7 @@
     {
       "type": "shell",
       "inline": [
-        "if [ {{build_name}} = aws -o {{build_name}} = azure ]; then sudo apt-get update; sudo DEBIAN_FRONTEND=noninteractive apt purge -y linux-aws* linux-headers-{{build_name}}* linux-image*{{build_name}}* linux-modules*-{{build_name}}*; sudo DEBIAN_FRONTEND=noninteractive apt-get install -y linux-{{build_name}}-lts-22.04; sudo reboot ; fi"
+        "if [ {{build_name}} = aws -o {{build_name}} = azure ]; then sudo apt-get update; sudo DEBIAN_FRONTEND=noninteractive apt purge -y linux-{{build_name}}* linux-headers-{{build_name}}* linux-image*{{build_name}}* linux-modules*-{{build_name}}*; sudo DEBIAN_FRONTEND=noninteractive apt-get install -y linux-{{build_name}}-lts-22.04; sudo reboot ; fi"
       ],
       "expect_disconnect": true
     },


### PR DESCRIPTION
following the changes in 42e05cacdedcbabf1d416e32eeb2cf317b9669f5, during the package removal, forgot to change one of the packages to use cloud provider based on parameter rather then hardcoded

Fixing it