### PR TITLE
[ami,gce]: reduce snapshot size to minimum allowed

### DIFF
--- a/packer/scylla.json
+++ b/packer/scylla.json
@@ -48,7 +48,7 @@
           "delete_on_termination": true,
           "device_name": "/dev/sda1",
           "volume_type": "gp3",
-          "volume_size": 30
+          "volume_size": 8
         }
       ],
       "region": "{{user `region`}}",

--- a/packer/scylla.json
+++ b/packer/scylla.json
@@ -4,40 +4,6 @@
       "name": "aws",
       "type": "amazon-ebs",
       "access_key": "{{user `access_key`}}",
-      "ami_block_device_mappings": [
-        {
-          "device_name": "/dev/sdb",
-          "virtual_name": "ephemeral0"
-        },
-        {
-          "device_name": "/dev/sdc",
-          "virtual_name": "ephemeral1"
-        },
-        {
-          "device_name": "/dev/sdd",
-          "virtual_name": "ephemeral2"
-        },
-        {
-          "device_name": "/dev/sde",
-          "virtual_name": "ephemeral3"
-        },
-        {
-          "device_name": "/dev/sdf",
-          "virtual_name": "ephemeral4"
-        },
-        {
-          "device_name": "/dev/sdg",
-          "virtual_name": "ephemeral5"
-        },
-        {
-          "device_name": "/dev/sdh",
-          "virtual_name": "ephemeral6"
-        },
-        {
-          "device_name": "/dev/sdi",
-          "virtual_name": "ephemeral7"
-        }
-      ],
       "ami_name": "{{user `image_name`| clean_resource_name}}",
       "associate_public_ip_address": "{{user `associate_public_ip_address`}}",
       "sriov_support": true,

--- a/packer/scylla.json
+++ b/packer/scylla.json
@@ -81,7 +81,7 @@
       "use_internal_ip": false,
       "preemptible": true,
       "omit_external_ip": false,
-      "disk_size": 30,
+      "disk_size": 10,
       "image_labels":  {
           "scylla_version": "{{user `scylla_full_version`| clean_resource_name}}",
           "scylla_machine_image_version": "{{user `scylla_machine_image_version`| clean_resource_name}}",


### PR DESCRIPTION
Every AMI we create today holds a 30Gb EBS snapshot, if we take into account the fact that we copy those images to other regions and have multiple images (dev, debug, releases) it is adding up to our cost.

This commit reduces the size of the snapshot to 8Gb (it's the minimum value allowed for a snapshot)

In addition, it's reducing also the time for the build process from 30 minutes to ~12 minutes (which is also good)

Refs: https://github.com/scylladb/scylla-pkg/issues/3712