### PR TITLE
packer: increase pause_before to 40 seconds

### DIFF
--- a/packer/scylla.json
+++ b/packer/scylla.json
@@ -192,7 +192,7 @@
       "destination": "/home/{{user `ssh_username`}}/",
       "source": "files/",
       "type": "file",
-      "pause_before": "20s"
+      "pause_before": "40s"
     },
     {
       "destination": "/home/{{user `ssh_username`}}/",


### PR DESCRIPTION
Following an unknown SSH connection failure raised after the build-machine rebooted

Ref https://github.com/scylladb/scylla-pkg/issues/3646