### PR TITLE
Update github action using curl method

### DIFF
--- a/.github/workflows/trigger_jenkins.yaml
+++ b/.github/workflows/trigger_jenkins.yaml
@@ -25,22 +25,26 @@ jobs:
           fi
           echo "JOB_NAME=${FOLDER_NAME}/job/next-machine-image" >> $GITHUB_ENV
 
-      - name: Start Jenkins Job
-        uses: scylladb-actions/jenkins-client@v0.2.0
-        with:
-          job_name: ${{ env.JOB_NAME }}
-          base_url: https://jenkins.scylladb.com
-          user: ${{ secrets.JENKINS_USERNAME }}
-          password: ${{ secrets.JENKINS_TOKEN }}
-
-      - name: Notify Slack on Failure
-        if: failure()
+      - name: Trigger Jenkins Job
+        env:
+          JENKINS_USER: ${{ secrets.JENKINS_USERNAME }}
+          JENKINS_API_TOKEN: ${{ secrets.JENKINS_TOKEN }}
+          JENKINS_URL: "https://jenkins.scylladb.com"
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         run: |
-          echo "Action failed, sending Slack alert..."
-          curl -X POST -H 'Content-type: application/json' \
-            -H "Authorization: Bearer ${{ secrets.SLACK_BOT_TOKEN }}" \
-            --data '{
-              "channel": "#releng-team",
-              "text": "🚨 @here '${{ env.JOB_NAME }}' failed to be triggered, please check https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }} for more details."
-            }' \
-            https://slack.com/api/chat.postMessage
+          echo "Triggering Jenkins Job: $JOB_NAME"
+          if ! curl -X POST "$JENKINS_URL/job/$JOB_NAME/buildWithParameters" --fail --user "$JENKINS_USER:$JENKINS_API_TOKEN" -i -v; then
+            echo "Error: Jenkins job trigger failed"
+
+            # Send Slack message
+            curl -X POST -H 'Content-type: application/json' \
+              -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+              --data '{
+                "channel": "#releng-team",
+                "text": "🚨 @here '$JOB_NAME' failed to be triggered, please check https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }} for more details",
+                "icon_emoji": ":warning:"
+              }' \
+              https://slack.com/api/chat.postMessage
+
+            exit 1
+          fi


### PR DESCRIPTION
Before we were using a marketplace Github action which had some limitations. With this pull request we are updating the github action using curl option which will gives us full control of the flow instead of relying on pre made github action.

Fixes: scylladb#659