### PR TITLE
adding EC2 instance type option to use while building the AMI + change current default 

### DIFF
--- a/packer/build_image.sh
+++ b/packer/build_image.sh
@@ -274,7 +274,7 @@ if [ "$TARGET" = "aws" ]; then
         ;;
       "aarch64")
         SOURCE_AMI_FILTER="ubuntu-minimal/images/hvm-ssd/ubuntu-jammy-22.04-arm64*"
-        INSTANCE_TYPE="im4gn.xlarge"
+        INSTANCE_TYPE="im4gn.2xlarge"
         ;;
       *)
         echo "Unsupported architecture: $arch"

--- a/packer/build_image.sh
+++ b/packer/build_image.sh
@@ -19,7 +19,7 @@ APT_KEY='d0a112e067426ab2'
 
 print_usage() {
     echo "$0 --localdeb --repo [URL] --target [distribution]"
-    echo "  [--localdeb]          Deploy locally built debs Default: false"
+    echo "  [--localdeb]            Deploy locally built debs Default: false"
     echo "  --repo                  Repository for both install and update, specify .repo/.list file URL"
     echo "  --repo-for-install      Repository for install, specify .repo/.list file URL"
     echo "  --repo-for-update       Repository for update, specify .repo/.list file URL"
@@ -37,6 +37,7 @@ print_usage() {
     echo "  [--log-file]            Path for log. Default build/ami.log on current dir. Default: build/packer.log"
     echo "  --target                Target cloud (aws/gce/azure), mandatory when using this script directly, and not by soft links"
     echo "  --arch                  Set the image build architecture. Valid options: x86_64 | aarch64 . if use didn't pass this parameter it will use local node architecture"
+    echo "  --ec2-instance-type     Set EC2 instance type to use while building the AMI. If empty will use defaults per architecture"
     exit 1
 }
 LOCALDEB=0
@@ -96,7 +97,7 @@ while [ $# -gt 0 ]; do
             ;;
         "--ami-regions"):
             AMI_REGIONS=$2
-            echo "--ami-regions prameter: AMI_REGIONS |$AMI_REGIONS|"
+            echo "--ami-regions parameter: AMI_REGIONS |$AMI_REGIONS|"
             shift 2
             ;;
         "--ami-users"):
@@ -150,6 +151,10 @@ while [ $# -gt 0 ]; do
             ;;
         "--arch")
             ARCH="$2"
+            shift 2
+            ;;
+        "--ec2-instance-type")
+            INSTANCE_TYPE="$2"
             shift 2
             ;;
         *)
@@ -270,11 +275,15 @@ if [ "$TARGET" = "aws" ]; then
     case "$arch" in
       "x86_64")
         SOURCE_AMI_FILTER="ubuntu-minimal/images/hvm-ssd/ubuntu-jammy-22.04-amd64*"
-        INSTANCE_TYPE="c4.xlarge"
+        if [ -z "$INSTANCE_TYPE" ]; then
+          INSTANCE_TYPE="c4.xlarge"
+        fi
         ;;
       "aarch64")
         SOURCE_AMI_FILTER="ubuntu-minimal/images/hvm-ssd/ubuntu-jammy-22.04-arm64*"
-        INSTANCE_TYPE="im4gn.2xlarge"
+        if [ -z "$INSTANCE_TYPE" ]; then
+          INSTANCE_TYPE="im4gn.2xlarge"
+        fi
         ;;
       *)
         echo "Unsupported architecture: $arch"


### PR DESCRIPTION
This PR includes 2 commits:
- 780dd8753c90fad1b6933366fb64caf9bf8260c7 - change default INSTANCE_TYPE for ARM to im4gn.2xlarge
- 1bdf38e781ab40780d271a6825c90395fa51a723 - adding new 'ec2-instance-type' parameter