### PR TITLE
dist: support smooth upgrade from enterprise to source available

### DIFF
--- a/dist/debian/control.template
+++ b/dist/debian/control.template
@@ -9,6 +9,16 @@ Rules-Requires-Root: no
 Package: %{product}-machine-image
 Architecture: all
 Depends: %{product}, %{product}-python3, ${shlibs:Depends}, ${misc:Depends}
+Replaces: scylla-enterprise-machine-image (<< 2025.1.0~)
+Breaks: scylla-enterprise-machine-image (<< 2025.1.0~)
 Description: Scylla Machine Image
  Scylla is a highly scalable, eventually consistent, distributed,
  partitioned row DB.
+
+Package: scylla-enterprise-machine-image
+Depends: %{product}-machine-image (= ${binary:Version})
+Architecture: all
+Priority: optional
+Section: oldlibs
+Description: transitional package
+ This is a transitional package. It can safely be removed.

--- a/dist/redhat/scylla-machine-image.spec
+++ b/dist/redhat/scylla-machine-image.spec
@@ -8,6 +8,8 @@ License:        ASL 2.0
 URL:            http://www.scylladb.com/
 Source0:        %{name}-%{version}-%{release}.tar
 Requires:       %{product} = %{version} %{product}-python3 curl
+Provides:       scylla-enterprise-machine-image = %{version}-%{release}
+Obsoletes:      scylla-enterprise-machine-image < 2025.1.0
 
 BuildArch:      noarch
 


### PR DESCRIPTION
dist: support smooth upgrade from enterprise to source availalbe When upgrading for example from `2024.1` to `2025.1` the package name is not identical casuing the upgrade command to fail.

This makes packages upgradable from enterprise.

Related scylladb/scylladb#22420