### PR TITLE
packer: purge postfix from machine image

### DIFF
--- a/packer/scylla_install_image
+++ b/packer/scylla_install_image
@@ -172,7 +172,14 @@ if __name__ == "__main__":
     run("apt-get update -y", shell=True, check=True)
     run("apt-get full-upgrade -y", shell=True, check=True)
     run(
-        "apt-get purge -y accountsservice acpid amd64-microcode apport fuse fwupd-signed modemmanager motd-news-config open-vm-tools python3-apport snapd udisks2 unattended-upgrades update-notifier-common",
+        f"apt-get install -y --auto-remove {args.product}-machine-image {args.product}-server-dbg "
+        "chrony cpufrequtils curl dnsutils ethtool htop initramfs-tools jq mdadm ncat netcat-openbsd "
+        "net-tools nload nmap python3-boto sysstat systemd-coredump tmux traceroute vim-nox vim.tiny wget xfsprogs aide",
+        shell=True,
+        check=True,
+    )
+    run(
+        "apt-get purge -y accountsservice acpid amd64-microcode apport fuse fwupd-signed modemmanager motd-news-config open-vm-tools postfix python3-apport snapd udisks2 unattended-upgrades update-notifier-common",
         shell=True,
         check=True,
     )
@@ -180,13 +187,6 @@ if __name__ == "__main__":
         "dpkg -l 'linux-*headers*' 2>/dev/null | awk '/^ii/{print $2}' | xargs -r apt-get purge -y",
         shell=True,
         check=False,
-    )
-    run(
-        f"apt-get install -y --auto-remove {args.product}-machine-image {args.product}-server-dbg "
-        "chrony cpufrequtils curl dnsutils ethtool htop initramfs-tools jq mdadm ncat netcat-openbsd "
-        "net-tools nload nmap python3-boto sysstat systemd-coredump tmux traceroute vim-nox vim.tiny wget xfsprogs aide",
-        shell=True,
-        check=True,
     )
     run(
         f"curl -L -o /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_{deb_arch()} && chmod +x /usr/local/bin/yq",


### PR DESCRIPTION
Port 25 (SMTP) was found open on Scylla instances due to postfix being installed as a dependency.

Add purging postfix during image build as it is not needed by Scylla.

Closes: SMI-261

### Testing
- Executed the artifacts tests with images built with the current changes for 3 providers:
GCE: 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/dimakr/job/artifacts/job/artifacts-gce-image-new/19/
AWS: 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/dimakr/job/artifacts/job/artifacts-ami-test/8/
Azure: 🟢 https://jenkins.scylladb.com/job/scylla-staging/job/dimakr/job/artifacts/job/artifacts-azure-image-test/18/

- postfix installation and port 25 checks

Azure
```
azureuser@test-timesync-nvme:~$ ss -tlnp | grep :25
azureuser@test-timesync-nvme:~$ dpkg -l postfix
dpkg-query: no packages found matching postfix
azureuser@test-timesync-nvme:~$
```
AWS
```
scyllaadm@ip-10-0-1-132:~$ ss -tlnp | grep :25
scyllaadm@ip-10-0-1-132:~$ dpkg -l postfix
dpkg-query: no packages found matching postfix
scyllaadm@ip-10-0-1-132:~$
```
GCP
```
ubuntu@test-timesync:~$ ss -tlnp | grep :25
ubuntu@test-timesync:~$ dpkg -l postfix
dpkg-query: no packages found matching postfix
ubuntu@test-timesync:~$
```
OCI
```
scyllaadm@test-timesync-oci:~$ ss -tlnp | grep :25
scyllaadm@test-timesync-oci:~$ dpkg -l postfix
dpkg-query: no packages found matching postfix
scyllaadm@test-timesync-oci:~$ 
```