### PR TITLE
aws: add missing instance size i4i.12xlarge and i4i.24xlarge

### DIFF
--- a/common/aws_io_params.yaml
+++ b/common/aws_io_params.yaml
@@ -543,11 +543,21 @@ i4i.8xlarge:
   read_bandwidth: 3115819008
   write_iops: 239980
   write_bandwidth: 2289285120
+i4i.12xlarge:
+  read_iops: 294982
+  read_bandwidth: 3116245760
+  write_iops: 67283
+  write_bandwidth: 2287695786
 i4i.16xlarge:
   read_iops: 374273
   read_bandwidth: 3088962816
   write_iops: 240185
   write_bandwidth: 2292813568
+i4i.24xlarge:
+  read_iops: 282557
+  read_bandwidth: 3116171434
+  write_iops: 67003
+  write_bandwidth: 2288658688
 i4i.32xlarge:
   read_iops: 374273
   read_bandwidth: 3095612416


### PR DESCRIPTION
Add preset io parametter of i4i.12xlarge and i4i.24xlarge, which we mistakenly
did not added when we support i4i instance type on the commit https://github.com/scylladb/scylla-machine-image/commit/b7a00ecfedcc24dba54bf62d4ac6ffb308f27fb5.

Here's raw output of iotune:

- i4i.12xlarge (1/3)
Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 2182 MB/s (deviation 3%)
Measuring sequential read bandwidth: 2971 MB/s (deviation 7%)
Measuring random write IOPS: 67397 IOPS
Measuring random read IOPS: 297871 IOPS

- i4i.12xlarge (2/3)
Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 2181 MB/s (deviation 3%)
Measuring sequential read bandwidth: 2971 MB/s (deviation 7%)
Measuring random write IOPS: 67248 IOPS (deviation 4%)
Measuring random read IOPS: 289840 IOPS

- i4i.12xlarge (3/3)
Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 2181 MB/s
Measuring sequential read bandwidth: 2971 MB/s (deviation 7%)
Measuring random write IOPS: 67206 IOPS (deviation 4%)
Measuring random read IOPS: 297236 IOPS

- i4i.24xlarge (1/3)
Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 2182 MB/s (deviation 3%)
Measuring sequential read bandwidth: 2971 MB/s (deviation 7%)
Measuring random write IOPS: 67450 IOPS
Measuring random read IOPS: 283417 IOPS

- i4i.24xlarge (2/3)
Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 2183 MB/s
Measuring sequential read bandwidth: 2971 MB/s (deviation 7%)
Measuring random write IOPS: 66218 IOPS (deviation 3%)
Measuring random read IOPS: 280804 IOPS

- i4i.24xlarge (3/3)
Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 2181 MB/s (deviation 3%)
Measuring sequential read bandwidth: 2971 MB/s (deviation 7%)
Measuring random write IOPS: 67341 IOPS (deviation 3%)
Measuring random read IOPS: 283450 IOPS

Closes https://github.com/scylladb/scylla-machine-image/issues/617