### PR TITLE
Capture exception stderr from scylla_io_setup child

### DIFF
--- a/common/scylla_cloud_io_setup
+++ b/common/scylla_cloud_io_setup
@@ -60,7 +60,11 @@ class aws_io_setup(cloud_io_setup):
             self.save()
         else:
             logging.warning("This is a supported instance but with no pre-configured io, scylla_io_setup will be run")
-            subprocess.run('scylla_io_setup', shell=True, check=True, capture_output=True, timeout=300)
+            try:
+                result = subprocess.run('scylla_io_setup', shell=True, check=True, capture_output=True, timeout=300)
+            except subprocess.CalledProcessError as e:
+                logging.error(f"scylla_io_setup failed with error: {e.stderr.decode().strip()}")
+                raise
 
 
 class gcp_io_setup(cloud_io_setup):


### PR DESCRIPTION
During latest effort to get io-properties on i7i family we added scylladb/ PR#25315 and during development of that feature we got some failures related to iotune and it turned out the error logs don't get propagated up to surface because this subprocess launch of scylla_io_tune is called with check=True, capture_output=True and the exception isn't caught to print stderr.