### PR TITLE
ami: create with gp3 as volume_type

### DIFF
--- a/packer/scylla.json
+++ b/packer/scylla.json
@@ -47,6 +47,7 @@
         {
           "delete_on_termination": true,
           "device_name": "/dev/sda1",
+          "volume_type": "gp3",
           "volume_size": 30
         }
       ],


### PR DESCRIPTION
Until today,  all our images (and snapshots) are gp2 type.

We should move all to gp3 which is more cost effective and better performance

Closes: https://github.com/scylladb/scylla-machine-image/issues/495