### PR TITLE
AWS: add t3.micro as dev-mode instance

### DIFF
--- a/lib/scylla_cloud.py
+++ b/lib/scylla_cloud.py
@@ -745,6 +745,8 @@ class aws_instance(cloud_instance):
         return False
 
     def is_dev_instance_type(self):
+        if self.instancetype in ['t3.micro']:
+            return True
         return False
 
     def get_en_interface_type(self):


### PR DESCRIPTION
Following the dev-mode instances support was added on https://github.com/scylladb/scylla-machine-image/pull/479
This change adds the t3.micro as AWS dev-mode instance


cc @carlosms 