### PR TITLE
ami_variables: update aws variables for releng account

### DIFF
--- a/packer/ami_variables.json
+++ b/packer/ami_variables.json
@@ -1,5 +1,5 @@
 {
-	"security_group_id": "sg-c5e1f7a0",
+	"security_group_id": "sg-088128b2712c264d1",
 	"region": "us-east-1",
 	"associate_public_ip_address": "true",
 	"instance_type": "c4.xlarge"

--- a/packer/build_image.sh
+++ b/packer/build_image.sh
@@ -29,6 +29,7 @@ print_usage() {
     echo "  [--scylla-build-sha-id] Scylla build SHA id form metadata file"
     echo "  [--branch]              Set the release branch for GCE label. Default: master"
     echo "  [--ami-regions]         Set regions to copy the AMI when done building it (including permissions and tags)"
+    echo "  [--ami-users]           A list of account IDs that have access to launch the AMI"
     echo "  [--build-tag]           Jenkins Build tag"
     echo "  --download-no-server    Download all deb needed excluding scylla from repo-for-install"
     echo "  [--build-mode]          Choose which build mode to use for Scylla installation. Default: release. Valid options: release|debug"
@@ -96,6 +97,11 @@ while [ $# -gt 0 ]; do
         "--ami-regions"):
             AMI_REGIONS=$2
             echo "--ami-regions prameter: AMI_REGIONS |$AMI_REGIONS|"
+            shift 2
+            ;;
+        "--ami-users"):
+            AMI_USERS=$2
+            echo "--ami-users parameter: AMI_USERS |$AMI_USERS|"
             shift 2
             ;;
         "--log-file")
@@ -345,6 +351,7 @@ set -x
   -var operating_system="$OPERATING_SYSTEM" \
   -var branch="$BRANCH" \
   -var ami_regions="$AMI_REGIONS" \
+  -var ami_users="$AMI_USERS" \
   -var arch="$ARCH" \
   -var product="$PRODUCT" \
   -var build_mode="$BUILD_MODE" \

--- a/packer/scylla.json
+++ b/packer/scylla.json
@@ -89,6 +89,7 @@
           "build_mode": "{{user `build_mode`| clean_resource_name}}"
       },
       "ami_regions": "{{user `ami_regions`}}",
+      "ami_users": "{{user `ami_users`}}",
       "aws_polling": {
         "delay_seconds": "30",
         "max_attempts": "100"


### PR DESCRIPTION
d84794b7b17a614fd64cc63aea0fcb0674920453 - ami valiables updated to use releng account
5ac4d127939c6c51dfa50664a1de98399b884e37 - adding an option of `ami_users` - adding permissions to AMI during packer build

Should be merged together with: https://github.com/scylladb/scylla-pkg/pull/3392