### PR TITLE
Trigger Jenkins job using github action

### DIFF
--- a/.github/workflows/trigger_jenkins.yaml
+++ b/.github/workflows/trigger_jenkins.yaml
@@ -1,0 +1,43 @@
+name: Trigger Jenkins Job
+
+on:
+  push:
+    branches:
+      - next**
+
+jobs:
+  trigger-jenkins:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Determine Jenkins Job Name
+        run: |
+          if [[ "${{ github.ref_name }}" == "next" ]]; then
+            echo "JOB_NAME=scylla-master/next-machine-image" >> $GITHUB_ENV
+          else
+            VERSION=$(echo "${{ github.ref_name }}" | awk -F'-' '{print $2}')
+            echo "JOB_NAME=scylla-${VERSION}/next-machine-image-trigger" >> $GITHUB_ENV
+          fi
+
+      - name: Trigger Jenkins Job
+        env:
+          JENKINS_USER: ${{ secrets.JENKINS_USERNAME }}
+          JENKINS_API_TOKEN: ${{ secrets.JENKINS_TOKEN }}
+          JENKINS_URL: "https://jenkins.scylladb.com"
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        run: |
+          echo "Triggering Jenkins Job: $JOB_NAME"
+          if ! curl -X POST "$JENKINS_URL/job/$JOB_NAME/build" --fail --user "$JENKINS_USER:$JENKINS_API_TOKEN"; then
+            echo "Error: Jenkins job trigger failed"
+
+            # Send Slack message
+            curl -X POST -H 'Content-type: application/json' \
+              -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+              --data '{
+                "channel": "#jenkins-notifications",
+                "text": "🚨 Jenkins job *'$JOB_NAME'* failed!",
+                "icon_emoji": ":warning:"
+              }' \
+              https://slack.com/api/chat.postMessage
+
+            exit 1
+          fi


### PR DESCRIPTION
This action will help preventing next-trigger and next-trigger-machine-image for running every 15 minutes.

This action will run on push for a specific branch. For now we'll start with releng-testing for the first tests

Fixes: #4853