### PR TITLE
Ensure that Users Have Sensible Umask Values

### DIFF
--- a/packer/apply_cis_rules
+++ b/packer/apply_cis_rules
@@ -238,3 +238,28 @@ MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512,h
     with open('/etc/ssh/sshd_config.d/99-cis-rules.conf', 'w') as f:
         f.write(sshd_config)
     run('systemctl restart ssh.service', shell=True, check=True)
+
+
+    # xccdf_org.ssgproject.content_rule_accounts_umask_etc_bashrc
+    bash_bashrc = '''
+
+umask 027
+    '''[1:-1]
+    with open('/etc/bash.bashrc', 'a') as f:
+        f.write(bash_bashrc)
+
+    # xccdf_org.ssgproject.content_rule_accounts_umask_etc_login_defs
+    with open('/etc/login.defs') as f:
+        login_defs = f.read()
+    login_defs = re.sub(r'^UMASK\s+022', 'UMASK           027', login_defs, flags=re.MULTILINE)
+    with open('/etc/login.defs', 'w') as f:
+        f.write(login_defs)
+
+    # xccdf_org.ssgproject.content_rule_accounts_umask_etc_profile
+    umask_sh = '''
+#!/bin/bash
+umask 027
+    '''[1:-1]
+    with open('/etc/profile.d/99-umask.sh', 'w') as f:
+        f.write(umask_sh)
+    os.chmod('/etc/profile.d/99-umask.sh', 0o755)


### PR DESCRIPTION
We should configure default umask to more strict value.

This will apply following CIS compliance rules:
- xccdf_org.ssgproject.content_rule_accounts_umask_etc_bashrc
- xccdf_org.ssgproject.content_rule_accounts_umask_etc_login_defs
- xccdf_org.ssgproject.content_rule_accounts_umask_etc_profile

Fixes #704