### PR TITLE
ami-arm: change instance type during image build

### DIFF
--- a/packer/build_image.sh
+++ b/packer/build_image.sh
@@ -268,7 +268,7 @@ if [ "$TARGET" = "aws" ]; then
         ;;
       "aarch64")
         SOURCE_AMI_FILTER="ubuntu-minimal/images/hvm-ssd/ubuntu-jammy-22.04-arm64*"
-        INSTANCE_TYPE="a1.xlarge"
+        INSTANCE_TYPE="im4gn.xlarge"
         ;;
       *)
         echo "Unsupported architecture: $arch"


### PR DESCRIPTION
Started to get an error during arm ami build:
```
09:53:19  [1;31m==> aws: Error launching source instance: InsufficientInstanceCapacity: We currently do not have sufficient a1.xlarge capacity in the Availability Zone you requested (us-east-1b). Our system will be working on provisioning additional capacity. You can currently get a1.xlarge capacity by not specifying an Availability Zone in your request or choosing us-east-1c, us-east-1d.
```

Switching to more common instance type (the basic type we are also using for testing) , `im4gn.xlarge`