### PR TITLE
remove package manifest creation as it's not in use

### DIFF
--- a/packer/scylla.json
+++ b/packer/scylla.json
@@ -208,12 +208,6 @@
       "type": "shell"
     },
     {
-      "source": "/home/{{user `ssh_username`}}/{{user `product`}}-packages-{{user `scylla_full_version`}}-{{user `arch`}}.txt",
-      "destination": "build/",
-      "direction": "download",
-      "type": "file"
-    },
-    {
       "source": "/home/{{user `ssh_username`}}/{{user `product`}}-{{build_name}}-kernel-{{user `scylla_full_version`}}-{{user `arch`}}.txt",
       "destination": "build/",
       "direction": "download",

--- a/packer/scylla_install_image
+++ b/packer/scylla_install_image
@@ -214,18 +214,6 @@ WantedBy=multi-user.target
         with open('/etc/ssh/sshd_config.d/50-cloudimg-settings.conf', 'w') as f:
             f.write('ClientAliveInterval 180 \nHostKeyAlgorithms +ssh-rsa \nPubkeyAcceptedKeyTypes +ssh-rsa')
 
-    # generate package manifest to scylla-packages.txt
-    deps = run(f'apt-cache depends --recurse --no-recommends --no-suggests --no-conflicts --no-breaks --no-replaces --no-enhances --installed {args.product}', stdout=PIPE, stderr=STDOUT, shell=True, check=True, encoding='utf-8').stdout.splitlines()
-    pkgs=[]
-    for d in deps:
-        if re.match(r'^\w', d) and not re.match(r'.+:i386$', d) and d not in pkgs:
-            pkgs.append(d)
-    with open('{}/{}-packages-{}-{}.txt'.format(homedir, args.product, args.scylla_version, arch()), 'w') as f:
-        for pkg_name in pkgs:
-            pkg_name_version = run(f"dpkg-query --showformat='${{Package}}=${{Version}}' --show {pkg_name}", capture_output=True, shell=True, check=True, encoding='utf-8').stdout
-            f.write(f'{pkg_name_version}\n')
-    print('{}/{}-packages-{}-{}.txt generated.'.format(homedir, args.product, args.scylla_version, arch()))
-
     kver = run('uname -r', shell=True, check=True, capture_output=True, encoding='utf-8').stdout.strip()
     with open('{}/{}-{}-kernel-{}-{}.txt'.format(homedir, args.product, args.target_cloud, args.scylla_version, arch()), 'a+') as f:
             f.write(f'kernel-version: {kver}\n')


### PR DESCRIPTION
the 3rd party upgrade procedure was dropped from docs in https://github.com/scylladb/scylladb/issues/15733

Removing the code as we don't need it any more

Refs: https://github.com/scylladb/scylla-pkg/issues/3892