### PR TITLE
packer/build_image.sh: update GPG key

### DIFF
--- a/packer/build_image.sh
+++ b/packer/build_image.sh
@@ -15,7 +15,7 @@ DEBUG=false
 BUILD_MODE='release'
 TARGET=
 APT_KEYS_DIR='/etc/apt/keyrings'
-APT_KEY='d0a112e067426ab2 491c93b9de7496a7'
+APT_KEY='a43e06657bac99e3'
 
 print_usage() {
     echo "$0 --localdeb --repo [URL] --target [distribution]"


### PR DESCRIPTION
A new GPG key was created for supporting both rpm and deb in RSA mode

Related to https://github.com/scylladb/scylla-enterprise/issues/4222