### PR TITLE
Support developer-mode instance types

### DIFF
--- a/common/scylla_configure.py
+++ b/common/scylla_configure.py
@@ -106,7 +106,7 @@ class ScyllaMachineImageConfigurator(UserData):
 
     def set_developer_mode(self):
         default_developer_mode = self.CONF_DEFAULTS["developer_mode"]
-        if self.instance_user_data.get("developer_mode", default_developer_mode):
+        if self.instance_user_data.get("developer_mode", default_developer_mode) or self.cloud_instance.is_dev_instance_type():
             LOGGER.info("Setting up developer mode")
             subprocess.run(['/usr/sbin/scylla_dev_mode_setup', '--developer-mode', '1'], timeout=60, check=True)
 

--- a/common/scylla_login
+++ b/common/scylla_login
@@ -48,6 +48,12 @@ next run 'sudo scylla_create_devices', 'sudo scylla_io_setup'
 then 'sudo systemctl start scylla-server'.
 For a list of optimized instance types and more instructions, see %s
 '''[1:-1]
+MSG_DEV_INSTANCE_TYPE = '''
+    {yellow}WARNING: {type} is intended for development purposes only and should not be used in production environments!
+    This ScyllaDB instance is running in developer-mode.{nocolor}
+
+For a list of supported instance types and more instructions, please refer to %s
+'''[1:-1]
 MSG_SETUP_ACTIVATING = '''
     {green}Constructing RAID volume...{nocolor}
 
@@ -105,12 +111,13 @@ $ nodetool status
 if __name__ == '__main__':
     colorprint(MSG_HEADER.format(scylla_version=out("scylla --version")))
     cloud_instance = get_cloud_instance()
-    if not cloud_instance.is_supported_instance_class():
+    if cloud_instance.is_dev_instance_type():
+        colorprint(MSG_DEV_INSTANCE_TYPE % cloud_instance.getting_started_url, type=cloud_instance.instancetype)
+    elif not cloud_instance.is_supported_instance_class():
         non_root_disks = cloud_instance.get_local_disks() + cloud_instance.get_remote_disks()
         if len(non_root_disks) == 0:
             colorprint(MSG_UNSUPPORTED_INSTANCE_TYPE_NO_DISKS % cloud_instance.getting_started_url,
                 type=cloud_instance.instance_class())
-
         else:
             colorprint(MSG_UNSUPPORTED_INSTANCE_TYPE % cloud_instance.getting_started_url,
                 type=cloud_instance.instance_class())

--- a/lib/scylla_cloud.py
+++ b/lib/scylla_cloud.py
@@ -93,6 +93,10 @@ class cloud_instance(metaclass=ABCMeta):
     def is_supported_instance_class(self):
         pass
 
+    @abstractmethod
+    def is_dev_instance_type(self):
+        pass
+
     @property
     @abstractmethod
     def instancetype(self):
@@ -318,6 +322,11 @@ class gcp_instance(cloud_instance):
     def is_recommended_instance_size(self):
         """if this instance has at least 2 cpus, it has a recommended size"""
         if int(self.instance_size()) > 1:
+            return True
+        return False
+
+    def is_dev_instance_type(self):
+        if self.instancetype in ['e2-micro', 'e2-small', 'e2-medium']:
             return True
         return False
 
@@ -602,6 +611,9 @@ class azure_instance(cloud_instance):
             return True
         return False
 
+    def is_dev_instance_type(self):
+        return False
+
     def private_ipv4(self):
         return self.__instance_metadata("/network/interface/0/ipv4/ipAddress/0/privateIpAddress")
 
@@ -746,6 +758,9 @@ class aws_instance(cloud_instance):
             return True
         return False
 
+    def is_dev_instance_type(self):
+        return False
+
     def get_en_interface_type(self):
         instance_class = self.instance_class()
         instance_size = self.instance_size()
@@ -844,7 +859,7 @@ def get_cloud_instance():
         raise Exception("Unknown cloud provider! Only AWS/GCP/Azure supported.")
 
 
-CONCOLORS = {'green': '\033[1;32m', 'red': '\033[1;31m', 'nocolor': '\033[0m'}
+CONCOLORS = {'green': '\033[1;32m', 'red': '\033[1;31m', 'yellow': '\033[1;33m', 'nocolor': '\033[0m'}
 
 
 def colorprint(msg, **kwargs):


### PR DESCRIPTION
Currently, attempting to launch machine-image-setup on instances that don't meet scylla's requirements would result in setup failures,

This commit adds support for developer-mode instance types. when users launch these instances, scylla will run on `developer-mode`, and a WARN message will be displayed in the login message to inform users about the intended usage of these instances.

Fix: #477