### PR TITLE
[images] add https prefix to url

### DIFF
--- a/packer/build_image.sh
+++ b/packer/build_image.sh
@@ -56,7 +56,7 @@ while [ $# -gt 0 ]; do
         "--repo")
             REPO_FOR_INSTALL=$2
             echo "--repo parameter: REPO_FOR_INSTALL $REPO_FOR_INSTALL"
-            INSTALL_ARGS="$INSTALL_ARGS --repo $2"
+            INSTALL_ARGS="$INSTALL_ARGS --repo https://$2"
             shift 2
             ;;
         "--repo-for-install")


### PR DESCRIPTION
Following the change made in https://github.com/scylladb/scylla-pkg/issues/3764. the redirect change
is now failing our image build process with the following error:
```
02:25:02  + bash -c 'set -o pipefail; /jenkins/workspace/scylla-master/ami/scylla-pkg/tools/packaging/dpackager -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID -- ./build_image.sh --target aws --product scylla --repo downloads.scylladb.com/unstable/scylla/master/deb/unified/2024-03-05T21:07:35Z/scylladb-master/scylla.list --arch x86_64 --build-mode release --ami-regions us-west-2,eu-west-2,eu-west-1,eu-central-1,eu-north-1 --ami-users 797456418907 --log-file ami_x86_64.log    --build-id 1352 --build-tag jenkins-scylla-master-ami-1352 --branch master --scylla-build-sha-id ea47a2cee91392101f5630409c7650b307498e5e '
02:25:02  5.5.0-dev-20240306.6e92623
02:25:02  --target parameter TARGET: |aws|
02:25:02  --product parameter: PRODUCT |scylla|
02:25:02  --repo parameter: REPO_FOR_INSTALL downloads.scylladb.com/unstable/scylla/master/deb/unified/2024-03-05T21:07:35Z/scylladb-master/scylla.list
02:25:02  --ami-regions parameter: AMI_REGIONS |us-west-2,eu-west-2,eu-west-1,eu-central-1,eu-north-1|
02:25:02  --ami-users parameter: AMI_USERS |797456418907|
02:25:02  --log-file parameter: PACKER_LOG_PATH |ami_x86_64.log|
02:25:02  --build-id parameter: BUILD_ID |1352|
02:25:02  --build-tag parameter: BUILD_TAG |jenkins-scylla-master-ami-1352|
02:25:02  --branch parameter: BRANCH |master|
02:25:02  --build-id parameter: SCYLLA_BUILD_SHA_ID |ea47a2cee91392101f5630409c7650b307498e5e|
02:25:02  INSTALL_ARGS: | --repo downloads.scylladb.com/unstable/scylla/master/deb/unified/2024-03-05T21:07:35Z/scylladb-master/scylla.list --product scylla|
02:25:02  Importing apt key (d0a112e067426ab2 491c93b9de7496a7)
02:25:02  gpg: keybox '/etc/apt/keyrings/scylladb.gpg' created
02:25:03  gpg: /tmp/trustdb.gpg: trustdb created
02:25:03  gpg: key 491C93B9DE7496A7: public key "ScyllaDB Package Signing Key 2024 <security@scylladb.com>" imported
02:25:03  gpg: key D0A112E067426AB2: public key "ScyllaDB Package Signing Key 2022 <security@scylladb.com>" imported
02:25:03  gpg: Total number processed: 2
02:25:03  gpg:               imported: 2
02:25:03  E: Malformed line 1 in source list /etc/apt/sources.list.d/tmp.0uavludx5L.list (type)
02:25:03  E: The list of sources could not be read.
```

Fixing it

following this change, https://github.com/scylladb/scylla-pkg/pull/3887 and https://github.com/scylladb/scylla-pkg/pull/3896 will be reverted