### PR TITLE
Install cpufrequtils and run scylla_cpuscaling_setup

### DIFF
--- a/common/scylla_image_setup
+++ b/common/scylla_image_setup
@@ -23,9 +23,7 @@ if __name__ == '__main__':
         run(f'/opt/scylladb/scripts/scylla_swap_setup --swap-directory {swap_directory}', shell=True, check=True)
     machine_image_configured = Path('/etc/scylla/machine_image_configured')
     if not machine_image_configured.exists():
-        # On Ubuntu, we configure CPU scaling while AMI building time
-        if is_redhat_variant():
-            run('/opt/scylladb/scripts/scylla_cpuscaling_setup', shell=True, check=True)
+        run('/opt/scylladb/scripts/scylla_cpuscaling_setup', shell=True, check=True)
         cloud_instance = get_cloud_instance()
         run('/opt/scylladb/scylla-machine-image/scylla_configure.py', shell=True, check=True)
 

--- a/packer/scylla_install_image
+++ b/packer/scylla_install_image
@@ -79,7 +79,7 @@ if __name__ == '__main__':
     run('apt-get update --allow-insecure-repositories -y', shell=True, check=True)
     run('apt-get full-upgrade -y', shell=True, check=True)
     run('apt-get purge -y apport python3-apport fuse', shell=True, check=True)
-    run('apt-get install -y systemd-coredump vim.tiny nmap ncat tmux jq python3-boto xfsprogs mdadm initramfs-tools ethtool vim-nox sysstat ', shell=True, check=True)
+    run('apt-get install -y systemd-coredump vim.tiny nmap ncat tmux jq python3-boto xfsprogs mdadm initramfs-tools ethtool vim-nox sysstat cpufrequtils ', shell=True, check=True)
     run(f'apt-get install -y --auto-remove --allow-unauthenticated {args.product}-machine-image {args.product}-server-dbg', shell=True, check=True)
 
     os.remove('/etc/apt/sources.list.d/scylla_install.list')


### PR DESCRIPTION
It was mistakenly does not configured as expected, fixing. (Probably we broke this when we switched from Ubuntu minimal base image, since it does not have cpufrequtils)

Fixes #550