### PR TITLE
change subnet_id to subnet_filter in json config

### DIFF
--- a/packer/ami_variables.json
+++ b/packer/ami_variables.json
@@ -1,5 +1,4 @@
 {
-	"subnet_id": "subnet-ec4a72c4",
 	"security_group_id": "sg-c5e1f7a0",
 	"region": "us-east-1",
 	"associate_public_ip_address": "true",

--- a/packer/scylla.json
+++ b/packer/scylla.json
@@ -63,7 +63,12 @@
       "ssh_timeout": "5m",
       "ssh_username": "{{user `ssh_username`}}",
       "ssh_clear_authorized_keys": true,
-      "subnet_id": "{{user `subnet_id`}}",
+      "subnet_filter": {
+          "filters": {
+              "tag:Name": "image-build-subnet*"
+          },
+          "random": true
+      },
       "user_data_file": "user_data.txt",
       "ami_description": "{{user `scylla_ami_description`}}",
       "tags": {


### PR DESCRIPTION
fix for ERROR: "im4gn.xlarge capacity issue in Availability Zone (us-east-1b)" during AMI creation with packer build.

`subnet_id` variable changed to `subnet_filter` with `tag:Name` and `random` selection, which includes few available subnets (and not one dedicated subnet).

It also allow us to be more dynamic and update `tag:Name` of subnets in AWS config directly - to remove or add subnets 