### PR TITLE
(gcp): Use lts kernel version

### DIFF
--- a/packer/scylla.json
+++ b/packer/scylla.json
@@ -172,6 +172,13 @@
       "expect_disconnect": true
     },
     {
+      "type": "shell",
+      "inline": [
+        "if [ {{build_name}} = gce ]; then sudo apt-get update; sudo DEBIAN_FRONTEND=noninteractive apt purge -y linux-gcp* linux-headers-gcp* linux-image*gcp* linux-modules*-gcp*; sudo DEBIAN_FRONTEND=noninteractive apt-get install -y linux-gcp-lts-22.04; sudo reboot ; fi"
+      ],
+      "expect_disconnect": true
+    },
+    {
       "destination": "/home/{{user `ssh_username`}}/",
       "source": "files/",
       "type": "file"


### PR DESCRIPTION
Based on https://packages.ubuntu.com/jammy-updates/linux-gcp-lts-22.04 gcp has now an official lts for 22.04

Closes: https://github.com/scylladb/scylla-machine-image/issues/452