### PR TITLE
aws: add missing instance size i4i.12xlarge and i4i.24xlarge for branch-2024.2

### DIFF
--- a/common/scylla_cloud_io_setup
+++ b/common/scylla_cloud_io_setup
@@ -408,11 +408,21 @@ class aws_io_setup(cloud_io_setup):
             self.disk_properties["read_bandwidth"] = 3115819008 * nr_disks
             self.disk_properties["write_iops"] = 239980 * nr_disks
             self.disk_properties["write_bandwidth"] = 2289285120 * nr_disks
+        elif self.idata.instancetype == "i4i.12xlarge":
+            self.disk_properties["read_iops"] = 294982 * nr_disks
+            self.disk_properties["read_bandwidth"] = 3116245760 * nr_disks
+            self.disk_properties["write_iops"] = 67283 * nr_disks
+            self.disk_properties["write_bandwidth"] = 2287695786 * nr_disks
         elif self.idata.instancetype == "i4i.16xlarge":
             self.disk_properties["read_iops"] = 374273 * nr_disks
             self.disk_properties["read_bandwidth"] = 3088962816 * nr_disks
             self.disk_properties["write_iops"] = 240185 * nr_disks
             self.disk_properties["write_bandwidth"] = 2292813568 * nr_disks
+        elif self.idata.instancetype == "i4i.24xlarge":
+            self.disk_properties["read_iops"] = 282557 * nr_disks
+            self.disk_properties["read_bandwidth"] = 3116171434 * nr_disks
+            self.disk_properties["write_iops"] = 67003 * nr_disks
+            self.disk_properties["write_bandwidth"] = 2288658688 * nr_disks
         elif self.idata.instancetype == "i4i.32xlarge":
             self.disk_properties["read_iops"] = 374273 * nr_disks
             self.disk_properties["read_bandwidth"] = 3095612416 * nr_disks


### PR DESCRIPTION
This is branch-2024.2 version of https://github.com/scylladb/scylla-machine-image/pull/620.
Since we cannot backport  https://github.com/scylladb/scylla-machine-image/pull/620 because there is source code incompatibility on io parameters since we recently moved to aws_io_params.yaml, so the commit message does not include "cherry picked from".

----

Add preset io parametter of i4i.12xlarge and i4i.24xlarge, which we mistakenly did not added when we support i4i instance type on the commit b7a00ec.

Here's raw output of iotune:

- i4i.12xlarge (1/3) Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 2182 MB/s (deviation 3%) Measuring sequential read bandwidth: 2971 MB/s (deviation 7%) Measuring random write IOPS: 67397 IOPS
Measuring random read IOPS: 297871 IOPS

- i4i.12xlarge (2/3) Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 2181 MB/s (deviation 3%) Measuring sequential read bandwidth: 2971 MB/s (deviation 7%) Measuring random write IOPS: 67248 IOPS (deviation 4%) Measuring random read IOPS: 289840 IOPS

- i4i.12xlarge (3/3) Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 2181 MB/s
Measuring sequential read bandwidth: 2971 MB/s (deviation 7%) Measuring random write IOPS: 67206 IOPS (deviation 4%) Measuring random read IOPS: 297236 IOPS

- i4i.24xlarge (1/3) Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 2182 MB/s (deviation 3%) Measuring sequential read bandwidth: 2971 MB/s (deviation 7%) Measuring random write IOPS: 67450 IOPS
Measuring random read IOPS: 283417 IOPS

- i4i.24xlarge (2/3) Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 2183 MB/s
Measuring sequential read bandwidth: 2971 MB/s (deviation 7%) Measuring random write IOPS: 66218 IOPS (deviation 3%) Measuring random read IOPS: 280804 IOPS

- i4i.24xlarge (3/3) Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 2181 MB/s (deviation 3%) Measuring sequential read bandwidth: 2971 MB/s (deviation 7%) Measuring random write IOPS: 67341 IOPS (deviation 3%) Measuring random read IOPS: 283450 IOPS

Related #617