### PR TITLE
(images):create kernel-version output with cloud source

### DIFF
--- a/packer/scylla.json
+++ b/packer/scylla.json
@@ -195,7 +195,7 @@
       "type": "file"
     },
     {
-      "source": "/home/{{user `ssh_username`}}/{{user `product`}}-kernel-{{user `scylla_full_version`}}-{{user `arch`}}.txt",
+      "source": "/home/{{user `ssh_username`}}/{{user `product`}}-{{build_name}}-kernel-{{user `scylla_full_version`}}-{{user `arch`}}.txt",
       "destination": "build/",
       "direction": "download",
       "type": "file"

--- a/packer/scylla_install_image
+++ b/packer/scylla_install_image
@@ -239,6 +239,6 @@ WantedBy=multi-user.target
     print('{}/{}-packages-{}-{}.txt generated.'.format(homedir, args.product, args.scylla_version, arch()))
 
     kver = run('uname -r', shell=True, check=True, capture_output=True, encoding='utf-8').stdout.strip()
-    with open('{}/{}-kernel-{}-{}.txt'.format(homedir, args.product, args.scylla_version, arch()), 'w') as f:
+    with open('{}/{}-{}-kernel-{}-{}.txt'.format(homedir, args.product, args.target_cloud, args.scylla_version, arch()), 'a+') as f:
             f.write(f'kernel-version: {kver}\n')
-    print('{}/{}-kernel-{}-{}.txt generated.'.format(homedir, args.product, args.scylla_version, arch()))
+    print('{}/{}-{}-kernel-{}-{}.txt generated.'.format(homedir, args.product, args.target_cloud, args.scylla_version, arch()))


### PR DESCRIPTION
Today when we create images we have the same file name for all cloud images.

Let's generate a cloud specific kernel filename

Ref: https://github.com/scylladb/scylla-pkg/pull/3406