### PR TITLE
scylla_install_image: disable cloud provider agents

### DIFF
--- a/packer/scylla_install_image
+++ b/packer/scylla_install_image
@@ -118,14 +118,17 @@ if __name__ == '__main__':
 
         kernel_opt = ''
         grub_variable = 'GRUB_CMDLINE_LINUX_DEFAULT'
+        run('systemctl mask amazon-ssm-agent', shell=True, check=True)
     elif args.target_cloud == 'gce':
         # align with other clouds image
         run('apt-get purge -y rsyslog', shell=True, check=True)
         kernel_opt = ''
         grub_variable = 'GRUB_CMDLINE_LINUX_DEFAULT'
+        run('systemctl mask google-osconfig-agent', shell=True, check=True)
     elif args.target_cloud == 'azure':
         kernel_opt = ' rootdelay=300'
         grub_variable = 'GRUB_CMDLINE_LINUX'
+        run('systemctl mask walinuxagent', shell=True, check=True)
 
     run('systemctl disable apt-daily-upgrade.timer apt-daily.timer dpkg-db-backup.timer motd-news.timer', shell=True, check=True)
     run('systemctl daemon-reload', shell=True, check=True)


### PR DESCRIPTION
currently, if the BYOA customer is assigned the required AWS Profile on the instance or will deploy scylla in GCP customer will able to fetch metadata about the OS itself, and also be able to execute a command on a target instance, which may lead to loose of control for instances deployed in BYOA.

Fixes: https://github.com/scylladb/scylla-pkg/issues/4883

### Testing
- [x] https://jenkins.scylladb.com/job/releng-testing/job/next-machine-image/21/