### PR TITLE
scylla_install_image: preinstall scylla_raid_setup dependencies

### DIFF
--- a/packer/scylla_install_image
+++ b/packer/scylla_install_image
@@ -77,7 +77,7 @@ if __name__ == '__main__':
     run('apt-get update --allow-insecure-repositories -y', shell=True, check=True)
     run('apt-get full-upgrade -y', shell=True, check=True)
     run('apt-get purge -y apport python3-apport fuse', shell=True, check=True)
-    run('apt-get install -y systemd-coredump vim.tiny nload nmap ncat tmux jq python3-boto', shell=True, check=True)
+    run('apt-get install -y systemd-coredump vim.tiny nload nmap ncat tmux jq python3-boto xfsprogs mdadm initramfs-tools', shell=True, check=True)
     run(f'apt-get install -y --auto-remove --allow-unauthenticated {args.product}-machine-image {args.product}-server-dbg', shell=True, check=True)
 
     os.remove('/etc/apt/sources.list.d/scylla_install.list')


### PR DESCRIPTION
scylla_raid_setup requires to install xfsprogs, mdadm, initramfs-tools. We should preinstall these packages while building machine image instead of starting scylla_image_setup, to speed up the instance boot process.

Related scylladb/scylladb#19651