### PR TITLE
scylla_install_image:remove /var/cache/debconf/config.dat after image creation

### DIFF
--- a/packer/scylla_install_image
+++ b/packer/scylla_install_image
@@ -170,6 +170,7 @@ WantedBy=multi-user.target
 
     os.remove('{}/.ssh/authorized_keys'.format(homedir))
     os.remove('/var/lib/scylla-housekeeping/housekeeping.uuid')
+    os.remove('/var/cache/debconf/config.dat')
 
     with open('/etc/default/grub.d/50-cloudimg-settings.cfg') as f:
         grub = f.read()


### PR DESCRIPTION


during our rolling-upgrade process, we keep getting the following failure:
```
Command: 'sudo DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confold" -o Dpkg::Options::="--force-confdef" upgrade -y '
Exit code: 100
Stdout:
linux-aws linux-headers-aws linux-image-aws
0 upgraded, 0 newly installed, 0 to remove and 3 not upgraded.
1 not fully installed or removed.
After this operation, 0 B of additional disk space will be used.
Setting up shim-signed (1.40.9+15.7-0ubuntu1) ...
mount: /var/lib/grub/esp: special device /dev/disk/by-id/nvme-Amazon_Elastic_Block_Store_vol0b2a94761ddb1d0c5-part15 does not exist.
dpkg: error processing package shim-signed (--configure):
installed shim-signed package post-installation script subprocess returned error exit status 32
Errors were encountered while processing:
shim-signed
Stderr:
E: Sub-process /usr/bin/dpkg returned an error code (1)
```

Happened for all images

As suggested by @syuu1228, let's remove `config.dat` once we complete the image creation

Closes: https://github.com/scylladb/scylla-enterprise/issues/2818