### PR TITLE
packer/scylla_install_image: update gpg key inisde the image

### DIFF
--- a/packer/scylla_install_image
+++ b/packer/scylla_install_image
@@ -65,7 +65,7 @@ if __name__ == '__main__':
     run('apt-get update --allow-insecure-repositories -y', shell=True, check=True)
     run('apt-get install -y gnupg2', shell=True, check=True)
     run(f'mkdir -p {apt_keys_dir}; gpg --homedir /tmp --no-default-keyring --keyring {apt_keys_dir}/scylladb.gpg '
-        f'--keyserver hkp://keyserver.ubuntu.com:80 --recv-keys d0a112e067426ab2 491c93b9de7496a7', shell=True, check=True)
+        f'--keyserver hkp://keyserver.ubuntu.com:80 --recv-keys a43e06657bac99e3', shell=True, check=True)
 
     if args.repo_for_install:
         run(f'curl -L -o /etc/apt/sources.list.d/scylla_install.list {args.repo_for_install}', shell=True, check=True)


### PR DESCRIPTION
Following the changes in 23bc340, it seems i missed a place for the gpg key replacement

adding it so we can run `apt-get update` inside our images

Fixes: https://github.com/scylladb/scylla-pkg/issues/4255