### PR TITLE
aws: add i7ie instance type

### DIFF
--- a/common/aws_io_params.yaml
+++ b/common/aws_io_params.yaml
@@ -558,3 +558,23 @@ i4i.metal:
   read_bandwidth: 3088599296
   write_iops: 239549
   write_bandwidth: 2302438912
+i7ie.large:
+  read_iops: 58449
+  read_bandwidth: 574854656
+  write_iops: 47145
+  write_bandwidth: 253132917
+i7ie.xlarge:
+  read_iops: 117257
+  read_bandwidth: 1148572714
+  write_iops: 94180
+  write_bandwidth: 505684885
+i7ie.2xlarge:
+  read_iops: 117257
+  read_bandwidth: 1148572714
+  write_iops: 94180
+  write_bandwidth: 505684885
+i7ie.ALL:
+  read_iops: 352834
+  read_bandwidth: 3422623232
+  write_iops: 119327
+  write_bandwidth: 1526442410

--- a/lib/scylla_cloud.py
+++ b/lib/scylla_cloud.py
@@ -812,7 +812,7 @@ class aws_instance(cloud_instance):
         return self._type.split(".")[0]
 
     def is_supported_instance_class(self):
-        if self.instance_class() in ['i2', 'i3', 'i3en', 'c5d', 'm5d', 'm5ad', 'r5d', 'z1d', 'c6gd', 'm6gd', 'r6gd', 'x2gd', 'im4gn', 'is4gen', 'i4i', 'i4g']:
+        if self.instance_class() in ['i2', 'i3', 'i3en', 'c5d', 'm5d', 'm5ad', 'r5d', 'z1d', 'c6gd', 'm6gd', 'r6gd', 'x2gd', 'im4gn', 'is4gen', 'i4i', 'i4g', 'i7ie']:
             return True
         return False
 
@@ -826,7 +826,7 @@ class aws_instance(cloud_instance):
         instance_size = self.instance_size()
         if instance_class in ['c3', 'c4', 'd2', 'i2', 'r3']:
             return 'ixgbevf'
-        if instance_class in ['a1', 'c5', 'c5a', 'c5d', 'c5n', 'c6g', 'c6gd', 'f1', 'g3', 'g4', 'h1', 'i3', 'i3en', 'inf1', 'm5', 'm5a', 'm5ad', 'm5d', 'm5dn', 'm5n', 'm6g', 'm6gd', 'p2', 'p3', 'r4', 'r5', 'r5a', 'r5ad', 'r5b', 'r5d', 'r5dn', 'r5n', 't3', 't3a', 'u-6tb1', 'u-9tb1', 'u-12tb1', 'u-18tn1', 'u-24tb1', 'x1', 'x1e', 'z1d', 'c6g', 'c6gd', 'm6g', 'm6gd', 't4g', 'r6g', 'r6gd', 'x2gd', 'im4gn', 'is4gen', 'i4i', 'i4g']:
+        if instance_class in ['a1', 'c5', 'c5a', 'c5d', 'c5n', 'c6g', 'c6gd', 'f1', 'g3', 'g4', 'h1', 'i3', 'i3en', 'inf1', 'm5', 'm5a', 'm5ad', 'm5d', 'm5dn', 'm5n', 'm6g', 'm6gd', 'p2', 'p3', 'r4', 'r5', 'r5a', 'r5ad', 'r5b', 'r5d', 'r5dn', 'r5n', 't3', 't3a', 'u-6tb1', 'u-9tb1', 'u-12tb1', 'u-18tn1', 'u-24tb1', 'x1', 'x1e', 'z1d', 'c6g', 'c6gd', 'm6g', 'm6gd', 't4g', 'r6g', 'r6gd', 'x2gd', 'im4gn', 'is4gen', 'i4i', 'i4g', 'i7ie']:
             return 'ena'
         if instance_class == 'm4':
             if instance_size == '16xlarge':


### PR DESCRIPTION
Adding preset io parameters of i7ie to scylla_cloud_io_setup, and also added i7ie to supported instance type on aws_instance class.

Closes #559