### PR TITLE
gpg: add the 2024 pub key

### DIFF
--- a/packer/build_image.sh
+++ b/packer/build_image.sh
@@ -15,7 +15,7 @@ DEBUG=false
 BUILD_MODE='release'
 TARGET=
 APT_KEYS_DIR='/etc/apt/keyrings'
-APT_KEY='d0a112e067426ab2'
+APT_KEY='d0a112e067426ab2 491c93b9de7496a7'
 
 print_usage() {
     echo "$0 --localdeb --repo [URL] --target [distribution]"

--- a/packer/scylla_install_image
+++ b/packer/scylla_install_image
@@ -62,9 +62,8 @@ if __name__ == '__main__':
         print('Error: need to specify --localdeb or --repo/--repo-for-install')
         sys.exit(1)
 
-    run('apt-key adv --keyserver keyserver.ubuntu.com --recv-keys d0a112e067426ab2', shell=True, check=True)
     run(f'mkdir -p {apt_keys_dir}; gpg --homedir /tmp --no-default-keyring --keyring {apt_keys_dir}/scylladb.gpg '
-        f'--keyserver hkp://keyserver.ubuntu.com:80 --recv-keys d0a112e067426ab2', shell=True, check=True)
+        f'--keyserver hkp://keyserver.ubuntu.com:80 --recv-keys d0a112e067426ab2 491c93b9de7496a7', shell=True, check=True)
 
     if args.repo_for_install:
         run(f'curl -L -o /etc/apt/sources.list.d/scylla_install.list {args.repo_for_install}', shell=True, check=True)


### PR DESCRIPTION
...and remove the old apt-get which is no longer required

Ref https://github.com/scylladb/scylla-pkg/issues/3738