### PR TITLE
Add support for the new z3 instances (GCP)

### DIFF
--- a/common/gcp_io_params.yaml
+++ b/common/gcp_io_params.yaml
@@ -1,0 +1,65 @@
+z3-highmem-8-highlssd:
+  read_iops: 750000
+  read_bandwidth: 3221225472
+  write_iops: 500000
+  write_bandwidth: 2684354560
+
+z3-highmem-16-highlssd:
+  read_iops: 1500000
+  read_bandwidth: 6442450944
+  write_iops: 1000000
+  write_bandwidth: 5368709120
+
+z3-highmem-22-highlssd:
+  read_iops: 2250000
+  read_bandwidth: 9663676416
+  write_iops: 1500000
+  write_bandwidth: 8053063680
+
+z3-highmem-32-highlssd:
+  read_iops: 3000000
+  read_bandwidth: 12884901888
+  write_iops: 2000000
+  write_bandwidth: 10737418240
+
+z3-highmem-44-highlssd:
+  read_iops: 4500000
+  read_bandwidth: 19327352832
+  write_iops: 3000000
+  write_bandwidth: 16106127360
+
+z3-highmem-88-highlssd:
+  read_iops: 9000000
+  read_bandwidth: 38654705664
+  write_iops: 6000000
+  write_bandwidth: 32212254720
+
+z3-highmem-14-standardlssd:
+  read_iops: 750000
+  read_bandwidth: 3221225472
+  write_iops: 500000
+  write_bandwidth: 2684354560
+
+z3-highmem-22-standardlssd:
+  read_iops: 1500000
+  read_bandwidth: 6442450944
+  write_iops: 1000000
+  write_bandwidth: 5368709120
+
+z3-highmem-44-standardlssd:
+  read_iops: 2250000
+  read_bandwidth: 9663676416
+  write_iops: 1500000
+  write_bandwidth: 8053063680
+
+z3-highmem-88-standardlssd:
+  read_iops: 4500000
+  read_bandwidth: 19327352832
+  write_iops: 3000000
+  write_bandwidth: 16106127360
+
+z3-highmem-176-standardlssd:
+  read_iops: 9000000
+  read_bandwidth: 38654705664
+  write_iops: 6000000
+  write_bandwidth: 32212254720

--- a/common/scylla_cloud_io_setup
+++ b/common/scylla_cloud_io_setup
@@ -72,9 +72,31 @@ class gcp_io_setup(cloud_io_setup):
         if not self.idata.is_supported_instance_class():
             logging.error('This is not a recommended Google Cloud instance setup for auto local disk tuning.')
             raise UnsupportedInstanceClassError()
-        self.disk_properties = {}
         self.disk_properties["mountpoint"] = '/var/lib/scylla'
+        
+        instance_type = self.idata.instancetype
         nr_disks = self.idata.nvme_disk_count
+        
+        # Try to load instance-specific parameters from YAML file
+        try:
+            with open('/opt/scylladb/scylla-machine-image/gcp_io_params.yaml') as f:
+                io_params = yaml.safe_load(f)
+            
+            t = None
+            if instance_type in io_params:
+                t = instance_type
+
+            if t:
+                for p in ["read_iops", "read_bandwidth", "write_iops", "write_bandwidth"]:
+                    self.disk_properties[p] = io_params[t][p]
+                self.save()
+                return
+        except FileNotFoundError:
+            logging.warning("GCP I/O parameters file not found, falling back to disk-count-based logic")
+        except Exception as e:
+            logging.warning(f"Error loading GCP I/O parameters: {e}, falling back to disk-count-based logic")
+        
+        # Fallback to original disk-count-based logic for instances not in YAML
         # below is based on https://cloud.google.com/compute/docs/disks/local-ssd#performance
         # and https://cloud.google.com/compute/docs/disks/local-ssd#nvme
         # note that scylla iotune might measure more, this is GCP recommended

--- a/dist/debian/debian/rules
+++ b/dist/debian/debian/rules
@@ -10,6 +10,7 @@ override_dh_auto_install:
 	install -d -m755 $(CURDIR)/debian/tmp/opt/scylladb/scylla-machine-image/lib
 	install -m644 lib/log.py lib/scylla_cloud.py lib/user_data.py lib/param_estimation.py $(CURDIR)/debian/tmp/opt/scylladb/scylla-machine-image/lib
 	install -m644 common/aws_io_params.yaml $(CURDIR)/debian/tmp/opt/scylladb/scylla-machine-image
+	install -m644 common/gcp_io_params.yaml $(CURDIR)/debian/tmp/opt/scylladb/scylla-machine-image
 	install -m644 common/aws_net_params.json $(CURDIR)/debian/tmp/opt/scylladb/scylla-machine-image
 	install -m755 common/scylla_configure.py common/scylla_post_start.py common/scylla_create_devices $(CURDIR)/debian/tmp/opt/scylladb/scylla-machine-image
 	./tools/relocate_python_scripts.py \

--- a/dist/redhat/scylla-machine-image.spec
+++ b/dist/redhat/scylla-machine-image.spec
@@ -36,6 +36,7 @@ install -d -m755 $RPM_BUILD_ROOT/opt/scylladb/scylla-machine-image
 install -d -m755 $RPM_BUILD_ROOT/opt/scylladb/scylla-machine-image/lib
 install -m644 lib/log.py lib/scylla_cloud.py lib/user_data.py lib/param_estimation.py $RPM_BUILD_ROOT/opt/scylladb/scylla-machine-image/lib
 install -m644 common/aws_io_params.yaml $RPM_BUILD_ROOT/opt/scylladb/scylla-machine-image/
+install -m644 common/gcp_io_params.yaml $RPM_BUILD_ROOT/opt/scylladb/scylla-machine-image/
 install -m644 common/aws_net_params.json $RPM_BUILD_ROOT/opt/scylladb/scylla-machine-image/
 install -m755 common/scylla_configure.py common/scylla_post_start.py common/scylla_create_devices \
         $RPM_BUILD_ROOT/opt/scylladb/scylla-machine-image/

--- a/tests/test_gcp_instance.py
+++ b/tests/test_gcp_instance.py
@@ -254,6 +254,16 @@ class TestGcpInstance(TestCase, GcpMetadata):
         ins = gcp_instance()
         assert ins.is_supported_instance_class()
 
+    def test_is_supported_instance_class_z3_highmem_8_highlssd(self):
+        self.httpretty_gcp_metadata(instance_type='z3-highmem-8-highlssd')
+        ins = gcp_instance()
+        assert ins.is_supported_instance_class()
+
+    def test_is_supported_instance_class_z3_highmem_88_standardlssd(self):
+        self.httpretty_gcp_metadata(instance_type='z3-highmem-88-standardlssd')
+        ins = gcp_instance()
+        assert ins.is_supported_instance_class()
+
     def test_is_recommended_instance_size_n2_standard_8(self):
         self.httpretty_gcp_metadata()
         ins = gcp_instance()


### PR DESCRIPTION
- Add gcp_io_params.yaml with per-SSD specs for 11 z3 variants
- Align GCP I/O setup logic with AWS architecture (YAML + multiplication)
- Update package deployment for RPM/DEB
- Add test coverage for z3 instance class validation

Fixes: scylladb#724