### PR TITLE
packer: increase pause_before value and add ssh_read_write_timeout

### DIFF
--- a/packer/scylla.json
+++ b/packer/scylla.json
@@ -61,6 +61,7 @@
           "most_recent": true
       },
       "ssh_timeout": "5m",
+      "ssh_read_write_timeout": "5m",
       "ssh_username": "{{user `ssh_username`}}",
       "ssh_clear_authorized_keys": true,
       "subnet_filter": {
@@ -100,6 +101,7 @@
       "source_image_family": "{{user `source_image_family`}}",
       "ssh_username": "{{user `ssh_username`}}",
       "ssh_timeout": "6m",
+      "ssh_read_write_timeout": "5m",
       "project_id": "{{user `project_id`}}",
       "zone": "{{user `zone`}}",
       "image_storage_locations": ["{{user `image_storage_location`}}"],
@@ -136,6 +138,8 @@
       "name": "azure",
       "type": "azure-arm",
       "ssh_username": "{{user `ssh_username`}}",
+      "ssh_timeout": "5m",
+      "ssh_read_write_timeout": "5m",
       "client_id": "{{user `client_id`}}",
       "client_secret": "{{user `client_secret`}}",
       "tenant_id": "{{user `tenant_id`}}",
@@ -187,7 +191,7 @@
       "destination": "/home/{{user `ssh_username`}}/",
       "source": "files/",
       "type": "file",
-      "pause_before": "10s"
+      "pause_before": "20s"
     },
     {
       "destination": "/home/{{user `ssh_username`}}/",


### PR DESCRIPTION
After adding the `pause_before` param on db75e41 I saw that we have SSH connection issues, so in this PR I'm increasing the pause to 20s and adding the `ssh_read_write_timeout` param

Example failure:

```
10:08:16  [1;32m==> aws: Pausing 10s before the next provisioner...[0m
10:08:27  [1;32m==> aws: Uploading files/ => /home/ubuntu/[0m
10:08:30  [1;31m==> aws: Upload failed: dial tcp 54.198.229.78:22: connect: connection refused[0m
10:08:30  [1;32m==> aws: Provisioning step had errors: Running the cleanup provisioner, if present...[0m
10:08:30  [1;32m==> aws: Terminating the source AWS instance...[0m
10:09:36  [1;32m==> aws: Cleaning up any extra volumes...[0m
10:09:36  [1;32m==> aws: No volumes to clean up, skipping[0m
10:09:36  [1;32m==> aws: Deleting temporary keypair...[0m
10:09:36  [1;31mBuild 'aws' errored after 2 minutes 23 seconds: dial tcp 54.198.229.78:22: connect: connection refused[0m
10:09:36  
10:09:36  ==> Wait completed after 2 minutes 23 seconds
10:09:36  
10:09:36  ==> Some builds didn't complete successfully and had errors:
10:09:36  --> aws: dial tcp 54.198.229.78:22: connect: connection refused
10:09:36  
10:09:36  ==> Builds finished but no artifacts were created.
```