### PR TITLE
Revert "pre-allocate swapfile while building image"

### DIFF
--- a/common/scylla_image_setup
+++ b/common/scylla_image_setup
@@ -11,9 +11,16 @@ from lib.scylla_cloud import get_cloud_instance, is_gce, is_azure, is_redhat_var
 from subprocess import run
 
 if __name__ == '__main__':
-    if is_azure() and not Path('/mnt/swapfile').exists():
-        Path('/etc/systemd/system/mnt-swapfile.swap').unlink(missing_ok=True)
-        run('/opt/scylladb/scripts/scylla_swap_setup --swap-directory /mnt', shell=True, check=True)
+    if is_azure():
+        swap_directory = Path('/mnt')
+        swap_unit = Path('/etc/systemd/system/mnt-swapfile.swap')
+    else:
+        swap_directory = Path('/')
+        swap_unit = Path('/etc/systemd/system/swapfile.swap')
+    swapfile = swap_directory / 'swapfile'
+    if not swapfile.exists():
+        swap_unit.unlink(missing_ok=True)
+        run(f'/opt/scylladb/scripts/scylla_swap_setup --swap-directory {swap_directory}', shell=True, check=True)
     machine_image_configured = Path('/etc/scylla/machine_image_configured')
     if not machine_image_configured.exists():
         # On Ubuntu, we configure CPU scaling while AMI building time

--- a/packer/scylla_install_image
+++ b/packer/scylla_install_image
@@ -33,10 +33,6 @@ def deb_arch():
     darch={'x86_64': 'amd64', 'aarch64': 'arm64'}
     return darch[arch()]
 
-def half_of_diskfree():
-    disk = os.statvfs('/')
-    return int((disk.f_bavail * disk.f_frsize) / 2)
-
 if __name__ == '__main__':
     if os.getuid() > 0:
         print('Requires root permission.')
@@ -144,8 +140,6 @@ if __name__ == '__main__':
     run('/opt/scylladb/scripts/scylla_cpuscaling_setup --force', shell=True, check=True)
 
     run(f'/opt/scylladb/scripts/scylla_sysconfig_setup --set-clocksource', shell=True, check=True)
-    if args.target_cloud == 'aws' or args.target_cloud == 'gce':
-        run(f'/opt/scylladb/scripts/scylla_swap_setup --swap-size-bytes {half_of_diskfree()} --swap-directory /', shell=True, check=True)
     run('/opt/scylladb/scripts/scylla_coredump_setup', shell=True, check=True)
     dot_mount = '''
 [Unit]


### PR DESCRIPTION
This reverts commit 069318bb48963aa5bede707579e499a8bd1288c4.

Related with #491, we need to reduce snapshot size of the rootfs, we should not pre-allocate swapfile while building image.