### PR TITLE
build_image: fix Illegal option `--env-tag`

### DIFF
--- a/packer/build_image.sh
+++ b/packer/build_image.sh
@@ -85,6 +85,11 @@ while [ $# -gt 0 ]; do
             echo "--build-tag parameter: BUILD_TAG |$BUILD_TAG|"
             shift 2
             ;;
+        "--env-tag")
+            ENV_TAG=$2
+            echo "--env-tag parameter: ENV_TAG |$ENV_TAG|"
+            shift 2
+            ;;
         "--branch")
             BRANCH=$2
             echo "--branch parameter: BRANCH |$BRANCH|"


### PR DESCRIPTION
follow the commit 870d6a6ce7b6c5cb01f151f89b335b3d55ebe958  
the `ERROR: Illegal option: --env-tag` is displayed on build image process (ami, gce, azure)

seems this part is missing in the backport

adding it

Failed job: https://jenkins.scylladb.com/job/scylla-6.2/job/azure-image/10/
`00:06:37  ERROR: Illegal option: --env-tag`

Verification passed:
https://jenkins.scylladb.com/job/scylla-6.2/job/azure-image/11/