### PR TITLE
Fix trigger_jenkins action - FOLDER_NAME regex

### DIFF
--- a/.github/workflows/trigger_jenkins.yaml
+++ b/.github/workflows/trigger_jenkins.yaml
@@ -15,10 +15,10 @@ jobs:
             FOLDER_NAME="scylla-master"
           else
             VERSION=$(echo "${{ github.ref_name }}" | awk -F'-' '{print $2}')
-            if [[ "$VERSION" =~ ^[0-9]+\.[0-9]+$ ]]; then
-              FOLDER_NAME="scylla-$VERSION"
-            elif [[ "$VERSION" =~ ^202[0-4]\.[0-9]+$ ]]; then
+            if [[ "$VERSION" =~ ^202[0-4]\.[0-9]+$ ]]; then
               FOLDER_NAME="enterprise-$VERSION"
+            elif [[ "$VERSION" =~ ^[0-9]+\.[0-9]+$ ]]; then
+              FOLDER_NAME="scylla-$VERSION"
             fi
           fi
           echo "JOB_NAME=${FOLDER_NAME}/job/next-machine-image" >> $GITHUB_ENV


### PR DESCRIPTION
Releases like 2024.1 or 2024.2 are falling under the regex rule for ^[0-9]+\.[0-9]+ To avoid it, we are changing the order of the regex rules so 2024.x falls under enterprise-$VERSION while 2025.x 6.x x.x falls under scylla-$VERSION

Relates to issue #4853