### PR TITLE
scylla_conifgure.py: remove "experimental" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ listed here only the one get defaults scylla AMI
 
 * **Object Properties**    
     * **cluster_name** ([*string*](https://docs.python.org/library/stdtypes.html#str)) – Name of the cluster (*default=`generated name that would work for only one node cluster`*)
-    * **experimental** ([*boolean*](https://docs.python.org/library/stdtypes.html#boolean-values)) – To enable all experimental features add to the scylla.yaml (*default=’false’*)
     * **auto_bootstrap** ([*boolean*](https://docs.python.org/library/stdtypes.html#boolean-values)) – Enable auto bootstrap (*default=’true’*)
     * **listen_address** ([*string*](https://docs.python.org/library/stdtypes.html#str)) – Defaults to ec2 instance private ip
     * **broadcast_rpc_address** ([*string*](https://docs.python.org/library/stdtypes.html#str)) – Defaults to ec2 instance private ip

--- a/common/scylla_configure.py
+++ b/common/scylla_configure.py
@@ -24,7 +24,6 @@ class ScyllaMachineImageConfigurator(UserData):
     CONF_DEFAULTS = {
         'scylla_yaml': {
             'cluster_name': "scylladb-cluster-%s" % int(time.time()),
-            'experimental': False,
             'auto_bootstrap': True,
             'listen_address': "",  # will be configured as a private IP when instance meta data is read
             'broadcast_rpc_address': "",  # will be configured as a private IP when instance meta data is read

--- a/tests/test_scylla_configure.py
+++ b/tests/test_scylla_configure.py
@@ -128,7 +128,6 @@ class TestScyllaConfigurator(TestCase):
             assert scylla_yaml["broadcast_rpc_address"] == ip_to_set
             assert scylla_yaml["seed_provider"][0]["parameters"][0]["seeds"] == ip_to_set
             # check defaults
-            assert scylla_yaml["experimental"] is False
             assert scylla_yaml["auto_bootstrap"] is True
 
     def test_postconfig_script(self):
@@ -202,7 +201,6 @@ class TestScyllaConfigurator(TestCase):
                 assert scylla_yaml["broadcast_rpc_address"] == ip_to_set
                 assert scylla_yaml["seed_provider"][0]["parameters"][0]["seeds"] == ip_to_set
                 # check defaults
-                assert scylla_yaml["experimental"] is False
                 assert scylla_yaml["auto_bootstrap"] is True
 
     def test_do_not_start_on_first_boot(self):


### PR DESCRIPTION
Following the changes done in https://github.com/scylladb/scylladb/pull/15233 . we need also remove the `Experimental` options in the machine-image


Closes: scylladb#484