### PR TITLE
packer: fix provision race-conditions following reboot

### DIFF
--- a/packer/scylla.json
+++ b/packer/scylla.json
@@ -186,7 +186,8 @@
     {
       "destination": "/home/{{user `ssh_username`}}/",
       "source": "files/",
-      "type": "file"
+      "type": "file",
+      "pause_before": "10s"
     },
     {
       "destination": "/home/{{user `ssh_username`}}/",


### PR DESCRIPTION
I found out that (periodically) the GCE build fails on uploading the files to packer instance
```
14:10:39  [0;32m    gce: NEEDRESTART-KEXP: 5.15.0-1035-gcp[0m
14:10:39  [0;32m    gce: NEEDRESTART-KSTA: 3[0m
14:10:43  [1;32m==> gce: Uploading files/ => /home/ubuntu/[0m
14:11:03  [1;31m==> gce: Upload failed: wait: remote command exited without exit status or exit signal[0m
.....
14:11:50  [1;31mBuild 'gce' errored after 2 minutes 30 seconds: wait: remote command exited without exit status or exit signal[0m
14:11:50  
14:11:50  ==> Wait completed after 2 minutes 30 seconds
14:11:50  
14:11:50  ==> Some builds didn't complete successfully and had errors:
14:11:50  --> gce: wait: remote command exited without exit status or exit signal
14:11:50  
14:11:50  ==> Builds finished but no artifacts were created.
````


According to packer [0] it might be caused by the reboot action (part of the kernel-install recently added)
causes race conditions between the provisions

> Sometimes, when executing a command like reboot, the shell script
will return and Packer will start executing the next one before SSH actually quits and the machine restarts

We should handle it with `pause_before` - I set it to 10s, if it's not gonna help I'll increase it to 20s and add the `ssh_read_write_timeout`

[0] https://developer.hashicorp.com/packer/docs/provisioners/shell#handling-reboots