### PR TITLE
aws: add i8g instance type

### DIFF
--- a/common/aws_io_params.yaml
+++ b/common/aws_io_params.yaml
@@ -588,3 +588,47 @@ i7ie.ALL:
   read_bandwidth: 3422623232
   write_iops: 119327
   write_bandwidth: 1526442410
+i8g.large:
+  read_iops: 82268
+  read_bandwidth: 605359957
+  write_iops: 45598
+  write_bandwidth: 419360096
+i8g.xlarge:
+  read_iops: 164442
+  read_bandwidth: 1216944170
+  write_iops: 90446
+  write_bandwidth: 838613674
+i8g.2xlarge:
+  read_iops: 328275
+  read_bandwidth: 2438557696
+  write_iops: 134545
+  write_bandwidth: 1687947733
+i8g.4xlarge:
+  read_iops: 553607
+  read_bandwidth: 4797597013
+  write_iops: 140814
+  write_bandwidth: 3419948373
+i8g.8xlarge:
+  read_iops: 527429
+  read_bandwidth: 4797424981
+  write_iops: 139669
+  write_bandwidth: 3421133482
+i8g.12xlarge:
+  read_iops: 511314
+  read_bandwidth: 4794307754
+  write_iops: 139187
+  write_bandwidth: 3421301930
+i8g.16xlarge:
+  read_iops: 505671
+  read_bandwidth: 4797634048
+  write_iops: 139999
+  write_bandwidth: 3420557226
+i8g.24xlarge:
+  read_iops: 518127
+  read_bandwidth: 4796989610
+  write_iops: 139994
+  write_bandwidth: 3423059285
+i8g.metal-24xl:
+  read_iops: 511950
+  read_bandwidth: 4788620288
+  write_iops: 139157

--- a/lib/scylla_cloud.py
+++ b/lib/scylla_cloud.py
@@ -812,7 +812,7 @@ class aws_instance(cloud_instance):
         return self._type.split(".")[0]
 
     def is_supported_instance_class(self):
-        if self.instance_class() in ['i2', 'i3', 'i3en', 'c5d', 'm5d', 'm5ad', 'r5d', 'z1d', 'c6gd', 'm6gd', 'r6gd', 'x2gd', 'im4gn', 'is4gen', 'i4i', 'i4g', 'i7ie']:
+        if self.instance_class() in ['i2', 'i3', 'i3en', 'c5d', 'm5d', 'm5ad', 'r5d', 'z1d', 'c6gd', 'm6gd', 'r6gd', 'x2gd', 'im4gn', 'is4gen', 'i4i', 'i4g', 'i7ie', 'i8g']:
             return True
         return False
 
@@ -826,7 +826,7 @@ class aws_instance(cloud_instance):
         instance_size = self.instance_size()
         if instance_class in ['c3', 'c4', 'd2', 'i2', 'r3']:
             return 'ixgbevf'
-        if instance_class in ['a1', 'c5', 'c5a', 'c5d', 'c5n', 'c6g', 'c6gd', 'f1', 'g3', 'g4', 'h1', 'i3', 'i3en', 'inf1', 'm5', 'm5a', 'm5ad', 'm5d', 'm5dn', 'm5n', 'm6g', 'm6gd', 'p2', 'p3', 'r4', 'r5', 'r5a', 'r5ad', 'r5b', 'r5d', 'r5dn', 'r5n', 't3', 't3a', 'u-6tb1', 'u-9tb1', 'u-12tb1', 'u-18tn1', 'u-24tb1', 'x1', 'x1e', 'z1d', 'c6g', 'c6gd', 'm6g', 'm6gd', 't4g', 'r6g', 'r6gd', 'x2gd', 'im4gn', 'is4gen', 'i4i', 'i4g', 'i7ie']:
+        if instance_class in ['a1', 'c5', 'c5a', 'c5d', 'c5n', 'c6g', 'c6gd', 'f1', 'g3', 'g4', 'h1', 'i3', 'i3en', 'inf1', 'm5', 'm5a', 'm5ad', 'm5d', 'm5dn', 'm5n', 'm6g', 'm6gd', 'p2', 'p3', 'r4', 'r5', 'r5a', 'r5ad', 'r5b', 'r5d', 'r5dn', 'r5n', 't3', 't3a', 'u-6tb1', 'u-9tb1', 'u-12tb1', 'u-18tn1', 'u-24tb1', 'x1', 'x1e', 'z1d', 'c6g', 'c6gd', 'm6g', 'm6gd', 't4g', 'r6g', 'r6gd', 'x2gd', 'im4gn', 'is4gen', 'i4i', 'i4g', 'i7ie', 'i8g']:
             return 'ena'
         if instance_class == 'm4':
             if instance_size == '16xlarge':


### PR DESCRIPTION
Adding preset io parameters of i8g to scylla_cloud_io_setup, and also added i8g to supported instance type on aws_instance class.

All preset values are measured by iotune on target instances.

Here's measurement environment details:
 - Measured on i8g.* instances with latest version of Ubuntu 24.04 LTS AMI (We cannot use Scylla AMI since we do want to measure single drive performance)
 - Measured single local SSD w/o RAID0, since we simulate RAID0 performance on scylla_cloud_io_setup script from single drive performance
 - Use iotune for the measurement, executed 3 times for each instance size and used average of the results
 - Automated measurement by script: https://github.com/syuu1228/ec2_run_script

Here's raw output of iotune:
- i8g.large (0/3) Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 399 MB/s (deviation 14%) Measuring sequential read bandwidth: 577 MB/s (deviation 43%) Measuring random write IOPS: 45598 IOPS (deviation 31%) Measuring random read IOPS: 82269 IOPS (deviation 29%) Writing result to /etc/scylla.d/io_properties.yaml

- i8g.large (1/3) Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 399 MB/s (deviation 14%) Measuring sequential read bandwidth: 577 MB/s (deviation 43%) Measuring random write IOPS: 45601 IOPS (deviation 31%) Measuring random read IOPS: 82266 IOPS (deviation 29%) Writing result to /etc/scylla.d/io_properties.yaml

- i8g.large (2/3) Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 399 MB/s (deviation 14%) Measuring sequential read bandwidth: 577 MB/s (deviation 43%) Measuring random write IOPS: 45596 IOPS (deviation 31%) Measuring random read IOPS: 82269 IOPS (deviation 29%) Writing result to /etc/scylla.d/io_properties.yaml

- i8g.xlarge (0/3) Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 799 MB/s (deviation 14%) Measuring sequential read bandwidth: 1160 MB/s (deviation 43%) Measuring random write IOPS: 90444 IOPS (deviation 19%) Measuring random read IOPS: 164432 IOPS (deviation 29%) Writing result to /etc/scylla.d/io_properties.yaml

- i8g.xlarge (1/3) Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 799 MB/s (deviation 14%) Measuring sequential read bandwidth: 1160 MB/s (deviation 43%) Measuring random write IOPS: 90490 IOPS (deviation 20%) Measuring random read IOPS: 164456 IOPS (deviation 29%) Writing result to /etc/scylla.d/io_properties.yaml

- i8g.xlarge (2/3) Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 799 MB/s (deviation 14%) Measuring sequential read bandwidth: 1160 MB/s (deviation 43%) Measuring random write IOPS: 90405 IOPS (deviation 19%) Measuring random read IOPS: 164439 IOPS (deviation 29%) Writing result to /etc/scylla.d/io_properties.yaml

- i8g.2xlarge (0/3) Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 1609 MB/s (deviation 14%) Measuring sequential read bandwidth: 2325 MB/s (deviation 41%) Measuring random write IOPS: 135841 IOPS
Measuring random read IOPS: 328308 IOPS (deviation 23%) Writing result to /etc/scylla.d/io_properties.yaml

- i8g.2xlarge (1/3) Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 1609 MB/s (deviation 14%) Measuring sequential read bandwidth: 2325 MB/s (deviation 41%) Measuring random write IOPS: 133803 IOPS (deviation 3%) Measuring random read IOPS: 328216 IOPS (deviation 22%) Writing result to /etc/scylla.d/io_properties.yaml

- i8g.2xlarge (2/3) Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 1609 MB/s (deviation 14%) Measuring sequential read bandwidth: 2325 MB/s (deviation 41%) Measuring random write IOPS: 133992 IOPS
Measuring random read IOPS: 328302 IOPS (deviation 23%) Writing result to /etc/scylla.d/io_properties.yaml

- i8g.4xlarge (0/3) Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 3260 MB/s (deviation 10%) Measuring sequential read bandwidth: 4575 MB/s (deviation 26%) Measuring random write IOPS: 141234 IOPS
Measuring random read IOPS: 554281 IOPS
Writing result to /etc/scylla.d/io_properties.yaml

- i8g.4xlarge (1/3) Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 3262 MB/s (deviation 10%) Measuring sequential read bandwidth: 4575 MB/s (deviation 26%) Measuring random write IOPS: 140699 IOPS
Measuring random read IOPS: 552544 IOPS
Writing result to /etc/scylla.d/io_properties.yaml

- i8g.4xlarge (2/3) Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 3262 MB/s (deviation 10%) Measuring sequential read bandwidth: 4575 MB/s (deviation 26%) Measuring random write IOPS: 140510 IOPS
Measuring random read IOPS: 553998 IOPS
Writing result to /etc/scylla.d/io_properties.yaml

- i8g.8xlarge (0/3) Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 3262 MB/s (deviation 8%) Measuring sequential read bandwidth: 4574 MB/s (deviation 26%) Measuring random write IOPS: 139456 IOPS
Measuring random read IOPS: 528086 IOPS
Writing result to /etc/scylla.d/io_properties.yaml

- i8g.8xlarge (1/3) Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 3262 MB/s (deviation 8%) Measuring sequential read bandwidth: 4575 MB/s (deviation 26%) Measuring random write IOPS: 140425 IOPS
Measuring random read IOPS: 527157 IOPS
Writing result to /etc/scylla.d/io_properties.yaml

- i8g.8xlarge (2/3) Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 3262 MB/s (deviation 9%) Measuring sequential read bandwidth: 4575 MB/s (deviation 26%) Measuring random write IOPS: 139128 IOPS
Measuring random read IOPS: 527045 IOPS
Writing result to /etc/scylla.d/io_properties.yaml

- i8g.12xlarge (0/3) Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 3263 MB/s (deviation 10%) Measuring sequential read bandwidth: 4575 MB/s (deviation 26%) Measuring random write IOPS: 139198 IOPS
Measuring random read IOPS: 512264 IOPS
Writing result to /etc/scylla.d/io_properties.yaml

- i8g.12xlarge (1/3) Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 3262 MB/s (deviation 11%) Measuring sequential read bandwidth: 4566 MB/s (deviation 25%) Measuring random write IOPS: 139031 IOPS
Measuring random read IOPS: 509359 IOPS
Writing result to /etc/scylla.d/io_properties.yaml

- i8g.12xlarge (2/3) Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 3262 MB/s (deviation 10%) Measuring sequential read bandwidth: 4575 MB/s (deviation 26%) Measuring random write IOPS: 139333 IOPS
Measuring random read IOPS: 512320 IOPS
Writing result to /etc/scylla.d/io_properties.yaml

- i8g.16xlarge (0/3) Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 3262 MB/s (deviation 10%) Measuring sequential read bandwidth: 4575 MB/s (deviation 26%) Measuring random write IOPS: 140104 IOPS
Measuring random read IOPS: 506129 IOPS
Writing result to /etc/scylla.d/io_properties.yaml

- i8g.16xlarge (1/3) Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 3262 MB/s (deviation 10%) Measuring sequential read bandwidth: 4575 MB/s (deviation 26%) Measuring random write IOPS: 139681 IOPS
Measuring random read IOPS: 504401 IOPS
Writing result to /etc/scylla.d/io_properties.yaml

- i8g.16xlarge (2/3) Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 3261 MB/s (deviation 10%) Measuring sequential read bandwidth: 4575 MB/s (deviation 26%) Measuring random write IOPS: 140213 IOPS
Measuring random read IOPS: 506485 IOPS
Writing result to /etc/scylla.d/io_properties.yaml

- i8g.24xlarge (0/3) Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 3265 MB/s (deviation 14%) Measuring sequential read bandwidth: 4574 MB/s (deviation 26%) Measuring random write IOPS: 139638 IOPS
Measuring random read IOPS: 517821 IOPS
Writing result to /etc/scylla.d/io_properties.yaml

- i8g.24xlarge (1/3) Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 3262 MB/s (deviation 10%) Measuring sequential read bandwidth: 4574 MB/s (deviation 26%) Measuring random write IOPS: 140312 IOPS
Measuring random read IOPS: 517178 IOPS
Writing result to /etc/scylla.d/io_properties.yaml

- i8g.24xlarge (2/3) Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 3265 MB/s (deviation 14%) Measuring sequential read bandwidth: 4574 MB/s (deviation 26%) Measuring random write IOPS: 140032 IOPS
Measuring random read IOPS: 519382 IOPS (deviation 3%) Writing result to /etc/scylla.d/io_properties.yaml

- i8g.metal-24xl (0/3) Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 3260 MB/s (deviation 10%) Measuring sequential read bandwidth: 4569 MB/s (deviation 25%) Measuring random write IOPS: 138682 IOPS
Measuring random read IOPS: 513462 IOPS
Writing result to /etc/scylla.d/io_properties.yaml

- i8g.metal-24xl (1/3) Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 3263 MB/s (deviation 10%) Measuring sequential read bandwidth: 4575 MB/s (deviation 26%) Measuring random write IOPS: 139715 IOPS
Measuring random read IOPS: 510749 IOPS
Writing result to /etc/scylla.d/io_properties.yaml

- i8g.metal-24xl (2/3) Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 3260 MB/s (deviation 9%) Measuring sequential read bandwidth: 4555 MB/s (deviation 24%) Measuring random write IOPS: 139076 IOPS
Measuring random read IOPS: 511639 IOPS
Writing result to /etc/scylla.d/io_properties.yaml

Fixes #560