### PR TITLE
Verify Integrity with AIDE

### DIFF
--- a/packer/apply_cis_rules
+++ b/packer/apply_cis_rules
@@ -261,3 +261,14 @@ MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512,h
         f.write(f"Defaults timestamp_timeout={var_sudo_timestamp_timeout}\n")
     os.chmod('/etc/sudoers.d/99_timestamp_timeout', 0o660)
     run('visudo -cf /etc/sudoers.d/99_timestamp_timeout', shell=True, check=True)
+
+    # xccdf_org.ssgproject.content_rule_package_aide_installed
+    # Install aide package non-interactively
+    run(['apt-get', 'install', '-y', 'aide'],
+                   env={**os.environ, 'DEBIAN_FRONTEND': 'noninteractive'})
+
+    # xccdf_org.ssgproject.content_rule_aide_build_database
+    run(['/usr/sbin/aideinit', '-y', '-f'])
+
+    # xccdf_org.ssgproject.content_rule_aide_periodic_checking_systemd_timer
+    # Nothing to do, periodic job is enabled by default


### PR DESCRIPTION
Advanced Intrusion Detection Environment (AIDE) is a intrusion detection tool that uses predefined rules to check the integrity of files and directories in the Linux operating system. AIDE has its own database to check the integrity of files and directories.

AIDE takes a snapshot of files and directories including modification times, permissions, and file hashes which can then be used to compare against the current state of the filesystem to detect modifications to the system.

By monitoring the filesystem state compromised files can be detected to prevent or limit the exposure of accidental or malicious misconfigurations or modified binaries.

This will apply following CIS compliance rules:
 - xccdf_org.ssgproject.content_rule_package_aide_installed
 - xccdf_org.ssgproject.content_rule_aide_build_database
 - xccdf_org.ssgproject.content_rule_aide_periodic_checking_systemd_timer

Fixes #694
Related scylladb/scylla-pkg#2953