### PR TITLE
Set Password Maximum Age

### DIFF
--- a/packer/apply_cis_rules
+++ b/packer/apply_cis_rules
@@ -358,3 +358,26 @@ ucredit = -1
     # Write the modified content back to the file
     with open(PAM_CONF, 'w') as f:
         f.write(content)
+
+
+    # xccdf_org.ssgproject.content_rule_accounts_maximum_age_login_defs
+    var_accounts_maximum_age_login_defs = '365'
+
+    # Check if PASS_MAX_DAYS exists in /etc/login.defs
+    with open('/etc/login.defs', 'r') as f:
+        content = f.read()
+
+    if re.search(r'^PASS_MAX_DAYS', content, re.MULTILINE):
+        # Replace existing PASS_MAX_DAYS line
+        new_content = re.sub(r'PASS_MAX_DAYS.*',
+                           f'PASS_MAX_DAYS     {var_accounts_maximum_age_login_defs}',
+                           content)
+        with open('/etc/login.defs', 'w') as f:
+            f.write(new_content)
+        success = True
+    else:
+        success = False
+
+    if not success:
+        with open('/etc/login.defs', 'a') as f:
+            f.write(f"PASS_MAX_DAYS      {var_accounts_maximum_age_login_defs}\n")


### PR DESCRIPTION
To specify password maximum age for new accounts, edit the file /etc/login.defs and add or correct the following line:

PASS_MAX_DAYS 365
A value of 180 days is sufficient for many environments. The DoD requirement is 60. The profile requirement is 365.

Rationale:
Any password, no matter how complex, can eventually be cracked. Therefore, passwords need to be changed periodically. If the operating system does not limit the lifetime of passwords and force users to change their passwords, there is the risk that the operating system passwords could be compromised.

Setting the password maximum age ensures users are required to periodically change their passwords. Requiring shorter password lifetimes increases the risk of users writing down the password in a convenient location subject to physical compromise.

fixes: [SMI-198](https://scylladb.atlassian.net/browse/SMI-198)

[SMI-198]: https://scylladb.atlassian.net/browse/SMI-198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ