### PR TITLE
Set Account Expiration Following Inactivity

### DIFF
--- a/packer/apply_cis_rules
+++ b/packer/apply_cis_rules
@@ -381,3 +381,11 @@ ucredit = -1
     if not success:
         with open('/etc/login.defs', 'a') as f:
             f.write(f"PASS_MAX_DAYS      {var_accounts_maximum_age_login_defs}\n")
+
+
+    # xccdf_org.ssgproject.content_rule_account_disable_post_pw_expiration
+    var_account_disable_post_pw_expiration = '45'
+    config_file = "/etc/default/useradd"
+    with open(config_file, 'a') as f:
+        f.write('\n')
+        f.write(f"INACTIVE={var_account_disable_post_pw_expiration}\n")


### PR DESCRIPTION
To specify the number of days after a password expires (which signifies inactivity) until an account is permanently disabled, add or correct the following line in /etc/default/useradd:
```
INACTIVE=45
```
If a password is currently on the verge of expiration, then 45 day(s) remain(s) until the account is automatically disabled. However, if the password will not expire for another 60 days, then 60 days plus 45 day(s) could elapse until the account would be automatically disabled. See the useradd man page for more information.

Rationale:
Inactive identifiers pose a risk to systems and applications because attackers may exploit an inactive identifier and potentially obtain undetected access to the system. Disabling inactive accounts ensures that accounts which may not have been responsibly removed are not available to attackers who may have compromised their credentials. Owners of inactive accounts will not notice if unauthorized access to their user account has been obtained.

This will apply following CIS compliance rules:
 - xccdf_org.ssgproject.content_rule_account_disable_post_pw_expiration

Fixes SMI-197
Related scylladb/scylla-pkg#2953