### PR TITLE
exit with 1 when Exception catched and raise exception when HTTP error code is client error

### DIFF
--- a/common/scylla_configure.py
+++ b/common/scylla_configure.py
@@ -124,6 +124,7 @@ class ScyllaMachineImageConfigurator(UserData):
             except Exception as e:
                 scylla_excepthook(*sys.exc_info())
                 LOGGER.error("Post configuration script failed: %s", e)
+                sys.exit(1)
 
     def start_scylla_on_first_boot(self):
         default_start_scylla_on_first_boot = self.CONF_DEFAULTS["start_scylla_on_first_boot"]
@@ -141,6 +142,7 @@ class ScyllaMachineImageConfigurator(UserData):
         except Exception as e:
             scylla_excepthook(*sys.exc_info())
             LOGGER.error("Failed to create devices: %s", e)
+            sys.exit(1)
 
     def configure(self):
         self.configure_scylla_yaml()

--- a/common/scylla_create_devices
+++ b/common/scylla_create_devices
@@ -93,3 +93,4 @@ if __name__ == "__main__":
         create_raid(disk_devices, args.raid_level)
     except (DiskIsNotEmptyError, NoDiskFoundError) as e:
         print(e)
+        sys.exit(1)

--- a/common/scylla_post_start.py
+++ b/common/scylla_post_start.py
@@ -30,6 +30,7 @@ class ScyllaMachineImagePostStart(UserData):
             except Exception as e:
                 scylla_excepthook(*sys.exc_info())
                 LOGGER.error(f"Post start script failed: {e}")
+                sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/lib/scylla_cloud.py
+++ b/lib/scylla_cloud.py
@@ -74,7 +74,10 @@ def curl(url, headers=None, method=None, byte=False, timeout=3, max_retries=5, r
     while True:
         try:
             return _curl_one(url, headers, method, byte, timeout)
-        except (urllib.error.URLError, socket.timeout):
+        except (urllib.error.URLError, socket.timeout) as e:
+            # if HTTP error code is client error (400-499), skip retrying
+            if isinstance(e, urllib.error.HTTPError) and e.code in range(400,500):
+                raise
             time.sleep(retry_interval)
             retries += 1
             if retries >= max_retries:
@@ -85,7 +88,10 @@ async def aiocurl(url, headers=None, method=None, byte=False, timeout=3, max_ret
     while True:
         try:
             return _curl_one(url, headers, method, byte, timeout)
-        except (urllib.error.URLError, socket.timeout):
+        except (urllib.error.URLError, socket.timeout) as e:
+            # if HTTP error code is client error (400-499), skip retrying
+            if isinstance(e, urllib.error.HTTPError) and e.code in range(400,500):
+                raise
             await asyncio.sleep(retry_interval)
             retries += 1
             if retries >= max_retries:


### PR DESCRIPTION
On https://github.com/scylladb/scylla-machine-image/issues/498, status of scylla-image-post-start.service is NOT "failed" even
the script causing error, because scylla_post_start.py catches all
exceptions and just logging it, so the script finishes without error.

To getting notify users the script failed operation during running, we
should sys.exit(1) when the exception catched.

Also, when curl catched HTTP error 4xx = client error such as "404 Not Found"
or "403 Forbidden", it likely our script bug not server side issue, we
should re-raise exception immediately instead of retrying.


fixes https://github.com/scylladb/scylla-machine-image/issues/505