### PR TITLE
scylla-machine-image:replace package during upgrade

### DIFF
--- a/dist/debian/control.template
+++ b/dist/debian/control.template
@@ -9,6 +9,7 @@ Rules-Requires-Root: no
 Package: %{product}-machine-image
 Architecture: all
 Depends: %{product}, %{product}-python3, ${shlibs:Depends}, ${misc:Depends}
+Replaces: scylla-machine-image
 Description: Scylla Machine Image
  Scylla is a highly scalable, eventually consistent, distributed,
  partitioned row DB.

--- a/dist/redhat/scylla-machine-image.spec
+++ b/dist/redhat/scylla-machine-image.spec
@@ -10,7 +10,7 @@ Source0:        %{name}-%{version}-%{release}.tar
 Requires:       %{product} = %{version} %{product}-python3 curl
 
 BuildArch:      noarch
-Obsoletes:      %{product}-ami
+Obsoletes:      scylla-machine-image
 
 %global _python_bytecompile_errors_terminate_build 0
 %global __brp_python_bytecompile %{nil}


### PR DESCRIPTION
When upgrading OSS to Enterprise we need to make sure `scylla-machine-image` will be replaced with `scylla-enterprise-machine-image` package

Adding `Obsoletes` indication in the .spec file and controle.template so scylla-enterprise-machine-image is a replacement for scylla-machine-image.

Closes: https://github.com/scylladb/scylla-enterprise-machine-image/issues/51

Closes: https://github.com/scylladb/scylla-enterprise-machine-image/issues/50