### PR TITLE
Use github action instead of curl method to trigger jenkins

### DIFF
--- a/.github/workflows/trigger_jenkins.yaml
+++ b/.github/workflows/trigger_jenkins.yaml
@@ -1,4 +1,4 @@
-name: Trigger Jenkins Job
+name: Trigger next-machine-image gating
 
 on:
   push:
@@ -13,6 +13,8 @@ jobs:
         run: |
           if [[ "${{ github.ref_name }}" == "next" ]]; then
             FOLDER_NAME="scylla-master"
+          elif [[ "${{ github.ref_name }}" == "next-enterprise" ]]; then
+            FOLDER_NAME="scylla-enterprise"
           else
             VERSION=$(echo "${{ github.ref_name }}" | awk -F'-' '{print $2}')
             if [[ "$VERSION" =~ ^202[0-4]\.[0-9]+$ ]]; then
@@ -23,25 +25,22 @@ jobs:
           fi
           echo "JOB_NAME=${FOLDER_NAME}/job/next-machine-image" >> $GITHUB_ENV
 
-      - name: Trigger Jenkins Job
-        env:
-          JENKINS_USER: ${{ secrets.JENKINS_USERNAME }}
-          JENKINS_API_TOKEN: ${{ secrets.JENKINS_TOKEN }}
-          JENKINS_URL: "https://jenkins.scylladb.com"
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      - name: Start Jenkins Job
+        uses: scylladb-actions/jenkins-client@v0.1.0
+        with:
+          job_name: ${{ env.JOB_NAME }}
+          base_url: https://jenkins.scylladb.com
+          user: ${{ secrets.JENKINS_USERNAME }}
+          password: ${{ secrets.JENKINS_TOKEN }}
+
+      - name: Notify Slack on Failure
+        if: failure()
         run: |
-          echo "Triggering Jenkins Job: $JOB_NAME"
-          if ! curl -X POST "$JENKINS_URL/job/$JOB_NAME/buildWithParameters" --fail --user "$JENKINS_USER:$JENKINS_API_TOKEN" -i -v; then
-            echo "Error: Jenkins job trigger failed"
-
-            # Send Slack message
-            curl -X POST -H 'Content-type: application/json' \
-              -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
-              --data '{
-                "channel": "#releng-team",
-                "text": "🚨 @here '$JOB_NAME' failed to be triggered, please check https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }} for more details"
-              }' \
-              https://slack.com/api/chat.postMessage
-
-            exit 1
-          fi
+          echo "Action failed, sending Slack alert..."
+          curl -X POST -H 'Content-type: application/json' \
+            -H "Authorization: Bearer ${{ secrets.SLACK_BOT_TOKEN }}" \
+            --data '{
+              "channel": "#releng-team",
+              "text": "🚨 @here '${{ env.JOB_NAME }}' failed to be triggered, please check https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }} for more details."
+            }' \
+            https://slack.com/api/chat.postMessage


### PR DESCRIPTION
Improves the way we trigger next-machine-image job using a dedicated github action instead of using curl.

Fixes: scylladb#659