### PR TITLE
build.yml: bump the python-version to 3.11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v3
         with:
-          python-version: 3.8                         
+          python-version: 3.11
           architecture: x64
 
       - name: unittest


### PR DESCRIPTION
as per @fruch,

> we are using our own python version from scylla-python3, and currently
> on master it's 3.11

so, let's test with the version we use in production. this should also unlock the features from the language and the standard library provided in higher versions of CPython.