### PR TITLE
packer: remove unnecessary packages linux headers packages

### DIFF
--- a/packer/scylla_install_image
+++ b/packer/scylla_install_image
@@ -77,9 +77,14 @@ if __name__ == "__main__":
     run("apt-get update -y", shell=True, check=True)
     run("apt-get full-upgrade -y", shell=True, check=True)
     run(
-        "apt-get purge -y accountsservice acpid apport fuse fwupd-signed modemmanager motd-news-config open-vm-tools python3-apport snapd udisks2 unattended-upgrades update-notifier-common",
+        "apt-get purge -y accountsservice acpid amd64-microcode apport fuse fwupd-signed modemmanager motd-news-config open-vm-tools python3-apport snapd udisks2 unattended-upgrades update-notifier-common",
         shell=True,
         check=True,
+    )
+    run(
+        "dpkg -l 'linux-*headers*' 2>/dev/null | awk '/^ii/{print $2}' | xargs -r apt-get purge -y",
+        shell=True,
+        check=False,
     )
     run(
         f"apt-get install -y --auto-remove {args.product}-machine-image {args.product}-server-dbg "


### PR DESCRIPTION
Purge linux kernel headers (linux-aws-*-headers-*) and amd64-microcode from built images.

Closes: SMI-241