### PR TITLE
scylla_cloud_io_setup: add preset configuration for all supported instance types on EC2

### DIFF
--- a/common/scylla_cloud_io_setup
+++ b/common/scylla_cloud_io_setup
@@ -81,6 +81,172 @@ class aws_io_setup(cloud_io_setup):
             self.disk_properties["read_bandwidth"] = 507338935 * nr_disks
             self.disk_properties["write_iops"] = 57100 * nr_disks
             self.disk_properties["write_bandwidth"] = 483141731 * nr_disks
+        elif idata.instance_class() in ("m5d", "r5d"):
+            if idata.instance_size() == "large":
+                disk_properties["read_iops"] = 33271
+                disk_properties["read_bandwidth"] = 158538149
+                disk_properties["write_iops"] = 16820
+                disk_properties["write_bandwidth"] = 70219810
+            elif idata.instance_size() == "xlarge":
+                disk_properties["read_iops"] = 65979
+                disk_properties["read_bandwidth"] = 260654293
+                disk_properties["write_iops"] = 32534
+                disk_properties["write_bandwidth"] = 135897424
+            elif idata.instance_size() == "2xlarge":
+                disk_properties["read_iops"] = 130095
+                disk_properties["read_bandwidth"] = 621758272
+                disk_properties["write_iops"] = 63644
+                disk_properties["write_bandwidth"] = 267667525
+            elif idata.instance_size() == "4xlarge":
+                disk_properties["read_iops"] = 129822 * nr_disks
+                disk_properties["read_bandwidth"] = 620878826 * nr_disks
+                disk_properties["write_iops"] = 63212 * nr_disks
+                disk_properties["write_bandwidth"] = 267703397 * nr_disks
+            elif idata.instance_size() == "8xlarge":
+                disk_properties["read_iops"] = 257069 * nr_disks
+                disk_properties["read_bandwidth"] = 1250134869 * nr_disks
+                disk_properties["write_iops"] = 115433 * nr_disks
+                disk_properties["write_bandwidth"] = 532868032 * nr_disks
+            elif idata.instance_size() == "12xlarge":
+                disk_properties["read_iops"] = 381626 * nr_disks
+                disk_properties["read_bandwidth"] = 1865794816 * nr_disks
+                disk_properties["write_iops"] = 115333 * nr_disks
+                disk_properties["write_bandwidth"] = 795884800 * nr_disks
+            elif idata.instance_size() == "16xlarge":
+                disk_properties["read_iops"] = 257054 * nr_disks
+                disk_properties["read_bandwidth"] = 1254133802 * nr_disks
+                disk_properties["write_iops"] = 108163 * nr_disks
+                disk_properties["write_bandwidth"] = 532996277 * nr_disks
+            elif idata.instance_size() == "24xlarge":
+                disk_properties["read_iops"] = 374737 * nr_disks
+                disk_properties["read_bandwidth"] = 1855833386 * nr_disks
+                disk_properties["write_iops"] = 125214 * nr_disks
+                disk_properties["write_bandwidth"] = 796082133 * nr_disks
+            elif idata.instance_size() == "metal":
+                disk_properties["read_iops"] = 381441 * nr_disks
+                disk_properties["read_bandwidth"] = 1874585429 * nr_disks
+                disk_properties["write_iops"] = 108789 * nr_disks
+                disk_properties["write_bandwidth"] = 796443221 * nr_disks
+        elif idata.instance() == "m5ad.large":
+            disk_properties["read_iops"] = 33306
+            disk_properties["read_bandwidth"] = 158338864
+            disk_properties["write_iops"] = 16817
+            disk_properties["write_bandwidth"] = 70194288
+        elif idata.instance() == "m5ad.xlarge":
+            disk_properties["read_iops"] = 66127
+            disk_properties["read_bandwidth"] = 260377466
+            disk_properties["write_iops"] = 32893
+            disk_properties["write_bandwidth"] = 135897696
+        elif idata.instance() == "m5ad.2xlarge":
+            disk_properties["read_iops"] = 129977
+            disk_properties["read_bandwidth"] = 621997248
+            disk_properties["write_iops"] = 63442
+            disk_properties["write_bandwidth"] = 267648736
+        elif idata.instance() == "m5ad.4xlarge":
+            disk_properties["read_iops"] = 129937 * nr_disks
+            disk_properties["read_bandwidth"] = 620231082 * nr_disks
+            disk_properties["write_iops"] = 62666 * nr_disks
+            disk_properties["write_bandwidth"] = 267639125 * nr_disks
+        elif idata.instance() == "m5ad.8xlarge":
+            disk_properties["read_iops"] = 257095 * nr_disks
+            disk_properties["read_bandwidth"] = 1249927637 * nr_disks
+            disk_properties["write_iops"] = 114446 * nr_disks
+            disk_properties["write_bandwidth"] = 532821760 * nr_disks
+        elif idata.instance() == "m5ad.12xlarge":
+            disk_properties["read_iops"] = 376431 * nr_disks
+            disk_properties["read_bandwidth"] = 1865866709 * nr_disks
+            disk_properties["write_iops"] = 115985 * nr_disks
+            disk_properties["write_bandwidth"] = 796003477 * nr_disks
+        elif idata.instance() == "m5ad.16xlarge":
+            disk_properties["read_iops"] = 256358 * nr_disks
+            disk_properties["read_bandwidth"] = 1250889770 * nr_disks
+            disk_properties["write_iops"] = 114707 * nr_disks
+            disk_properties["write_bandwidth"] = 532998506 * nr_disks
+        elif idata.instance() == "m5ad.24xlarge":
+            disk_properties["read_iops"] = 258951 * nr_disks
+            disk_properties["read_bandwidth"] = 1865871317 * nr_disks
+            disk_properties["write_iops"] = 116030 * nr_disks
+            disk_properties["write_bandwidth"] = 796217706 * nr_disks
+        elif idata.instance() == "c5d.large":
+            disk_properties["read_iops"] = 22095
+            disk_properties["read_bandwidth"] = 104797834
+            disk_properties["write_iops"] = 10125
+            disk_properties["write_bandwidth"] = 41982906
+        elif idata.instance() == "c5d.xlarge":
+            disk_properties["read_iops"] = 44355
+            disk_properties["read_bandwidth"] = 212593018
+            disk_properties["write_iops"] = 20025
+            disk_properties["write_bandwidth"] = 84213472
+        elif idata.instance() == "c5d.2xlarge":
+            disk_properties["read_iops"] = 89036
+            disk_properties["read_bandwidth"] = 426821429
+            disk_properties["write_iops"] = 41697
+            disk_properties["write_bandwidth"] = 173730709
+        elif idata.instance() == "c5d.4xlarge":
+            disk_properties["read_iops"] = 193970
+            disk_properties["read_bandwidth"] = 928278314
+            disk_properties["write_iops"] = 83058
+            disk_properties["write_bandwidth"] = 351839733
+        elif idata.instance() == "c5d.9xlarge":
+            disk_properties["read_iops"] = 381800
+            disk_properties["read_bandwidth"] = 1865831893
+            disk_properties["write_iops"] = 112264
+            disk_properties["write_bandwidth"] = 795731264
+        elif idata.instance() == "c5d.12xlarge":
+            disk_properties["read_iops"] = 381775 * nr_disks
+            disk_properties["read_bandwidth"] = 1866481792 * nr_disks
+            disk_properties["write_iops"] = 114302 * nr_disks
+            disk_properties["write_bandwidth"] = 795607616 * nr_disks
+        elif idata.instance() == "c5d.18xlarge":
+            disk_properties["read_iops"] = 381270 * nr_disks
+            disk_properties["read_bandwidth"] = 1856972330 * nr_disks
+            disk_properties["write_iops"] = 125638 * nr_disks
+            disk_properties["write_bandwidth"] = 795813866 * nr_disks
+        elif idata.instance() == "c5d.24xlarge":
+            disk_properties["read_iops"] = 381355 * nr_disks
+            disk_properties["read_bandwidth"] = 1876056704 * nr_disks
+            disk_properties["write_iops"] = 104946 * nr_disks
+            disk_properties["write_bandwidth"] = 795901013 * nr_disks
+        elif idata.instance() == "c5d.metal":
+            disk_properties["read_iops"] = 381330 * nr_disks
+            disk_properties["read_bandwidth"] = 1865216426 * nr_disks
+            disk_properties["write_iops"] = 115484 * nr_disks
+            disk_properties["write_bandwidth"] = 796109546 * nr_disks
+        elif idata.instance() == "z1d.large":
+            disk_properties["read_iops"] = 33286
+            disk_properties["read_bandwidth"] = 158206858
+            disk_properties["write_iops"] = 16956
+            disk_properties["write_bandwidth"] = 70226280
+        elif idata.instance() == "z1d.xlarge":
+            disk_properties["read_iops"] = 66076
+            disk_properties["read_bandwidth"] = 260565488
+            disk_properties["write_iops"] = 32769
+            disk_properties["write_bandwidth"] = 135891989
+        elif idata.instance() == "z1d.2xlarge":
+            disk_properties["read_iops"] = 130235
+            disk_properties["read_bandwidth"] = 622297194
+            disk_properties["write_iops"] = 63891
+            disk_properties["write_bandwidth"] = 267679509
+        elif idata.instance() == "z1d.3xlarge":
+            disk_properties["read_iops"] = 193840
+            disk_properties["read_bandwidth"] = 927493696
+            disk_properties["write_iops"] = 82864
+            disk_properties["write_bandwidth"] = 351608480
+        elif idata.instance() == "z1d.6xlarge":
+            disk_properties["read_iops"] = 381902
+            disk_properties["read_bandwidth"] = 1865543381
+            disk_properties["write_iops"] = 117874
+            disk_properties["write_bandwidth"] = 795786901
+        elif idata.instance() == "z1d.12xlarge":
+            disk_properties["read_iops"] = 381648 * nr_disks
+            disk_properties["read_bandwidth"] = 1865706538 * nr_disks
+            disk_properties["write_iops"] = 115834 * nr_disks
+            disk_properties["write_bandwidth"] = 795876778 * nr_disks
+        elif idata.instance() == "z1d.metal":
+            disk_properties["read_iops"] = 381378 * nr_disks
+            disk_properties["read_bandwidth"] = 1857873109 * nr_disks
+            disk_properties["write_iops"] = 122453 * nr_disks
+            disk_properties["write_bandwidth"] = 795593024 * nr_disks
         elif self.idata.instance_class() in ("c6gd", "m6gd", "r6gd", "x2gd"):
             if self.idata.instance_size() == "medium":
                 self.disk_properties["read_iops"] = 14808


### PR DESCRIPTION
Since we merged https://github.com/scylladb/scylladb/commit/817f34d1a94a1daa1e8591c93a047081d51f5628, we are missing preset configuration for c5d, m5d, m5ad, r5d, z1d. On such instance, our AMI causes error during startup (see scylladb/scylladb#9660).
To fix the problem, we need to add preset configuration for these instance types.