### PR TITLE
[azure]:fix resource cleanup retry

### DIFF
--- a/packer/scylla.json
+++ b/packer/scylla.json
@@ -168,6 +168,7 @@
       },
       "vm_size": "{{user `vm_size`}}",
       "build_resource_group_name": "scylla-images",
+      "async_resourcegroup_delete": true,
       "keep_os_disk": true,
       "virtual_network_name": "scylla-images",
       "private_virtual_network_with_public_ip": true


### PR DESCRIPTION
During azure image build we keep seeing:
```
07:39:44  ␛[1;32m==> azure: Error deleting resource. Will retry.
07:39:44  ==> azure: Name: pkrip4th7si0bxq
07:39:44  ==> azure: Error: network.PublicIPAddressesClient#Delete: Failure sending request: StatusCode=400 -- Original Error: Code="PublicIPAddressCannotBeDeleted" Message="Public IP address /subscriptions/****/resourceGroups/scylla-images/providers/Microsoft.Network/publicIPAddresses/pkrip4th7si0bxq can not be deleted since it is still allocated to resource /subscriptions/****/resourceGroups/scylla-images/providers/Microsoft.Network/networkInterfaces/pkrni4th7si0bxq/ipConfigurations/ipconfig. In order to delete the public IP, disassociate/detach the Public IP address from the resource.  To learn how to do this, see aka.ms/deletepublicip." Details=[]
```

Closes: https://github.com/scylladb/scylla-pkg/issues/3021