### PR TITLE
fix(lib/scylla_cloud.py): SyntaxWarning: invalid escape sequence

### DIFF
--- a/lib/scylla_cloud.py
+++ b/lib/scylla_cloud.py
@@ -744,7 +744,7 @@ class aws_instance(cloud_instance):
     def __populate_disks(self):
         devmap = self.__instance_metadata("meta-data/block-device-mapping")
         self._disks = {}
-        devname = re.compile("^\D+")
+        devname = re.compile(r"^\D+")
         nvmes_present = self._non_root_nvmes()
         for k,v in nvmes_present.items():
             self._disks[k] = v


### PR DESCRIPTION
Log snippet, seen by accident:
```
2025-06-09T20:29:44.859 ip-172-31-177-178 !INFO | systemd[1]: Starting scylla-image-setup.service - Scylla Cloud Image Setup service...
2025-06-09T20:29:45.026 ip-172-31-177-178 !INFO | scylla_image_setup[724]: /opt/scylladb/scylla-machine-image/lib/scylla_cloud.py:747: SyntaxWarning: invalid escape sequence '\D'
2025-06-09T20:29:45.026 ip-172-31-177-178 !INFO | scylla_image_setup[724]:   devname = re.compile("^\D+")
2025-06-09T20:29:45.545 ip-172-31-177-178 !INFO | scylla_image_setup[942]: Setting up swapspace version 1, size = 16 GiB (17179865088 bytes)
```
Scylla version 2025.3.0~dev-0.20250606.1e36d74243d3 with build-id c934458fbac7e9fd36352520650ba7383e29d470

Fixes: https://github.com/scylladb/scylla-machine-image/issues/725