### PR TITLE
./github/scripts/auto-backport: align process to source available and more

### DIFF
--- a/.github/workflows/add-label-when-promoted.yaml
+++ b/.github/workflows/add-label-when-promoted.yaml
@@ -5,10 +5,12 @@ on:
     branches:
       - master
       - next-*.*
-      - enterprise
   pull_request_target:
     types: [labeled]
-    branches: [master, next, enterprise]
+    branches: [master, next]
+
+env:
+  DEFAULT_BRANCH: 'master'
 
 jobs:
   check-commit:
@@ -20,20 +22,11 @@ jobs:
       - name: Dump GitHub context
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
-        run: echo "$GITHUB_CONTEXT"
-      - name: Set Default Branch
-        id: set_branch
-        run: |
-          if [[ "${{ github.repository }}" == *enterprise* ]]; then
-            echo "stable_branch=enterprise" >> $GITHUB_OUTPUT
-          else
-            echo "stable_branch=master" >> $GITHUB_OUTPUT
-          fi
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           repository: ${{ github.repository }}
-          ref: ${{ env.stable_branch }}
+          ref: ${{ env.DEFAULT_BRANCH }}
           token: ${{ secrets.AUTO_BACKPORT_TOKEN }}
           fetch-depth: 0  # Fetch all history for all tags and branches
       - name: Set up Git identity
@@ -49,7 +42,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.AUTO_BACKPORT_TOKEN }}
         run: python .github/scripts/search_commits.py  --commits ${{ github.event.before }}..${{ github.sha }} --repository ${{ github.repository }} --ref ${{ github.ref }}
       - name: Run auto-backport.py when promotion completed
-        if: github.event_name == 'push' && github.ref == format('refs/heads/{0}', steps.set_branch.outputs.stable_branch)
+        if: github.event_name == 'push' && github.ref == format('refs/heads/{0}', env.DEFAULT_BRANCH)
         env:
           GITHUB_TOKEN: ${{ secrets.AUTO_BACKPORT_TOKEN }}
         run: python .github/scripts/auto-backport.py --repo ${{ github.repository }} --base-branch ${{ github.ref }} --commits ${{ github.event.before }}..${{ github.sha }}
@@ -68,4 +61,4 @@ jobs:
         if: github.event_name == 'pull_request_target' && steps.check_label.outputs.backport_label == 'true' && github.event.pull_request.merged == true
         env:
           GITHUB_TOKEN: ${{ secrets.AUTO_BACKPORT_TOKEN }}
-        run: python .github/scripts/auto-backport.py --repo ${{ github.repository }} --base-branch ${{ github.ref }} --pull-request ${{ github.event.pull_request.number }} --head-commit ${{ github.event.pull_request.base.sha }}
+        run: python .github/scripts/auto-backport.py --repo ${{ github.repository }} --base-branch ${{ github.ref }} --pull-request ${{ github.event.pull_request.number }} --head-commit ${{ github.event.pull_request.base.sha }} --label ${{ github.event.label.name }}


### PR DESCRIPTION
Syncing a few changes that have already been implemented in scylla-pkg:

* remove condition for enterprise - since we are now running always from the `scylla-machine-image` repo
* run backport process from stable branch (which is `master`)
* improve conflict cases - by adding a comment to notify the PR owner
* pass label for each pull_request_target trigger