### PR TITLE
images: add netcat-openbsd package

### DIFF
--- a/packer/scylla_install_image
+++ b/packer/scylla_install_image
@@ -79,7 +79,7 @@ if __name__ == '__main__':
     run('apt-get update --allow-insecure-repositories -y', shell=True, check=True)
     run('apt-get full-upgrade -y', shell=True, check=True)
     run('apt-get purge -y apport python3-apport fuse', shell=True, check=True)
-    run('apt-get install -y systemd-coredump vim.tiny nmap ncat tmux jq python3-boto xfsprogs mdadm initramfs-tools ethtool vim-nox sysstat cpufrequtils nload htop traceroute dnsutils net-tools', shell=True, check=True)
+    run('apt-get install -y systemd-coredump vim.tiny nmap ncat tmux jq python3-boto xfsprogs mdadm initramfs-tools ethtool vim-nox sysstat cpufrequtils nload htop traceroute dnsutils net-tools netcat-openbsd', shell=True, check=True)
     run(f'apt-get install -y --auto-remove --allow-unauthenticated {args.product}-machine-image {args.product}-server-dbg', shell=True, check=True)
 
     os.remove('/etc/apt/sources.list.d/scylla_install.list')


### PR DESCRIPTION
As it required by the cloud team

Fixes: https://github.com/scylladb/scylla-machine-image/issues/682

### Testing
- [ ] https://jenkins.scylladb.com/job/releng-testing/job/next-machine-image/30/