### PR TITLE
Delete .github/ISSUE_TEMPLATE  directory

### DIFF
--- a/.github/ISSUE_TEMPLATE /config.yml
+++ b/.github/ISSUE_TEMPLATE /config.yml
@@ -1,5 +1,0 @@
-blank_issues_enabled: false  # Disables blank issue creation
-contact_links:
-  - name: 🚀 Press to open an issue in Jira.
-    url: https://scylladb.atlassian.net/browse/SMI
-    about: "Opening issues is not allowed in this Github repository."


### PR DESCRIPTION
There was a typo in the directory name (an additional space)