### PR TITLE
packer: share AMIs with the entire aws scylla organization

### DIFF
--- a/packer/scylla.json
+++ b/packer/scylla.json
@@ -95,7 +95,10 @@
         "delay_seconds": "30",
         "max_attempts": "100"
       },
-      "shutdown_behavior": "terminate"
+      "shutdown_behavior": "terminate",
+      "ami_org_arns": [
+          "arn:aws:organizations::978072043225:organization/o-o561yy1rs6"
+      ]
     },
     {
       "name": "gce",


### PR DESCRIPTION
With this change, AMIs wil be shared with the entire aws scylla org (instead of specific accounts) to allow all accounts to use the AMI before it is promoted + avoid the need to maintain a list of accounts that require AMI access,

This is about the AMI, on another change on pkg we need to adjust the `change_snapshot_permissions()` function to loop through all the org account

Ref https://github.com/scylladb/scylla-pkg/issues/3529