### PR TITLE
scylla_image_setup: avoid script error when perftune.py failed

### DIFF
--- a/common/scylla_image_setup
+++ b/common/scylla_image_setup
@@ -6,11 +6,16 @@
 
 import os
 import sys
+import logging
 from pathlib import Path
+from lib.log import setup_logging
 from lib.scylla_cloud import get_cloud_instance, is_gce, is_azure, is_redhat_variant
 from subprocess import run
 
+LOGGER = logging.getLogger(__name__)
+
 if __name__ == '__main__':
+    setup_logging()
     if is_azure():
         swap_directory = Path('/mnt')
         swap_unit = Path('/etc/systemd/system/mnt-swapfile.swap')
@@ -44,5 +49,5 @@ if __name__ == '__main__':
                 run('systemctl is-active -q fstrim.timer && systemctl disable fstrim.timer', shell=True, check=True)
 
         if not os.path.ismount('/var/lib/scylla') and not cloud_instance.is_dev_instance_type():
-            print('Failed to initialize RAID volume!')
+            LOGGER.error('Failed to initialize RAID volume!')
         machine_image_configured.touch()

--- a/common/scylla_image_setup
+++ b/common/scylla_image_setup
@@ -7,12 +7,22 @@
 import os
 import sys
 import logging
+import subprocess
+import re
 from pathlib import Path
 from lib.log import setup_logging
 from lib.scylla_cloud import get_cloud_instance, is_gce, is_azure, is_redhat_variant
 from subprocess import run
 
 LOGGER = logging.getLogger(__name__)
+
+def disable_perftune():
+    with open('/etc/default/scylla-server') as f:
+        sysconfig = f.read()
+    sysconfig = re.sub(r'^SET_NIC_AND_DISKS=.*$', 'SET_NIC_AND_DISKS=no', sysconfig, flags=re.MULTILINE)
+    sysconfig = re.sub(r'^SET_CLOCKSOURCE=.*$', 'SET_CLOCKSOURCE=no', sysconfig, flags=re.MULTILINE)
+    with open('/etc/default/scylla-server', 'w') as f:
+        f.write(sysconfig)
 
 if __name__ == '__main__':
     setup_logging()
@@ -32,7 +42,11 @@ if __name__ == '__main__':
         cloud_instance = get_cloud_instance()
         run('/opt/scylladb/scylla-machine-image/scylla_configure.py', shell=True, check=True)
 
-        run('/opt/scylladb/scripts/scylla_sysconfig_setup --nic eth0 --setup-nic', shell=True, check=True)
+        try:
+            run('/opt/scylladb/scripts/scylla_sysconfig_setup --nic eth0 --setup-nic', shell=True, check=True)
+        except subprocess.CalledProcessError:
+            disable_perftune()
+            LOGGER.warning('Failed to enable perftune.py, continue without using it')
         if os.path.ismount('/var/lib/scylla'):
             if cloud_instance.is_supported_instance_class():
                 # We run io_setup only when ehpemeral disks are available


### PR DESCRIPTION
On EC2, some environments cause errors on perftune.py due to corrupted
NUMA topology information.
Even in such an environment, scylla_image_setup should not cause a script error.
It should handle the error, print a warning message, and then continue the startup process.

Related https://github.com/scylladb/seastar/issues/2925

----

This is scylla-machine-image part of the fix for https://github.com/scylladb/seastar/issues/2925