### PR TITLE
packer: add unified chrony time-sync configuration for all clouds

### DIFF
--- a/packer/scylla_install_image
+++ b/packer/scylla_install_image
@@ -31,6 +31,97 @@ def deb_arch():
     return darch[arch()]
 
 
+def get_chrony_sources(target_cloud: str) -> str:
+    """Return cloud-specific chrony time source directives.
+
+    Sources per cloud:
+    - aws: Amazon Time Sync Service + time.aws.com pool
+    - gce: Google internal metadata server (metadata.google.internal)
+    - azure: Hyper-V PTP clock with NTP fallback
+    - oci: OCI internal NTP
+    """
+    sources = {
+        "aws": dedent("""\
+            server 169.254.169.123 prefer iburst minpoll 4 maxpoll 4
+            pool time.aws.com iburst
+        """),
+        "gce": dedent("""\
+            server metadata.google.internal prefer iburst
+        """),
+        "azure": dedent("""\
+            refclock PHC /dev/ptp_hyperv poll 3 dpoll -2 offset 0
+            server 169.254.169.254 iburst
+        """),
+        "oci": dedent("""\
+            server 169.254.169.254 prefer iburst
+        """),
+    }
+    if target_cloud not in sources:
+        raise ValueError(f"unknown target cloud: {target_cloud}")
+    return sources[target_cloud]
+
+
+def build_chrony_conf(target_cloud: str) -> str:
+    """Build a complete chrony.conf for the given cloud provider."""
+    sources = get_chrony_sources(target_cloud)
+    return f"""\
+# chrony configuration for {target_cloud}
+# managed by scylla-machine-image — do not edit manually
+
+{sources}
+makestep 1.0 3
+driftfile /var/lib/chrony/drift
+rtcsync
+logdir /var/log/chrony
+maxupdateskew 100.0
+leapsectz right/UTC
+"""
+
+
+def configure_chrony(target_cloud: str) -> None:
+    """Configure chrony for the given cloud provider."""
+    # disable cloud-init NTP management so it doesn't overwrite this config on boot
+    os.makedirs("/etc/cloud/cloud.cfg.d", exist_ok=True)
+    with open("/etc/cloud/cloud.cfg.d/99-disable-ntp.cfg", "w") as f:
+        f.write(
+            dedent("""\
+            ntp:
+              enabled: false
+        """)
+        )
+
+    # remove vendor defaults
+    for path in glob.glob("/etc/chrony/sources.d/*") + glob.glob("/etc/chrony/conf.d/*"):
+        if os.path.isdir(path):
+            shutil.rmtree(path)
+        else:
+            os.remove(path)
+
+    with open("/etc/chrony/chrony.conf", "w") as f:
+        f.write(build_chrony_conf(target_cloud))
+
+    # azure: udev rule for PTP hyperv clock
+    if target_cloud == "azure":
+        with open("/etc/udev/rules.d/99-ptp-hyperv.rules", "w") as f:
+            f.write('SUBSYSTEM=="ptp", ATTR{clock_name}=="hyperv", SYMLINK+="ptp_hyperv"\n')
+
+    run("systemctl enable chrony-wait.service", shell=True, check=True)
+
+    # systemd drop-in for scylla-server to wait for time sync
+    override_path = "/etc/systemd/system/scylla-server.service.d/10-time-sync.conf"
+    os.makedirs(os.path.dirname(override_path), mode=0o755, exist_ok=True)
+    with open(override_path, "w") as f:
+        f.write(
+            dedent("""\
+            [Unit]
+            After=time-sync.target
+            Wants=time-sync.target
+        """)
+        )
+
+    run("systemctl daemon-reload", shell=True, check=True)
+
+
 if __name__ == "__main__":
     if os.getuid() > 0:
         print("Requires root permission.")
@@ -46,6 +137,10 @@ if __name__ == "__main__":
     parser.add_argument("--target-cloud", choices=["aws", "gce", "azure", "oci"], help="specify target cloud")
     parser.add_argument("--scylla-version", help="Scylla version to be added to manifest file")
     args = parser.parse_args()
+
+    if not args.target_cloud:
+        print("Error: --target-cloud is required")
+        sys.exit(1)
 
     if args.repo and not args.repo_for_install:
         args.repo_for_install = args.repo
@@ -88,7 +183,7 @@ if __name__ == "__main__":
     )
     run(
         f"apt-get install -y --auto-remove {args.product}-machine-image {args.product}-server-dbg "
-        "cpufrequtils curl dnsutils ethtool htop initramfs-tools jq mdadm ncat netcat-openbsd "
+        "chrony cpufrequtils curl dnsutils ethtool htop initramfs-tools jq mdadm ncat netcat-openbsd "
         "net-tools nload nmap python3-boto sysstat systemd-coredump tmux traceroute vim-nox vim.tiny wget xfsprogs aide",
         shell=True,
         check=True,
@@ -103,16 +198,6 @@ if __name__ == "__main__":
         run(f"curl -L -o /etc/apt/sources.list.d/scylla.list {args.repo_for_update}", shell=True, check=True)
 
     if args.target_cloud == "aws":
-        with open("/etc/chrony/chrony.conf") as f:
-            chrony_conf = f.read()
-
-        chrony_conf = re.sub(r"^(pool .*$)", "# \\1", chrony_conf, flags=re.MULTILINE)
-        with open("/etc/chrony/chrony.conf", "w") as f:
-            f.write(chrony_conf)
-
-        with open("/etc/chrony/sources.d/ntp-pool.sources", "w") as f:
-            f.write("pool time.aws.com iburst\n")
-
         kernel_opt = ""
         grub_variable = "GRUB_CMDLINE_LINUX_DEFAULT"
         # Disable and mask amazon-ssm-agent to prevent it from running
@@ -142,6 +227,8 @@ if __name__ == "__main__":
         # Mask OCI monitoring agent if present
         run("systemctl mask oracle-cloud-agent || true", shell=True, check=True)
         run("systemctl mask oracle-cloud-agent-updater || true", shell=True, check=True)
+
+    configure_chrony(args.target_cloud)
 
     run(
         "systemctl mask apt-daily-upgrade.timer apt-daily.timer dpkg-db-backup.timer motd-news.timer apt-news.service esm-cache.service dailyaidecheck.timer",

--- a/tests/test_chrony_config.py
+++ b/tests/test_chrony_config.py
@@ -1,0 +1,125 @@
+#
+# Copyright 2026 ScyllaDB
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+
+sys.path.append(str(Path(__file__).parent.parent))
+
+_module_path = str(Path(__file__).parent.parent / "packer" / "scylla_install_image")
+scylla_install_image = SourceFileLoader("scylla_install_image", _module_path).load_module()
+sys.modules["scylla_install_image"] = scylla_install_image
+
+from unittest.mock import mock_open, patch  # noqa: E402
+
+from scylla_install_image import build_chrony_conf, configure_chrony, get_chrony_sources  # noqa: E402
+
+
+class TestGetChronySources:
+    def test_aws_sources(self):
+        sources = get_chrony_sources("aws")
+        assert "server 169.254.169.123 prefer iburst minpoll 4 maxpoll 4" in sources
+        assert "pool time.aws.com iburst" in sources
+
+    def test_gce_sources(self):
+        sources = get_chrony_sources("gce")
+        assert "server metadata.google.internal prefer iburst" in sources
+        assert "pool" not in sources.lower()
+
+    def test_azure_sources(self):
+        sources = get_chrony_sources("azure")
+        assert "refclock PHC /dev/ptp_hyperv poll 3 dpoll -2 offset 0" in sources
+        assert "server 169.254.169.254 iburst" in sources
+
+    def test_oci_sources(self):
+        sources = get_chrony_sources("oci")
+        assert "server 169.254.169.254 prefer iburst" in sources
+
+
+class TestBuildChronyConf:
+    def test_contains_universal_settings(self):
+        for cloud in ("aws", "gce", "azure", "oci"):
+            conf = build_chrony_conf(cloud)
+            assert "makestep 1.0 3" in conf, f"missing makestep for {cloud}"
+            assert "driftfile /var/lib/chrony/drift" in conf, f"missing driftfile for {cloud}"
+            assert "rtcsync" in conf, f"missing rtcsync for {cloud}"
+            assert "logdir /var/log/chrony" in conf, f"missing logdir for {cloud}"
+            assert "maxupdateskew 100.0" in conf, f"missing maxupdateskew for {cloud}"
+            assert "leapsectz right/UTC" in conf, f"missing leapsectz for {cloud}"
+
+
+class TestConfigureChrony:
+    @patch("scylla_install_image.run")
+    @patch("scylla_install_image.glob.glob", return_value=["/etc/chrony/sources.d/foo", "/etc/chrony/sources.d/bar"])
+    @patch("scylla_install_image.os.remove")
+    @patch("scylla_install_image.os.makedirs")
+    @patch("builtins.open", new_callable=mock_open)
+    def test_wipes_vendor_defaults(self, mock_file, mock_makedirs, mock_remove, mock_glob, mock_run):
+        configure_chrony("aws")
+        mock_glob.assert_any_call("/etc/chrony/sources.d/*")
+        mock_glob.assert_any_call("/etc/chrony/conf.d/*")
+        mock_remove.assert_any_call("/etc/chrony/sources.d/foo")
+        mock_remove.assert_any_call("/etc/chrony/sources.d/bar")
+
+    @patch("scylla_install_image.run")
+    @patch("scylla_install_image.glob.glob", return_value=[])
+    @patch("scylla_install_image.os.remove")
+    @patch("scylla_install_image.os.makedirs")
+    @patch("builtins.open", new_callable=mock_open)
+    def test_writes_chrony_conf(self, mock_file, mock_makedirs, mock_remove, mock_glob, mock_run):
+        configure_chrony("gce")
+        mock_file.assert_any_call("/etc/chrony/chrony.conf", "w")
+        handle = mock_file()
+        written = "".join(c.args[0] for c in handle.write.call_args_list)
+        assert "metadata.google.internal" in written
+
+    @patch("scylla_install_image.run")
+    @patch("scylla_install_image.glob.glob", return_value=[])
+    @patch("scylla_install_image.os.remove")
+    @patch("scylla_install_image.os.makedirs")
+    @patch("builtins.open", new_callable=mock_open)
+    def test_enables_chrony_wait(self, mock_file, mock_makedirs, mock_remove, mock_glob, mock_run):
+        configure_chrony("aws")
+        mock_run.assert_any_call("systemctl enable chrony-wait.service", shell=True, check=True)
+
+    @patch("scylla_install_image.run")
+    @patch("scylla_install_image.glob.glob", return_value=[])
+    @patch("scylla_install_image.os.remove")
+    @patch("scylla_install_image.os.makedirs")
+    @patch("builtins.open", new_callable=mock_open)
+    def test_creates_systemd_dropin(self, mock_file, mock_makedirs, mock_remove, mock_glob, mock_run):
+        configure_chrony("oci")
+        mock_makedirs.assert_any_call("/etc/systemd/system/scylla-server.service.d", mode=0o755, exist_ok=True)
+        mock_file.assert_any_call("/etc/systemd/system/scylla-server.service.d/10-time-sync.conf", "w")
+
+    @patch("scylla_install_image.run")
+    @patch("scylla_install_image.glob.glob", return_value=[])
+    @patch("scylla_install_image.os.remove")
+    @patch("scylla_install_image.os.makedirs")
+    @patch("builtins.open", new_callable=mock_open)
+    def test_azure_writes_udev_rule(self, mock_file, mock_makedirs, mock_remove, mock_glob, mock_run):
+        configure_chrony("azure")
+        mock_file.assert_any_call("/etc/udev/rules.d/99-ptp-hyperv.rules", "w")
+
+    @patch("scylla_install_image.run")
+    @patch("scylla_install_image.glob.glob", return_value=[])
+    @patch("scylla_install_image.os.remove")
+    @patch("scylla_install_image.os.makedirs")
+    @patch("builtins.open", new_callable=mock_open)
+    def test_runs_daemon_reload(self, mock_file, mock_makedirs, mock_remove, mock_glob, mock_run):
+        configure_chrony("aws")
+        mock_run.assert_any_call("systemctl daemon-reload", shell=True, check=True)
+
+    @patch("scylla_install_image.run")
+    @patch("scylla_install_image.glob.glob", return_value=[])
+    @patch("scylla_install_image.os.remove")
+    @patch("scylla_install_image.os.makedirs")
+    @patch("builtins.open", new_callable=mock_open)
+    def test_disables_cloud_init_ntp(self, mock_file, mock_makedirs, mock_remove, mock_glob, mock_run):
+        configure_chrony("gce")
+        mock_makedirs.assert_any_call("/etc/cloud/cloud.cfg.d", exist_ok=True)
+        mock_file.assert_any_call("/etc/cloud/cloud.cfg.d/99-disable-ntp.cfg", "w")


### PR DESCRIPTION
Implement unified chrony config builder supporting AWS, GCE, Azure, and OCI, with cloud-optimal time sources.
When configuration is applied the following actions are performed:
- disable cloud-init NTP management
- enable chrony-wait.service
- add systemd drop-in, so scylla-server starts only after time sync completes

Closes: SMI-181