### PR TITLE
Set Interactive Session Timeout

### DIFF
--- a/packer/apply_cis_rules
+++ b/packer/apply_cis_rules
@@ -238,3 +238,12 @@ MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512,h
     with open('/etc/ssh/sshd_config.d/99-cis-rules.conf', 'w') as f:
         f.write(sshd_config)
     run('systemctl restart ssh.service', shell=True, check=True)
+
+    # xccdf_org.ssgproject.content_rule_accounts_tmout
+    var_accounts_tmout = '900'
+    with open('/etc/profile.d/tmout.sh', 'w') as file:
+        file.write(f"\n# Set TMOUT to {var_accounts_tmout} per security requirements\n")
+        file.write(f"TMOUT={var_accounts_tmout}\n")
+        file.write("readonly TMOUT\n")
+        file.write("export TMOUT\n")
+    os.chmod('/etc/profile.d/tmout.sh', 0o755)


### PR DESCRIPTION
Setting the TMOUT option in /etc/profile ensures that all user sessions will terminate based on inactivity. The value of TMOUT should be exported and read only. The TMOUT setting in a file loaded by /etc/profile, e.g. /etc/profile.d/tmout.sh should read as follows:

```
TMOUT=900
readonly TMOUT export TMOUT
```

Rationale:
Terminating an idle session within a short time period reduces the window of opportunity for unauthorized personnel to take control of a management session enabled on the console or console port that has been left unattended.

This will apply following CIS compliance rules:
 - xccdf_org.ssgproject.content_rule_accounts_tmout

fixes #705
Related scylladb/scylla-pkg#2953