### PR TITLE
.github/workflows/add-label-when-promoted.yaml: add missing `run` command

### DIFF
--- a/.github/workflows/add-label-when-promoted.yaml
+++ b/.github/workflows/add-label-when-promoted.yaml
@@ -22,6 +22,7 @@ jobs:
       - name: Dump GitHub context
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"
       - name: Checkout repository
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
In https://github.com/scylladb/scylla-machine-image/pull/572 `run: echo "$GITHUB_CONTEXT"` line was removed by mistake causing the workflow to fail

Adding it back