### PR TITLE
Adding auditd rules to hardening machine-image

### DIFF
--- a/dist/common/audit_rules.d/70-cis-rules.rules
+++ b/dist/common/audit_rules.d/70-cis-rules.rules
@@ -1,0 +1,31 @@
+## xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_insmod
+-w /sbin/insmod -p x -k modules
+
+## xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_modprobe
+-w /sbin/modprobe -p x -k modules
+
+## xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_rmmod
+-w /sbin/rmmod -p x -k modules
+
+## xccdf_org.ssgproject.content_rule_audit_rules_mac_modification
+-w /etc/selinux/ -p wa -k MAC-policy
+
+## xccdf_org.ssgproject.content_rule_audit_rules_networkconfig_modification
+-a always,exit -F arch=b32 -S sethostname,setdomainname -F key=audit_rules_networkconfig_modification
+-a always,exit -F arch=b64 -S sethostname,setdomainname -F key=audit_rules_networkconfig_modification
+-w /etc/issue -p wa -k audit_rules_networkconfig_modification
+-w /etc/issue.net -p wa -k audit_rules_networkconfig_modification
+-w /etc/hosts -p wa -k audit_rules_networkconfig_modification
+-w /etc/networks -p wa -k audit_rules_networkconfig_modification
+-w /etc/network/ -p wa -k audit_rules_networkconfig_modification
+
+## xccdf_org.ssgproject.content_rule_audit_rules_session_events
+-w /var/run/utmp -p wa -k session
+-w /var/log/btmp -p wa -k session
+-w /var/log/wtmp -p wa -k session
+
+## xccdf_org.ssgproject.content_rule_audit_rules_suid_privilege_function
+-a always,exit -F arch=b32 -S execve -C uid!=euid -F euid=0 -k setuid
+-a always,exit -F arch=b64 -S execve -C uid!=euid -F euid=0 -k setuid
+-a always,exit -F arch=b32 -S execve -C gid!=egid -F egid=0 -k setgid
+-a always,exit -F arch=b64 -S execve -C gid!=egid -F egid=0 -k setgid

--- a/dist/debian/control.template
+++ b/dist/debian/control.template
@@ -8,7 +8,7 @@ Rules-Requires-Root: no
 
 Package: %{product}-machine-image
 Architecture: all
-Depends: %{product}, %{product}-python3, ${shlibs:Depends}, ${misc:Depends}
+Depends: %{product}, %{product}-python3, ${shlibs:Depends}, ${misc:Depends}, auditd
 Replaces: scylla-machine-image
 Description: Scylla Machine Image
  Scylla is a highly scalable, eventually consistent, distributed,

--- a/dist/debian/debian/rules
+++ b/dist/debian/debian/rules
@@ -16,6 +16,8 @@ override_dh_auto_install:
 	common/scylla_image_setup common/scylla_login common/scylla_configure.py \
 	common/scylla_create_devices common/scylla_post_start.py \
 	common/scylla_cloud_io_setup common/scylla_ec2_check
+	install -d -m750 $(CURDIR)/debian/tmp/etc/audit/rules.d
+	install -m640 dist/common/audit_rules.d/70-cis-rules.rules $(CURDIR)/debian/tmp/etc/audit/rules.d
 
 override_dh_installinit:
 	dh_installinit --no-start --name scylla-image-setup

--- a/dist/debian/debian/scylla-machine-image.install
+++ b/dist/debian/debian/scylla-machine-image.install
@@ -1,1 +1,2 @@
 opt/scylladb/scylla-machine-image/*
+etc/audit/rules.d/*.rules

--- a/dist/debian/debian/scylla-machine-image.postinst
+++ b/dist/debian/debian/scylla-machine-image.postinst
@@ -3,5 +3,6 @@
 if [ -d /run/systemd/system ]; then
     systemctl --system daemon-reload >/dev/null || true
 fi
+augenrules --load
 
 #DEBHELPER#

--- a/dist/redhat/scylla-machine-image.spec
+++ b/dist/redhat/scylla-machine-image.spec
@@ -7,7 +7,7 @@ Group:          Applications/Databases
 License:        ASL 2.0
 URL:            http://www.scylladb.com/
 Source0:        %{name}-%{version}-%{release}.tar
-Requires:       %{product} = %{version} %{product}-python3 curl
+Requires:       %{product} = %{version} %{product}-python3 curl auditd
 
 BuildArch:      noarch
 Obsoletes:      scylla-machine-image
@@ -42,6 +42,8 @@ install -m755 common/scylla_configure.py common/scylla_post_start.py common/scyl
     common/scylla_image_setup common/scylla_login common/scylla_configure.py \
     common/scylla_create_devices common/scylla_post_start.py \
     common/scylla_cloud_io_setup common/scylla_ec2_check
+install -d -m750 $RPM_BUILD_ROOT%{_sysconfdir}/audit/rules.d
+install -m640 dist/common/audit_rules.d/70-cis-rules.rules $RPM_BUILD_ROOT%{_sysconfdir}/audit/rules.d
 
 %pre
 /usr/sbin/groupadd scylla 2> /dev/null || :
@@ -50,6 +52,7 @@ install -m755 common/scylla_configure.py common/scylla_post_start.py common/scyl
 %post
 %systemd_post scylla-image-setup.service
 %systemd_post scylla-image-post-start.service
+augenrules --load
 
 %preun
 %systemd_preun scylla-image-setup.service
@@ -79,6 +82,7 @@ rm -rf $RPM_BUILD_ROOT
 %{_unitdir}/scylla-image-setup.service
 %{_unitdir}/scylla-image-post-start.service
 /opt/scylladb/scylla-machine-image/*
+%{_sysconfdir}/audit/rules.d/*.rules
 
 %changelog
 * Sun Nov 1 2020 Bentsi Magidovich <bentsi@scylladb.com>

--- a/packer/scylla_install_image
+++ b/packer/scylla_install_image
@@ -99,6 +99,9 @@ if __name__ == '__main__':
     # drop packages does not needed anymore
     run('apt-get autoremove --purge -y', shell=True, check=True)
 
+    # xccdf_org.ssgproject.content_rule_grub2_audit_argument
+    # xccdf_org.ssgproject.content_rule_grub2_audit_backlog_limit_argument
+    kernel_opt = 'audit=1 audit_backlog_limit=8192'
     if args.target_cloud == 'aws':
         run('apt-get install -y pip', shell=True, check=True)
         run('pip install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-2.0-18.tar.gz', shell=True, check=True)
@@ -117,15 +120,13 @@ if __name__ == '__main__':
         with open('/etc/chrony/sources.d/ntp-pool.sources', 'w') as f:
             f.write('pool time.aws.com iburst\n')
 
-        kernel_opt = ''
         grub_variable = 'GRUB_CMDLINE_LINUX_DEFAULT'
     elif args.target_cloud == 'gce':
         # align with other clouds image
         run('apt-get purge -y rsyslog', shell=True, check=True)
-        kernel_opt = ''
         grub_variable = 'GRUB_CMDLINE_LINUX_DEFAULT'
     elif args.target_cloud == 'azure':
-        kernel_opt = ' rootdelay=300'
+        kernel_opt += ' rootdelay=300'
         grub_variable = 'GRUB_CMDLINE_LINUX'
 
     run('systemctl disable apt-daily-upgrade.timer apt-daily.timer dpkg-db-backup.timer motd-news.timer', shell=True, check=True)
@@ -177,6 +178,17 @@ WantedBy=multi-user.target
     profile = '/etc/skel/.profile'
     with open(profile, 'a') as f:
         f.write('\n\n/opt/scylladb/scylla-machine-image/scylla_login\n')
+
+    with open('/etc/audit/auditd.conf') as f:
+        auditd = f.read()
+    # xccdf_org.ssgproject.content_rule_auditd_data_retention_max_log_file_action
+    auditd = re.sub(r'^max_log_file_action = .+$', 'max_log_file_action = KEEP_LOGS', auditd, flags=re.MULTILINE)
+    # xccdf_org.ssgproject.content_rule_auditd_data_retention_space_left_action
+    auditd = re.sub(r'^space_left_action = .+$', 'space_left_action = EMAIL', auditd, flags=re.MULTILINE)
+    # xccdf_org.ssgproject.content_rule_auditd_data_retention_admin_space_left_action
+    auditd = re.sub(r'^admin_space_left_action = .+$', 'admin_space_left_action = suspend', auditd, flags=re.MULTILINE)
+    with open('/etc/audit/auditd.conf', 'w') as f:
+        f.write(auditd)
 
     # On AWS, ssh user is statically created at AMI building time, so we need to
     # change it to 'scyllaadm`.


### PR DESCRIPTION
Install auditd and add auditd rules to hardening machine-image. Also add kernel boot parameters to audit.

This will apply following CIS compliance rules:
- xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_insmod
- xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_modprobe
- xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_rmmod
- xccdf_org.ssgproject.content_rule_audit_rules_mac_modification
- xccdf_org.ssgproject.content_rule_audit_rules_mac_modification
- xccdf_org.ssgproject.content_rule_audit_rules_networkconfig_modification
- xccdf_org.ssgproject.content_rule_audit_rules_session_events
- xccdf_org.ssgproject.content_rule_audit_rules_suid_privilege_function
- xccdf_org.ssgproject.content_rule_grub2_audit_argument
- xccdf_org.ssgproject.content_rule_grub2_audit_backlog_limit_argument
- xccdf_org.ssgproject.content_rule_auditd_data_retention_max_log_file_action
- xccdf_org.ssgproject.content_rule_auditd_data_retention_space_left_action
- xccdf_org.ssgproject.content_rule_auditd_data_retention_admin_space_left_action

Fixes scylladb/scylla-enterprise-machine-image#71
Related scylladb/scylla-pkg#2953