### PR TITLE
scylla_conifgure.py: skip construct data volume on dev_instance_type

### DIFF
--- a/common/scylla_configure.py
+++ b/common/scylla_configure.py
@@ -140,9 +140,12 @@ class ScyllaMachineImageConfigurator(UserData):
             LOGGER.info(f"Create scylla data devices as {device_type}")
             subprocess.run(cmd_create_devices, shell=True, check=True)
         except Exception as e:
-            scylla_excepthook(*sys.exc_info())
-            LOGGER.error("Failed to create devices: %s", e)
-            sys.exit(1)
+            if self.cloud_instance.is_dev_instance_type():
+                LOGGER.info("Skipping to create devices: %s", e)
+            else:
+                scylla_excepthook(*sys.exc_info())
+                LOGGER.error("Failed to create devices: %s", e)
+                sys.exit(1)
 
     def configure(self):
         self.configure_scylla_yaml()

--- a/common/scylla_image_setup
+++ b/common/scylla_image_setup
@@ -45,6 +45,6 @@ if __name__ == '__main__':
                 # some distro has fstrim enabled by default, since we are using XFS with online discard, we don't need fstrim
                 run('systemctl is-active -q fstrim.timer && systemctl disable fstrim.timer', shell=True, check=True)
 
-        if not os.path.ismount('/var/lib/scylla'):
+        if not os.path.ismount('/var/lib/scylla') and not cloud_instance.is_dev_instance_type():
             print('Failed to initialize RAID volume!')
         machine_image_configured.touch()


### PR DESCRIPTION
Since dev_instance_type does not have local SSD, we should skip running scylla_create_devices.

Fixes #551