### PR TITLE
scylla_cloud.py:Add `i4g` to supported instances

### DIFF
--- a/lib/scylla_cloud.py
+++ b/lib/scylla_cloud.py
@@ -742,7 +742,7 @@ class aws_instance(cloud_instance):
         return self._type.split(".")[0]
 
     def is_supported_instance_class(self):
-        if self.instance_class() in ['i2', 'i3', 'i3en', 'c5d', 'm5d', 'm5ad', 'r5d', 'z1d', 'c6gd', 'm6gd', 'r6gd', 'x2gd', 'im4gn', 'is4gen', 'i4i']:
+        if self.instance_class() in ['i2', 'i3', 'i3en', 'c5d', 'm5d', 'm5ad', 'r5d', 'z1d', 'c6gd', 'm6gd', 'r6gd', 'x2gd', 'im4gn', 'is4gen', 'i4i', 'i4g']:
             return True
         return False
 


### PR DESCRIPTION
Following the changes in
https://github.com/scylladb/scylla-machine-image/pull/460, we need also to add `i4g` to list of instance_class

This will prevent the following error during image startup
```
Version:
        5.4.0~dev-0.20230829.83ceedb18bdc
Nodetool:
        nodetool help
CQL Shell:
        cqlsh
More documentation available at:
        https://docs.scylladb.com/
By default, Scylla sends certain information about this node to a data collection server. For more details, see https://www.scylladb.com/privacy/

    i4g is not eligible for optimized automatic tuning!

To continue the setup of Scylla on this instance, run 'sudo scylla_io_setup'
then 'sudo systemctl start scylla-server'.
For a list of optimized instance types and more instructions, see http://www.scylladb.com/doc/getting-started-amazon/
```

Ref: https://github.com/scylladb/scylla-pkg/pull/3556