### PR TITLE
dist: "Obsoletes: scylla-machine-image" is invalid for OSS version

### DIFF
--- a/dist/debian/control.template
+++ b/dist/debian/control.template
@@ -9,7 +9,6 @@ Rules-Requires-Root: no
 Package: %{product}-machine-image
 Architecture: all
 Depends: %{product}, %{product}-python3, ${shlibs:Depends}, ${misc:Depends}
-Replaces: scylla-machine-image
 Description: Scylla Machine Image
  Scylla is a highly scalable, eventually consistent, distributed,
  partitioned row DB.

--- a/dist/redhat/scylla-machine-image.spec
+++ b/dist/redhat/scylla-machine-image.spec
@@ -10,7 +10,6 @@ Source0:        %{name}-%{version}-%{release}.tar
 Requires:       %{product} = %{version} %{product}-python3 curl
 
 BuildArch:      noarch
-Obsoletes:      scylla-machine-image
 
 %global _python_bytecompile_errors_terminate_build 0
 %global __brp_python_bytecompile %{nil}


### PR DESCRIPTION
I think this is defined for scylla-enterprise-machine-image, but we shouldn't have it for OSS version.