### PR TITLE
Fix broken link to the getting-started page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 build
+__pycache__
+.venv
+

--- a/common/scylla_login
+++ b/common/scylla_login
@@ -35,24 +35,25 @@ By default, Scylla sends certain information about this node to a data collectio
 MSG_UNSUPPORTED_INSTANCE_TYPE = '''
     {red}{type} is not eligible for optimized automatic tuning!{nocolor}
 
-To continue the setup of Scylla on this instance, run 'sudo scylla_io_setup' 
-then 'sudo systemctl start scylla-server'.
-For a list of optimized instance types and more instructions, see %s
+To continue the setup of Scylla on this instance, run 'sudo scylla_io_setup' then 'sudo systemctl start scylla-server'.
+For a list of optimized instance types and more instructions, see the requirements section in the 
+ScyllaDB documentation at https://docs.scylladb.com
 
 '''[1:-1]
 MSG_UNSUPPORTED_INSTANCE_TYPE_NO_DISKS = '''
     {red}{type} is not eligible for optimized automatic tuning!{nocolor}
 
-To continue the setup of Scylla on this instance, you need to attach additional disks, 
-next run 'sudo scylla_create_devices', 'sudo scylla_io_setup' 
-then 'sudo systemctl start scylla-server'.
-For a list of optimized instance types and more instructions, see %s
+To continue the setup of Scylla on this instance, you need to attach additional disks, next run 'sudo scylla_create_devices',
+'sudo scylla_io_setup' then 'sudo systemctl start scylla-server'.
+For a list of optimized instance types and more instructions, see the requirements section in the
+ScyllaDB documentation at https://docs.scylladb.com
 '''[1:-1]
 MSG_DEV_INSTANCE_TYPE = '''
     {yellow}WARNING: {type} is intended for development purposes only and should not be used in production environments!
     This ScyllaDB instance is running in developer-mode.{nocolor}
 
-For a list of supported instance types and more instructions, please refer to %s
+For a list of optimized instance types and more instructions, see the requirements section in the
+ScyllaDB documentation at https://docs.scylladb.com
 '''[1:-1]
 MSG_SETUP_ACTIVATING = '''
     {green}Constructing RAID volume...{nocolor}
@@ -112,15 +113,13 @@ if __name__ == '__main__':
     colorprint(MSG_HEADER.format(scylla_version=out("scylla --version")))
     cloud_instance = get_cloud_instance()
     if cloud_instance.is_dev_instance_type():
-        colorprint(MSG_DEV_INSTANCE_TYPE % cloud_instance.getting_started_url, type=cloud_instance.instancetype)
+        colorprint(MSG_DEV_INSTANCE_TYPE, type=cloud_instance.instancetype)
     elif not cloud_instance.is_supported_instance_class():
         non_root_disks = cloud_instance.get_local_disks() + cloud_instance.get_remote_disks()
         if len(non_root_disks) == 0:
-            colorprint(MSG_UNSUPPORTED_INSTANCE_TYPE_NO_DISKS % cloud_instance.getting_started_url,
-                type=cloud_instance.instance_class())
+            colorprint(MSG_UNSUPPORTED_INSTANCE_TYPE_NO_DISKS, type=cloud_instance.instance_class())
         else:
-            colorprint(MSG_UNSUPPORTED_INSTANCE_TYPE % cloud_instance.getting_started_url,
-                type=cloud_instance.instance_class())
+            colorprint(MSG_UNSUPPORTED_INSTANCE_TYPE, type=cloud_instance.instance_class())
     else:
         skip_scylla_server = False
         if not os.path.exists('/etc/scylla/machine_image_configured'):

--- a/lib/scylla_cloud.py
+++ b/lib/scylla_cloud.py
@@ -129,10 +129,6 @@ class cloud_instance(metaclass=ABCMeta):
     def endpoint_snitch(self):
         pass
 
-    @property
-    @abstractmethod
-    def getting_started_url(self):
-        pass
 
 
 class gcp_instance(cloud_instance):
@@ -141,7 +137,6 @@ class gcp_instance(cloud_instance):
     EPHEMERAL = "ephemeral"
     PERSISTENT = "persistent"
     ROOT = "root"
-    GETTING_STARTED_URL = "http://www.scylladb.com/doc/getting-started-google/"
     META_DATA_BASE_URL = "http://metadata.google.internal/computeMetadata/v1/instance/"
     ENDPOINT_SNITCH = "GoogleCloudSnitch"
 
@@ -157,9 +152,6 @@ class gcp_instance(cloud_instance):
     def endpoint_snitch(self):
         return self.ENDPOINT_SNITCH
 
-    @property
-    def getting_started_url(self):
-        return self.GETTING_STARTED_URL
 
     @staticmethod
     def is_gce_instance():
@@ -416,7 +408,6 @@ class azure_instance(cloud_instance):
     PERSISTENT = "persistent"
     SWAP = "swap"
     ROOT = "root"
-    GETTING_STARTED_URL = "http://www.scylladb.com/doc/getting-started-azure/"
     ENDPOINT_SNITCH = "AzureSnitch"
     META_DATA_BASE_URL = "http://169.254.169.254/metadata/instance"
 
@@ -433,10 +424,6 @@ class azure_instance(cloud_instance):
     @property
     def endpoint_snitch(self):
         return self.ENDPOINT_SNITCH
-
-    @property
-    def getting_started_url(self):
-        return self.GETTING_STARTED_URL
 
     @classmethod
     def is_azure_instance(cls):
@@ -637,7 +624,6 @@ class azure_instance(cloud_instance):
 
 class aws_instance(cloud_instance):
     """Describe several aspects of the current AWS instance"""
-    GETTING_STARTED_URL = "http://www.scylladb.com/doc/getting-started-amazon/"
     META_DATA_BASE_URL = "http://169.254.169.254/latest/"
     ENDPOINT_SNITCH = "Ec2Snitch"
     METADATA_TOKEN_TTL = 21600
@@ -730,9 +716,6 @@ class aws_instance(cloud_instance):
     def endpoint_snitch(self):
         return self.ENDPOINT_SNITCH
 
-    @property
-    def getting_started_url(self):
-        return self.GETTING_STARTED_URL
 
     @classmethod
     def is_aws_instance(cls):

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,3 +4,4 @@ psutil==5.9.1
 pytest==7.1.2
 PyYAML==6.0
 traceback-with-variables==2.0.4
+boto3==1.28.49

--- a/tests/test_aws_instance.py
+++ b/tests/test_aws_instance.py
@@ -226,11 +226,6 @@ vpc-ipv6-cidr-blocks
         ins = aws_instance()
         assert ins.endpoint_snitch == 'Ec2Snitch'
 
-    def test_getting_started_url(self):
-        self.httpretty_aws_metadata()
-        ins = aws_instance()
-        assert ins.getting_started_url == 'http://www.scylladb.com/doc/getting-started-amazon/'
-
     def test_instancetype_i3en_2xlarge(self):
         self.httpretty_aws_metadata()
         ins = aws_instance()

--- a/tests/test_azure_instance.py
+++ b/tests/test_azure_instance.py
@@ -117,11 +117,6 @@ network/
         ins = azure_instance()
         assert ins.endpoint_snitch == 'AzureSnitch'
 
-    def test_getting_started_url(self):
-        self.httpretty_azure_metadata()
-        ins = azure_instance()
-        assert ins.getting_started_url == 'http://www.scylladb.com/doc/getting-started-azure/'
-
     def test_instancelocation_standard_l16s_v2(self):
         self.httpretty_azure_metadata()
         ins = azure_instance()

--- a/tests/test_gcp_instance.py
+++ b/tests/test_gcp_instance.py
@@ -96,11 +96,6 @@ class TestGcpInstance(TestCase):
         ins = gcp_instance()
         assert ins.endpoint_snitch == 'GoogleCloudSnitch'
 
-    def test_getting_started_url(self):
-        self.httpretty_gcp_metadata()
-        ins = gcp_instance()
-        assert ins.getting_started_url == 'http://www.scylladb.com/doc/getting-started-google/'
-
     def test_instancetype_n2_standard_8(self):
         self.httpretty_gcp_metadata()
         ins = gcp_instance()


### PR DESCRIPTION
The previous links `/getting-started-google` and `/getting-started-azure` didn't exist
Ideally, we should refer to [0] but it's an OS page and I don't
want to add OS vs. Enterprise condition so for now let's go without a direct link

This PR also contains the following two minor changes

- https://github.com/scylladb/scylla-machine-image/commit/62752d746f4e0c789ea08a5c9bbc2a325b3a3a98 - Update gitignore
- https://github.com/scylladb/scylla-machine-image/commit/010fc98dc1be6c32a586ffe51e3eae83ae8abbef - Add boto3 as test-requirements


[0] https://opensource.docs.scylladb.com/master/getting-started/cloud-instance-recommendations
