### PR TITLE
Create config.yml - redirect issue creation to Jira

### DIFF
--- a/.github/ISSUE_TEMPLATE /config.yml
+++ b/.github/ISSUE_TEMPLATE /config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false  # Disables blank issue creation
+contact_links:
+  - name: 🚀 Press to open an issue in Jira.
+    url: https://scylladb.atlassian.net/jira/software/c/projects/SMI/list
+    about: "Opening issues is not allowed in this Github repository."


### PR DESCRIPTION
Issue creation for the scylla-machine-image will be via Jira. This file redirects the creation of issues to Jira.