### PR TITLE
[azure]:fix copy image due to long image name

### DIFF
--- a/packer/build_image.sh
+++ b/packer/build_image.sh
@@ -300,7 +300,15 @@ elif [ "$TARGET" = "azure" ]; then
     PACKER_ARGS+=(-var subscription_id="$AZURE_SUBSCRIPTION_ID")
 fi
 
-IMAGE_NAME="$PRODUCT-$VERSION-$ARCH-$(date '+%FT%T')"
+if [ "$TARGET" = "azure" ]; then
+  if [ "$BUILD_MODE" = "debug" ]; then
+    IMAGE_NAME="scylla-debug-$VERSION-$ARCH-$(date '+%FT%T')"
+  else
+    IMAGE_NAME="scylla-$VERSION-$ARCH-$(date '+%FT%T')"
+  fi
+else
+  IMAGE_NAME="$PRODUCT-$VERSION-$ARCH-$(date '+%FT%T')"
+fi
 if [ "$BUILD_MODE" = "debug" ]; then
   IMAGE_NAME="$PRODUCT-debug-$VERSION-$ARCH-$(date '+%FT%T')"
 fi


### PR DESCRIPTION
When trying to copy Azure image to other regions (on enterprise only), we get the following failure:
```
10:23:45  ERROR: command failed: ['/usr/bin/../../opt/az/bin/python3', '-m', 'azure.cli', 'snapshot', 'create', '--resource-group', 'image-copy-rg', '--name', 'scylla-enterprise-2023.2.0-dev-x86_64-2023-05-01T09-12-36_os_disk_snapshot-eastus2', '--location', 'eastus2', '--source', 'https://eastus2lalnrozwewefc0at6.blob.core.windows.net/snapshots/scylla-enterprise-2023.2.0-dev-x86_64-2023-05-01T09-12-36_os_disk_snapshot.vhd', '--source-storage-account-id', '/subscriptions/****/resourceGroups/image-copy-rg/providers/Microsoft.Storage/storageAccounts/eastus2lalnrozwewefc0at6', '--hyper-v-generation', 'V2', '--output', 'json', '--subscription', ****, '--tags', 'created_by=image-copy-extension']
10:23:45  ERROR: output: ERROR: (InvalidParameter) The value of parameter snapshot.name is invalid.
10:23:45  Code: InvalidParameter
10:23:45  Message: The value of parameter snapshot.name is invalid.
10:23:45  Target: snapshot.name
```

Since SCT are depending on `branch` and `region` to search for images, and during promoting we create an image gallery link to the relevant image, switching image name to use `generalProductName`(Scylla) instead of productName(Scylla/Scylla-enterprise)