### PR TITLE
aws: add i7i instance type

### DIFF
--- a/common/aws_io_params.yaml
+++ b/common/aws_io_params.yaml
@@ -588,3 +588,23 @@ i7ie.ALL:
   read_bandwidth: 3422623232
   write_iops: 119327
   write_bandwidth: 1526442410
+i7i.large:
+  read_iops: 82265
+  read_bandwidth: 605572458
+  write_iops: 45701
+  write_bandwidth: 419357536
+i7i.xlarge:
+  read_iops: 164466
+  read_bandwidth: 1216811392
+  write_iops: 91157
+  write_bandwidth: 838602026
+i7i.2xlarge:
+  read_iops: 328246
+  read_bandwidth: 2438352896
+  write_iops: 180500
+  write_bandwidth: 1688460672
+i7i.ALL:
+  read_iops: 561784
+  read_bandwidth: 4797273429
+  write_iops: 248036
+  write_bandwidth: 3424567808


### PR DESCRIPTION
Adding preset io parameters of i7ie to scylla_cloud_io_setup, and also added i7ie to supported instance type on aws_instance class.

All preset values are measured by iotune on target instances.

Fixes #692

Here's measurement environment details:
 - Measured on i7ie.* instances with latest version of Ubuntu 24.04 LTS AMI (We cannot use Scylla AMI since we do want to measure single drive performance)
 - Measured single local SSD w/o RAID0, since we simulate RAID0 performance on scylla_cloud_io_setup script from single drive performance
 - Use iotune for the measurement, executed 3 times for each instance size and used average of the results
 - Automated measurement by script: https://github.com/syuu1228/ec2_run_script

Here's raw output of iotune:
- i7i.large (1/3) Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 399 MB/s (deviation 14%) Measuring sequential read bandwidth: 577 MB/s (deviation 43%) Measuring random write IOPS: 45712 IOPS (deviation 32%) Measuring random read IOPS: 82263 IOPS (deviation 29%)

- i7i.large (2/3) Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 399 MB/s (deviation 14%) Measuring sequential read bandwidth: 577 MB/s (deviation 43%) Measuring random write IOPS: 45694 IOPS (deviation 32%) Measuring random read IOPS: 82269 IOPS (deviation 29%)

- i7i.large (3/3) Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 399 MB/s (deviation 14%) Measuring sequential read bandwidth: 577 MB/s (deviation 43%) Measuring random write IOPS: 45698 IOPS (deviation 32%) Measuring random read IOPS: 82263 IOPS (deviation 29%)

- i7i.xlarge (1/3) Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 799 MB/s (deviation 14%) Measuring sequential read bandwidth: 1160 MB/s (deviation 43%) Measuring random write IOPS: 91169 IOPS (deviation 31%) Measuring random read IOPS: 164463 IOPS (deviation 29%)

- i7i.xlarge (2/3) Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 799 MB/s (deviation 14%) Measuring sequential read bandwidth: 1160 MB/s (deviation 43%) Measuring random write IOPS: 91140 IOPS (deviation 31%) Measuring random read IOPS: 164471 IOPS (deviation 29%)

- i7i.xlarge (3/3) Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 799 MB/s (deviation 14%) Measuring sequential read bandwidth: 1160 MB/s (deviation 43%) Measuring random write IOPS: 91163 IOPS (deviation 31%) Measuring random read IOPS: 164464 IOPS (deviation 29%)

- i7i.2xlarge (1/3) Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 1610 MB/s (deviation 14%) Measuring sequential read bandwidth: 2325 MB/s (deviation 41%) Measuring random write IOPS: 180511 IOPS (deviation 16%) Measuring random read IOPS: 328265 IOPS (deviation 22%)

- i7i.2xlarge (2/3) Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 1610 MB/s (deviation 14%) Measuring sequential read bandwidth: 2325 MB/s (deviation 41%) Measuring random write IOPS: 180505 IOPS (deviation 16%) Measuring random read IOPS: 328285 IOPS (deviation 22%)

- i7i.2xlarge (3/3) Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 1610 MB/s (deviation 14%) Measuring sequential read bandwidth: 2325 MB/s (deviation 41%) Measuring random write IOPS: 180486 IOPS (deviation 16%) Measuring random read IOPS: 328188 IOPS (deviation 20%)

- i7i.4xlarge (1/3) Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 3265 MB/s (deviation 15%) Measuring sequential read bandwidth: 4574 MB/s (deviation 26%) Measuring random write IOPS: 246500 IOPS
Measuring random read IOPS: 560832 IOPS

- i7i.4xlarge (2/3) Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 3265 MB/s (deviation 15%) Measuring sequential read bandwidth: 4574 MB/s (deviation 26%) Measuring random write IOPS: 249999 IOPS
Measuring random read IOPS: 568353 IOPS

- i7i.4xlarge (3/3) Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 3265 MB/s (deviation 15%) Measuring sequential read bandwidth: 4575 MB/s (deviation 26%) Measuring random write IOPS: 247609 IOPS
Measuring random read IOPS: 556168 IOPS

- i7i.8xlarge (1/3) Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 3266 MB/s (deviation 9%) Measuring sequential read bandwidth: 4575 MB/s (deviation 26%) Measuring random write IOPS: 249854 IOPS
Measuring random read IOPS: 546530 IOPS

- i7i.8xlarge (2/3) Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 3263 MB/s (deviation 9%) Measuring sequential read bandwidth: 4575 MB/s (deviation 26%) Measuring random write IOPS: 245093 IOPS
Measuring random read IOPS: 540857 IOPS

- i7i.8xlarge (3/3) Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 3257 MB/s (deviation 8%) Measuring sequential read bandwidth: 4574 MB/s (deviation 26%) Measuring random write IOPS: 245359 IOPS
Measuring random read IOPS: 518827 IOPS (deviation 4%)

- i7i.12xlarge (1/3) Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 3265 MB/s (deviation 11%) Measuring sequential read bandwidth: 4575 MB/s (deviation 26%) Measuring random write IOPS: 248215 IOPS
Measuring random read IOPS: 521225 IOPS

- i7i.12xlarge (2/3) Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 3266 MB/s (deviation 11%) Measuring sequential read bandwidth: 4574 MB/s (deviation 26%) Measuring random write IOPS: 251375 IOPS
Measuring random read IOPS: 523440 IOPS

- i7i.12xlarge (3/3) Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 3265 MB/s (deviation 11%) Measuring sequential read bandwidth: 4574 MB/s (deviation 26%) Measuring random write IOPS: 240908 IOPS (deviation 4%) Measuring random read IOPS: 514354 IOPS (deviation 3%)

- i7i.16xlarge (1/3) Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 3265 MB/s (deviation 13%) Measuring sequential read bandwidth: 4574 MB/s (deviation 26%) Measuring random write IOPS: 249440 IOPS
Measuring random read IOPS: 515151 IOPS

- i7i.16xlarge (2/3) Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 3266 MB/s (deviation 13%) Measuring sequential read bandwidth: 4574 MB/s (deviation 26%) Measuring random write IOPS: 250466 IOPS
Measuring random read IOPS: 514093 IOPS

- i7i.16xlarge (3/3) Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 3266 MB/s (deviation 13%) Measuring sequential read bandwidth: 4574 MB/s (deviation 26%) Measuring random write IOPS: 249342 IOPS
Measuring random read IOPS: 512713 IOPS

- i7i.24xlarge (1/3) Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 3265 MB/s (deviation 15%) Measuring sequential read bandwidth: 4575 MB/s (deviation 26%) Measuring random write IOPS: 248951 IOPS
Measuring random read IOPS: 512901 IOPS

- i7i.24xlarge (2/3) Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 3265 MB/s (deviation 15%) Measuring sequential read bandwidth: 4574 MB/s (deviation 26%) Measuring random write IOPS: 248283 IOPS
Measuring random read IOPS: 513042 IOPS

- i7i.24xlarge (3/3) Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 3265 MB/s (deviation 15%) Measuring sequential read bandwidth: 4574 MB/s (deviation 26%) Measuring random write IOPS: 250348 IOPS
Measuring random read IOPS: 512544 IOPS

- i7i.48xlarge (1/3) Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 3262 MB/s (deviation 12%) Measuring sequential read bandwidth: 4575 MB/s (deviation 26%) Measuring random write IOPS: 247373 IOPS
Measuring random read IOPS: 511375 IOPS

- i7i.48xlarge (2/3) Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 3264 MB/s (deviation 15%) Measuring sequential read bandwidth: 4575 MB/s (deviation 26%) Measuring random write IOPS: 250994 IOPS
Measuring random read IOPS: 515932 IOPS

- i7i.48xlarge (3/3) Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 3265 MB/s (deviation 15%) Measuring sequential read bandwidth: 4575 MB/s (deviation 26%) Measuring random write IOPS: 250780 IOPS
Measuring random read IOPS: 517635 IOPS

- i7i.metal-24xl (1/3) Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 3261 MB/s (deviation 10%) Measuring sequential read bandwidth: 4573 MB/s (deviation 26%) Measuring random write IOPS: 246856 IOPS
Measuring random read IOPS: 512565 IOPS

- i7i.metal-24xl (2/3) Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 3262 MB/s (deviation 11%) Measuring sequential read bandwidth: 4574 MB/s (deviation 26%) Measuring random write IOPS: 248236 IOPS
Measuring random read IOPS: 512179 IOPS

- i7i.metal-24xl (3/3) Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 3261 MB/s (deviation 11%) Measuring sequential read bandwidth: 4574 MB/s (deviation 26%) Measuring random write IOPS: 249682 IOPS
Measuring random read IOPS: 518655 IOPS

- i7i.metal-48xl (1/3) Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 3263 MB/s (deviation 12%) Measuring sequential read bandwidth: 4574 MB/s (deviation 26%) Measuring random write IOPS: 248840 IOPS
Measuring random read IOPS: 529465 IOPS

- i7i.metal-48xl (2/3) Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 3265 MB/s (deviation 15%) Measuring sequential read bandwidth: 4574 MB/s (deviation 26%) Measuring random write IOPS: 251506 IOPS
Measuring random read IOPS: 532888 IOPS

- i7i.metal-48xl (3/3) Starting Evaluation. This may take a while...
Measuring sequential write bandwidth: 3264 MB/s (deviation 15%) Measuring sequential read bandwidth: 4574 MB/s (deviation 26%) Measuring random write IOPS: 250415 IOPS
Measuring random read IOPS: 530083 IOPS