### PR TITLE
packer/scylla.json: Add `apt-get update` after kernel package removal

### DIFF
--- a/packer/scylla.json
+++ b/packer/scylla.json
@@ -177,7 +177,7 @@
     {
       "type": "shell",
       "inline": [
-        "if [ {{build_name}} = aws -o {{build_name}} = azure ]; then sudo apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt purge -y linux-{{build_name}}* linux-headers-{{build_name}}* linux-image*{{build_name}}* linux-modules*-{{build_name}}* && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y linux-{{build_name}}-lts-22.04 && sudo reboot; fi"
+        "if [ {{build_name}} = aws -o {{build_name}} = azure ]; then sudo apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt purge -y linux-{{build_name}}* linux-headers-{{build_name}}* linux-image*{{build_name}}* linux-modules*-{{build_name}}* && sudo apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y linux-{{build_name}}-lts-22.04 && sudo reboot; fi"
       ],
       "expect_disconnect": true
     },


### PR DESCRIPTION
From time to time we get the following error during Azure build:
```
�[0;32m    azure: Reading state information...�[0m
 �[1;31m==> azure: E: Unable to locate package linux-azure-lts-22.04�[0m
 �[1;31m==> azure: E: Couldn't find any package by glob 'linux-azure-lts-22.04'�[0m
 �[1;31m==> azure: E: Couldn't find any package by regex 'linux-azure-lts-22.04'�[0m
 �[1;32m==> azure: Provisioning step had errors: Running the cleanup provisioner, if present...�[0m
 �[1;32m==> azure:
 ==> azure: Deleting individual resources ...�[0m
```

Couldn't find a main reason for this, as it can't be repreduced all time.

As suggested by @mykaul, adding `apt-get update` after kernel package pruge command

Fixes: https://github.com/scylladb/scylla-pkg/issues/3601