### PR TITLE
dist/debian/control.template: remove duplicate

### DIFF
--- a/dist/debian/control.template
+++ b/dist/debian/control.template
@@ -9,8 +9,7 @@ Rules-Requires-Root: no
 Package: %{product}-machine-image
 Architecture: all
 Depends: %{product}, %{product}-python3, ${shlibs:Depends}, ${misc:Depends}
-Replaces: scylla-machine-image
-Replaces: scylla-enterprise-machine-image (<< 2025.1.0~)
+Replaces: scylla-machine-image, scylla-enterprise-machine-image (<< 2025.1.0~)
 Breaks: scylla-enterprise-machine-image (<< 2025.1.0~)
 Description: Scylla Machine Image
  Scylla is a highly scalable, eventually consistent, distributed,


### PR DESCRIPTION
Following d3b4dcd7277ad1c4d8c59b89fb6377d2ad7ad2ef next-machine-image failed with the following error:
```
17:28:21   dpkg-buildpackage -rfakeroot -us -uc -ui
17:28:22  dpkg-buildpackage: error: syntax error in debian/control at line 13: duplicate field Replaces found
17:28:22  debuild: fatal error at line 1184:
17:28:22  dpkg-buildpackage -rfakeroot -us -uc -ui failed
```

### Testing
- [x] https://jenkins.scylladb.com/job/releng-testing/job/next-machine-image/15/