### PR TITLE
Add issue template configuration for GitHub - redirect issue creation to Jira

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false  # Disables blank issue creation
+contact_links:
+  - name: 🚀 Press to open an issue in Jira.
+    url: https://scylladb.atlassian.net/browse/SMI
+    about: "Opening issues is not allowed in this Github repository."


### PR DESCRIPTION
Issue creation is allowed only in Jira, in the SMI project.