### PR TITLE
[cloud images] add packages for Scylla cloud deployments

### DIFF
--- a/packer/scylla_install_image
+++ b/packer/scylla_install_image
@@ -77,7 +77,7 @@ if __name__ == '__main__':
     run('apt-get update --allow-insecure-repositories -y', shell=True, check=True)
     run('apt-get full-upgrade -y', shell=True, check=True)
     run('apt-get purge -y apport python3-apport fuse', shell=True, check=True)
-    run('apt-get install -y systemd-coredump vim.tiny', shell=True, check=True)
+    run('apt-get install -y systemd-coredump vim.tiny nload nmap ncat tmux jq ansible git python3-boto', shell=True, check=True)
     run(f'apt-get install -y --auto-remove --allow-unauthenticated {args.product}-machine-image {args.product}-server-dbg', shell=True, check=True)
 
     os.remove('/etc/apt/sources.list.d/scylla_install.list')


### PR DESCRIPTION
In order to reduce setup time for cloud, adding packages based on https://github.com/scylladb/siren-devops/blob/f5ddb43aeab16bc19695ae22692426e6d405e9e3/ansible/roles/cloud-base-image/tasks/main.yml#L20

Fixes: https://github.com/scylladb/scylla-enterprise-machine-image/issues/70