### PR TITLE
CIS compliance: user home directories must be exist / must be correct permission & owner

### DIFF
--- a/packer/apply_cis_rules
+++ b/packer/apply_cis_rules
@@ -462,3 +462,10 @@ ucredit = -1
         home_dir = user_entry.pw_dir
         if uid >= 1000 and uid != 65534:
             os.chown(home_dir, -1, gid)
+
+    # xccdf_org.ssgproject.content_rule_file_ownership_home_directories
+    for user_entry in pwd.getpwall():
+        uid = user_entry.pw_uid
+        home_dir = user_entry.pw_dir
+        if uid >= 1000 and uid != 65534:
+            os.chown(home_dir, uid, -1)


### PR DESCRIPTION
All interactive user home directories must be exist, and must be owned by correct user & group, and must have correct permission.

Rule ID:
- xccdf_org.ssgproject.content_rule_accounts_user_interactive_home_directory_exists
- xccdf_org.ssgproject.content_rule_file_groupownership_home_directories
- xccdf_org.ssgproject.content_rule_file_ownership_home_directories

Fixes [SMI-205](https://scylladb.atlassian.net/browse/SMI-205)
Related https://github.com/scylladb/scylla-pkg/issues/2953

[SMI-205]: https://scylladb.atlassian.net/browse/SMI-205?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ