### PR TITLE
gce: drop rsyslog for branch-5.3

### DIFF
--- a/packer/scylla_install_image
+++ b/packer/scylla_install_image
@@ -125,6 +125,8 @@ if __name__ == '__main__':
         kernel_opt = ''
         grub_variable = 'GRUB_CMDLINE_LINUX_DEFAULT'
     elif args.target_cloud == 'gce':
+        # align with other clouds image
+        run('apt-get purge -y rsyslog', shell=True, check=True)
         sysconfig_opt = '--disable-writeback-cache'
         kernel_opt = ''
         grub_variable = 'GRUB_CMDLINE_LINUX_DEFAULT'


### PR DESCRIPTION
On AWS and Azure Ubuntu Minimal image we don't have rsyslog, it just uses persistent journal log, but only GCE image has rsyslog. We want to align image configuration between clouds, let's drop rsyslog from GCE image.

Related scylladb/scylla-enterprise#3080

(cherry picked from commit a63350da21eddc2577604e182e73b7c54c59affb)