### PR TITLE
Add on-demand cloud image build via PR labels

### DIFF
--- a/.github/workflows/build-cloud-image.yaml
+++ b/.github/workflows/build-cloud-image.yaml
@@ -1,0 +1,343 @@
+name: Build Cloud Image from PR
+
+on:
+  pull_request_target:
+    types: [labeled]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  build-image:
+    if: startsWith(github.event.label.name, 'build/')
+    runs-on: ubuntu-latest
+    concurrency:
+      group: build-image-${{ github.event.pull_request.number }}-${{ github.event.label.name }}
+      cancel-in-progress: true
+
+    steps:
+      - name: Parse label
+        id: parse
+        run: |
+          LABEL="${{ github.event.label.name }}"
+          # Strip 'build/' prefix
+          TARGET_ARCH="${LABEL#build/}"
+          CLOUD="${TARGET_ARCH%-*}"
+          ARCH="${TARGET_ARCH##*-}"
+
+          # Validate cloud
+          case "$CLOUD" in
+            aws|gce|azure|oci) ;;
+            *)
+              echo "::error::Invalid cloud target: $CLOUD (label: $LABEL)"
+              exit 1
+              ;;
+          esac
+
+          # Validate arch
+          case "$ARCH" in
+            x86_64|aarch64) ;;
+            *)
+              echo "::error::Invalid architecture: $ARCH (label: $LABEL)"
+              exit 1
+              ;;
+          esac
+
+          echo "cloud=$CLOUD" >> "$GITHUB_OUTPUT"
+          echo "arch=$ARCH" >> "$GITHUB_OUTPUT"
+          echo "label=$LABEL" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout PR code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Install Packer
+        uses: hashicorp/setup-packer@main
+
+      - name: Install Packer plugins
+        working-directory: packer
+        run: packer init scylla.json || true
+
+      - name: Run SCYLLA-VERSION-GEN
+        id: version
+        run: |
+          source ./SCYLLA-VERSION-GEN
+          echo "version=$(cat build/SCYLLA-VERSION-FILE)" >> "$GITHUB_OUTPUT"
+          echo "release=$(cat build/SCYLLA-RELEASE-FILE)" >> "$GITHUB_OUTPUT"
+          echo "product=$(cat build/SCYLLA-PRODUCT-FILE)" >> "$GITHUB_OUTPUT"
+
+      - name: Configure AWS credentials
+        if: steps.parse.outputs.cloud == 'aws'
+        run: |
+          echo "AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}" >> "$GITHUB_ENV"
+          echo "AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}" >> "$GITHUB_ENV"
+
+      - name: Configure GCE credentials
+        if: steps.parse.outputs.cloud == 'gce'
+        run: |
+          GCE_CREDS_FILE="$RUNNER_TEMP/gce-credentials.json"
+          echo '${{ secrets.GCE_SERVICE_ACCOUNT_JSON }}' > "$GCE_CREDS_FILE"
+          echo "GOOGLE_APPLICATION_CREDENTIALS=$GCE_CREDS_FILE" >> "$GITHUB_ENV"
+
+      - name: Configure Azure credentials
+        if: steps.parse.outputs.cloud == 'azure'
+        run: |
+          echo "AZURE_CLIENT_ID=${{ secrets.AZURE_CLIENT_ID }}" >> "$GITHUB_ENV"
+          echo "AZURE_CLIENT_SECRET=${{ secrets.AZURE_CLIENT_SECRET }}" >> "$GITHUB_ENV"
+          echo "AZURE_TENANT_ID=${{ secrets.AZURE_TENANT_ID }}" >> "$GITHUB_ENV"
+          echo "AZURE_SUBSCRIPTION_ID=${{ secrets.AZURE_SUBSCRIPTION_ID }}" >> "$GITHUB_ENV"
+
+      - name: Configure OCI credentials
+        if: steps.parse.outputs.cloud == 'oci'
+        run: |
+          OCI_KEY_FILE="$RUNNER_TEMP/oci-api-key.pem"
+          echo "${{ secrets.OCI_KEY_FILE_CONTENTS }}" | base64 -d > "$OCI_KEY_FILE"
+          chmod 600 "$OCI_KEY_FILE"
+          echo "OCI_CLI_KEY_FILE=$OCI_KEY_FILE" >> "$GITHUB_ENV"
+          echo "OCI_USER_OCID=${{ secrets.OCI_USER_OCID }}" >> "$GITHUB_ENV"
+          echo "OCI_TENANCY_OCID=${{ secrets.OCI_TENANCY_OCID }}" >> "$GITHUB_ENV"
+          echo "OCI_FINGERPRINT=${{ secrets.OCI_FINGERPRINT }}" >> "$GITHUB_ENV"
+          echo "OCI_REGION=${{ secrets.OCI_REGION }}" >> "$GITHUB_ENV"
+          echo "OCI_COMPARTMENT_OCID=${{ secrets.OCI_COMPARTMENT_OCID }}" >> "$GITHUB_ENV"
+          echo "OCI_SUBNET_OCID=${{ secrets.OCI_SUBNET_OCID }}" >> "$GITHUB_ENV"
+          echo "OCI_AVAILABILITY_DOMAIN=${{ secrets.OCI_AVAILABILITY_DOMAIN }}" >> "$GITHUB_ENV"
+
+      - name: Build image
+        id: build
+        working-directory: packer
+        run: |
+          CLOUD="${{ steps.parse.outputs.cloud }}"
+          ARCH="${{ steps.parse.outputs.arch }}"
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          PR_BRANCH="${{ github.event.pull_request.head.ref }}"
+          VERSION="${{ steps.version.outputs.version }}"
+          RELEASE="${{ steps.version.outputs.release }}"
+          PRODUCT="${{ steps.version.outputs.product }}"
+
+          # Use a default unstable repo for PR builds
+          REPO="downloads.scylladb.com/unstable/${PRODUCT}/master/deb/unified/latest"
+
+          ./build_image.sh \
+            --target "$CLOUD" \
+            --arch "$ARCH" \
+            --debug \
+            --env-tag debug \
+            --branch "$PR_BRANCH" \
+            --build-tag "pr-${PR_NUMBER}" \
+            --repo "$REPO" \
+            --version "$VERSION" \
+            --scylla-release "$RELEASE" \
+            --scylla-machine-image-release "0.pr${PR_NUMBER}" \
+            --product "$PRODUCT"
+
+      - name: Extract image ID
+        id: image
+        if: success()
+        run: |
+          CLOUD="${{ steps.parse.outputs.cloud }}"
+          LOG_FILE="packer/build/packer.log"
+
+          case "$CLOUD" in
+            aws)
+              IMAGE_ID=$(grep "us-east-1:" "$LOG_FILE" | grep -oP 'ami-[a-f0-9]+' | tail -1)
+              ;;
+            gce)
+              IMAGE_ID=$(grep "A disk image was created" "$LOG_FILE" | grep -oP "'[^']+'" | tail -1 | tr -d "'")
+              ;;
+            azure)
+              IMAGE_ID=$(grep "Builds finished" "$LOG_FILE" | grep -oP '/subscriptions/[^\s]+' | tail -1)
+              ;;
+            oci)
+              IMAGE_ID=$(grep "An image was created:" "$LOG_FILE" | grep -oP 'ocid1\.image\.oc1\.[^ )]+' | tail -1)
+              ;;
+          esac
+
+          if [ -z "$IMAGE_ID" ]; then
+            echo "::warning::Could not extract image ID from packer log"
+            IMAGE_ID="(extraction failed — check build logs)"
+          fi
+
+          echo "image_id=$IMAGE_ID" >> "$GITHUB_OUTPUT"
+
+      - name: Trigger Jenkins test job
+        if: success()
+        env:
+          JENKINS_USER: ${{ secrets.JENKINS_USERNAME }}
+          JENKINS_API_TOKEN: ${{ secrets.JENKINS_TOKEN }}
+          JENKINS_URL: "https://jenkins.scylladb.com"
+        run: |
+          CLOUD="${{ steps.parse.outputs.cloud }}"
+          JOB_NAME="on-demand-image-test/${CLOUD}"
+          JOB_URL="$JENKINS_URL/job/$JOB_NAME"
+
+          # Check if job exists before triggering
+          if curl --silent --fail --user "$JENKINS_USER:$JENKINS_API_TOKEN" "$JOB_URL/api/json" > /dev/null 2>&1; then
+            curl -X POST "$JOB_URL/buildWithParameters" \
+              --fail \
+              --user "$JENKINS_USER:$JENKINS_API_TOKEN" \
+              --data-urlencode "IMAGE_ID=${{ steps.image.outputs.image_id }}" \
+              --data-urlencode "CLOUD_TARGET=$CLOUD" \
+              --data-urlencode "ARCH=${{ steps.parse.outputs.arch }}" \
+              --data-urlencode "PR_NUMBER=${{ github.event.pull_request.number }}" \
+              --data-urlencode "PR_BRANCH=${{ github.event.pull_request.head.ref }}" \
+              --data-urlencode "PR_SHA=${{ github.event.pull_request.head.sha }}" \
+              || echo "::warning::Failed to trigger Jenkins job $JOB_NAME"
+
+            echo "JENKINS_JOB_URL=$JOB_URL" >> "$GITHUB_ENV"
+          else
+            echo "::warning::Jenkins job $JOB_NAME does not exist yet. Skipping trigger."
+            echo "JENKINS_JOB_URL=" >> "$GITHUB_ENV"
+          fi
+
+      - name: Post PR comment (success)
+        if: success()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const cloud = '${{ steps.parse.outputs.cloud }}';
+            const arch = '${{ steps.parse.outputs.arch }}';
+            const imageId = `${{ steps.image.outputs.image_id }}`;
+            const prNumber = context.payload.pull_request.number;
+            const sha = '${{ github.event.pull_request.head.sha }}'.substring(0, 8);
+            const label = '${{ steps.parse.outputs.label }}';
+            const actor = context.payload.sender.login;
+            const jenkinsUrl = process.env.JENKINS_JOB_URL;
+            const jenkinsLink = jenkinsUrl ? `[link](${jenkinsUrl})` : '_job not configured_';
+
+            const body = `## Cloud Image Build: \`${cloud}\` (\`${arch}\`)
+
+            | Field | Value |
+            |-------|-------|
+            | **Target** | \`${cloud}\` |
+            | **Architecture** | \`${arch}\` |
+            | **Image ID** | \`${imageId}\` |
+            | **PR** | #${prNumber} |
+            | **Commit** | \`${sha}\` |
+            | **Jenkins Tests** | ${jenkinsLink} |
+
+            Triggered by @${actor} via label \`${label}\``;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body: body
+            });
+
+      - name: Swap labels (success)
+        if: success()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const label = '${{ steps.parse.outputs.label }}';
+            const cloud = '${{ steps.parse.outputs.cloud }}';
+            const arch = '${{ steps.parse.outputs.arch }}';
+            const prNumber = context.payload.pull_request.number;
+            const resultLabel = `build-result/${cloud}-${arch}/success`;
+
+            // Remove build label
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                name: label
+              });
+            } catch (e) {
+              // Label may already be removed
+            }
+
+            // Ensure result label exists
+            try {
+              await github.rest.issues.createLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: resultLabel,
+                color: '0e8a16',
+                description: `Image build succeeded for ${cloud} ${arch}`
+              });
+            } catch (e) {
+              // Label may already exist
+            }
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              labels: [resultLabel]
+            });
+
+      - name: Post PR comment (failure)
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const cloud = '${{ steps.parse.outputs.cloud }}';
+            const arch = '${{ steps.parse.outputs.arch }}';
+            const prNumber = context.payload.pull_request.number;
+            const sha = '${{ github.event.pull_request.head.sha }}'.substring(0, 8);
+            const label = '${{ steps.parse.outputs.label }}';
+            const actor = context.payload.sender.login;
+            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            const body = `## Cloud Image Build Failed: \`${cloud}\` (\`${arch}\`)
+
+            | Field | Value |
+            |-------|-------|
+            | **Target** | \`${cloud}\` |
+            | **Architecture** | \`${arch}\` |
+            | **PR** | #${prNumber} |
+            | **Commit** | \`${sha}\` |
+            | **Build Logs** | [GitHub Actions](${runUrl}) |
+
+            Triggered by @${actor} via label \`${label}\``;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body: body
+            });
+
+      - name: Swap labels (failure)
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const label = '${{ steps.parse.outputs.label }}';
+            const cloud = '${{ steps.parse.outputs.cloud }}';
+            const arch = '${{ steps.parse.outputs.arch }}';
+            const prNumber = context.payload.pull_request.number;
+            const resultLabel = `build-result/${cloud}-${arch}/failed`;
+
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                name: label
+              });
+            } catch (e) {}
+
+            try {
+              await github.rest.issues.createLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: resultLabel,
+                color: 'e11d48',
+                description: `Image build failed for ${cloud} ${arch}`
+              });
+            } catch (e) {}
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              labels: [resultLabel]
+            });

--- a/.github/workflows/build-cloud-image.yaml
+++ b/.github/workflows/build-cloud-image.yaml
@@ -7,337 +7,241 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  statuses: write
 
 jobs:
-  build-image:
-    if: startsWith(github.event.label.name, 'build/')
+  trigger-build:
+    if: >-
+      startsWith(github.event.label.name, 'build/') ||
+      startsWith(github.event.label.name, 'test/')
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     concurrency:
-      group: build-image-${{ github.event.pull_request.number }}-${{ github.event.label.name }}
+      group: machine-image-build-${{ github.event.pull_request.number }}
       cancel-in-progress: true
 
     steps:
-      - name: Parse label
-        id: parse
+      - name: Verify org membership
+        env:
+          SENDER_ASSOCIATION: ${{ github.event.sender.author_association }}
         run: |
-          LABEL="${{ github.event.label.name }}"
-          # Strip 'build/' prefix
-          TARGET_ARCH="${LABEL#build/}"
-          CLOUD="${TARGET_ARCH%-*}"
-          ARCH="${TARGET_ARCH##*-}"
-
-          # Validate cloud
-          case "$CLOUD" in
-            aws|gce|azure|oci) ;;
-            *)
-              echo "::error::Invalid cloud target: $CLOUD (label: $LABEL)"
-              exit 1
-              ;;
-          esac
-
-          # Validate arch
-          case "$ARCH" in
-            x86_64|aarch64) ;;
-            *)
-              echo "::error::Invalid architecture: $ARCH (label: $LABEL)"
-              exit 1
-              ;;
-          esac
-
-          echo "cloud=$CLOUD" >> "$GITHUB_OUTPUT"
-          echo "arch=$ARCH" >> "$GITHUB_OUTPUT"
-          echo "label=$LABEL" >> "$GITHUB_OUTPUT"
-
-      - name: Checkout PR code
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: Install Packer
-        uses: hashicorp/setup-packer@main
-
-      - name: Install Packer plugins
-        working-directory: packer
-        run: packer init scylla.json || true
-
-      - name: Run SCYLLA-VERSION-GEN
-        id: version
-        run: |
-          source ./SCYLLA-VERSION-GEN
-          echo "version=$(cat build/SCYLLA-VERSION-FILE)" >> "$GITHUB_OUTPUT"
-          echo "release=$(cat build/SCYLLA-RELEASE-FILE)" >> "$GITHUB_OUTPUT"
-          echo "product=$(cat build/SCYLLA-PRODUCT-FILE)" >> "$GITHUB_OUTPUT"
-
-      - name: Configure AWS credentials
-        if: steps.parse.outputs.cloud == 'aws'
-        run: |
-          echo "AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}" >> "$GITHUB_ENV"
-          echo "AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}" >> "$GITHUB_ENV"
-
-      - name: Configure GCE credentials
-        if: steps.parse.outputs.cloud == 'gce'
-        run: |
-          GCE_CREDS_FILE="$RUNNER_TEMP/gce-credentials.json"
-          echo '${{ secrets.GCE_SERVICE_ACCOUNT_JSON }}' > "$GCE_CREDS_FILE"
-          echo "GOOGLE_APPLICATION_CREDENTIALS=$GCE_CREDS_FILE" >> "$GITHUB_ENV"
-
-      - name: Configure Azure credentials
-        if: steps.parse.outputs.cloud == 'azure'
-        run: |
-          echo "AZURE_CLIENT_ID=${{ secrets.AZURE_CLIENT_ID }}" >> "$GITHUB_ENV"
-          echo "AZURE_CLIENT_SECRET=${{ secrets.AZURE_CLIENT_SECRET }}" >> "$GITHUB_ENV"
-          echo "AZURE_TENANT_ID=${{ secrets.AZURE_TENANT_ID }}" >> "$GITHUB_ENV"
-          echo "AZURE_SUBSCRIPTION_ID=${{ secrets.AZURE_SUBSCRIPTION_ID }}" >> "$GITHUB_ENV"
-
-      - name: Configure OCI credentials
-        if: steps.parse.outputs.cloud == 'oci'
-        run: |
-          OCI_KEY_FILE="$RUNNER_TEMP/oci-api-key.pem"
-          echo "${{ secrets.OCI_KEY_FILE_CONTENTS }}" | base64 -d > "$OCI_KEY_FILE"
-          chmod 600 "$OCI_KEY_FILE"
-          echo "OCI_CLI_KEY_FILE=$OCI_KEY_FILE" >> "$GITHUB_ENV"
-          echo "OCI_USER_OCID=${{ secrets.OCI_USER_OCID }}" >> "$GITHUB_ENV"
-          echo "OCI_TENANCY_OCID=${{ secrets.OCI_TENANCY_OCID }}" >> "$GITHUB_ENV"
-          echo "OCI_FINGERPRINT=${{ secrets.OCI_FINGERPRINT }}" >> "$GITHUB_ENV"
-          echo "OCI_REGION=${{ secrets.OCI_REGION }}" >> "$GITHUB_ENV"
-          echo "OCI_COMPARTMENT_OCID=${{ secrets.OCI_COMPARTMENT_OCID }}" >> "$GITHUB_ENV"
-          echo "OCI_SUBNET_OCID=${{ secrets.OCI_SUBNET_OCID }}" >> "$GITHUB_ENV"
-          echo "OCI_AVAILABILITY_DOMAIN=${{ secrets.OCI_AVAILABILITY_DOMAIN }}" >> "$GITHUB_ENV"
-
-      - name: Build image
-        id: build
-        working-directory: packer
-        run: |
-          CLOUD="${{ steps.parse.outputs.cloud }}"
-          ARCH="${{ steps.parse.outputs.arch }}"
-          PR_NUMBER="${{ github.event.pull_request.number }}"
-          PR_BRANCH="${{ github.event.pull_request.head.ref }}"
-          VERSION="${{ steps.version.outputs.version }}"
-          RELEASE="${{ steps.version.outputs.release }}"
-          PRODUCT="${{ steps.version.outputs.product }}"
-
-          # Use a default unstable repo for PR builds
-          REPO="downloads.scylladb.com/unstable/${PRODUCT}/master/deb/unified/latest"
-
-          ./build_image.sh \
-            --target "$CLOUD" \
-            --arch "$ARCH" \
-            --debug \
-            --env-tag debug \
-            --branch "$PR_BRANCH" \
-            --build-tag "pr-${PR_NUMBER}" \
-            --repo "$REPO" \
-            --version "$VERSION" \
-            --scylla-release "$RELEASE" \
-            --scylla-machine-image-release "0.pr${PR_NUMBER}" \
-            --product "$PRODUCT"
-
-      - name: Extract image ID
-        id: image
-        if: success()
-        run: |
-          CLOUD="${{ steps.parse.outputs.cloud }}"
-          LOG_FILE="packer/build/packer.log"
-
-          case "$CLOUD" in
-            aws)
-              IMAGE_ID=$(grep "us-east-1:" "$LOG_FILE" | grep -oP 'ami-[a-f0-9]+' | tail -1)
-              ;;
-            gce)
-              IMAGE_ID=$(grep "A disk image was created" "$LOG_FILE" | grep -oP "'[^']+'" | tail -1 | tr -d "'")
-              ;;
-            azure)
-              IMAGE_ID=$(grep "Builds finished" "$LOG_FILE" | grep -oP '/subscriptions/[^\s]+' | tail -1)
-              ;;
-            oci)
-              IMAGE_ID=$(grep "An image was created:" "$LOG_FILE" | grep -oP 'ocid1\.image\.oc1\.[^ )]+' | tail -1)
-              ;;
-          esac
-
-          if [ -z "$IMAGE_ID" ]; then
-            echo "::warning::Could not extract image ID from packer log"
-            IMAGE_ID="(extraction failed — check build logs)"
+          if [[ "$SENDER_ASSOCIATION" != "MEMBER" && "$SENDER_ASSOCIATION" != "OWNER" ]]; then
+            echo "::error::Only organization members can trigger image builds"
+            exit 1
           fi
 
-          echo "image_id=$IMAGE_ID" >> "$GITHUB_OUTPUT"
+      - name: Collect build and test labels
+        id: labels
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
 
-      - name: Trigger Jenkins test job
-        if: success()
+          LABELS=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/labels" --jq '.[].name')
+
+          BUILD_AMI=false
+          BUILD_GCP=false
+          BUILD_AZURE=false
+          BUILD_OCI=false
+          RUN_AMI_TEST=false
+          RUN_GCE_TEST=false
+          RUN_AZURE_TEST=false
+          RUN_OCI_TEST=false
+
+          while IFS= read -r label; do
+            case "$label" in
+              build/aws)   BUILD_AMI=true ;;
+              build/gce)   BUILD_GCP=true ;;
+              build/azure) BUILD_AZURE=true ;;
+              build/oci)   BUILD_OCI=true ;;
+              build/all)
+                BUILD_AMI=true; BUILD_GCP=true; BUILD_AZURE=true; BUILD_OCI=true ;;
+              test/aws)    BUILD_AMI=true; RUN_AMI_TEST=true ;;
+              test/gce)    BUILD_GCP=true; RUN_GCE_TEST=true ;;
+              test/azure)  BUILD_AZURE=true; RUN_AZURE_TEST=true ;;
+              test/oci)    BUILD_OCI=true; RUN_OCI_TEST=true ;;
+              test/all)
+                BUILD_AMI=true; BUILD_GCP=true; BUILD_AZURE=true; BUILD_OCI=true
+                RUN_AMI_TEST=true; RUN_GCE_TEST=true; RUN_AZURE_TEST=true; RUN_OCI_TEST=true ;;
+            esac
+          done <<< "$LABELS"
+
+          if [[ "$BUILD_AMI" == "false" && "$BUILD_GCP" == "false" && \
+                "$BUILD_AZURE" == "false" && "$BUILD_OCI" == "false" ]]; then
+            echo "::error::No valid build/ or test/ label found"
+            exit 1
+          fi
+
+          echo "build_ami=${BUILD_AMI}" >> "$GITHUB_OUTPUT"
+          echo "build_gcp=${BUILD_GCP}" >> "$GITHUB_OUTPUT"
+          echo "build_azure=${BUILD_AZURE}" >> "$GITHUB_OUTPUT"
+          echo "build_oci=${BUILD_OCI}" >> "$GITHUB_OUTPUT"
+          echo "run_ami_test=${RUN_AMI_TEST}" >> "$GITHUB_OUTPUT"
+          echo "run_gce_test=${RUN_GCE_TEST}" >> "$GITHUB_OUTPUT"
+          echo "run_azure_test=${RUN_AZURE_TEST}" >> "$GITHUB_OUTPUT"
+          echo "run_oci_test=${RUN_OCI_TEST}" >> "$GITHUB_OUTPUT"
+
+          TARGETS=""
+          [[ "$BUILD_AMI" == "true" ]] && TARGETS="${TARGETS}AWS "
+          [[ "$BUILD_GCP" == "true" ]] && TARGETS="${TARGETS}GCE "
+          [[ "$BUILD_AZURE" == "true" ]] && TARGETS="${TARGETS}Azure "
+          [[ "$BUILD_OCI" == "true" ]] && TARGETS="${TARGETS}OCI "
+          echo "targets=${TARGETS}" >> "$GITHUB_OUTPUT"
+
+          TESTS=""
+          [[ "$RUN_AMI_TEST" == "true" ]] && TESTS="${TESTS}AWS "
+          [[ "$RUN_GCE_TEST" == "true" ]] && TESTS="${TESTS}GCE "
+          [[ "$RUN_AZURE_TEST" == "true" ]] && TESTS="${TESTS}Azure "
+          [[ "$RUN_OCI_TEST" == "true" ]] && TESTS="${TESTS}OCI "
+          echo "tests=${TESTS:-none}" >> "$GITHUB_OUTPUT"
+
+      - name: Determine repo and branch
+        id: repo
+        env:
+          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          BASE_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$PR_HEAD_REPO" == "$BASE_REPO" ]]; then
+            MACHINE_IMAGE_REPO="git@github.com:${BASE_REPO}.git"
+          else
+            MACHINE_IMAGE_REPO="git@github.com:${PR_HEAD_REPO}.git"
+          fi
+
+          echo "repo=${MACHINE_IMAGE_REPO}" >> "$GITHUB_OUTPUT"
+          echo "branch=${PR_HEAD_REF}" >> "$GITHUB_OUTPUT"
+
+      - name: Trigger Jenkins build
+        id: jenkins
         env:
           JENKINS_USER: ${{ secrets.JENKINS_USERNAME }}
-          JENKINS_API_TOKEN: ${{ secrets.JENKINS_TOKEN }}
+          JENKINS_TOKEN: ${{ secrets.JENKINS_TOKEN }}
           JENKINS_URL: "https://jenkins.scylladb.com"
+          MACHINE_IMAGE_REPO: ${{ steps.repo.outputs.repo }}
+          MACHINE_IMAGE_BRANCH: ${{ steps.repo.outputs.branch }}
+          BUILD_AMI: ${{ steps.labels.outputs.build_ami }}
+          BUILD_GCP: ${{ steps.labels.outputs.build_gcp }}
+          BUILD_AZURE: ${{ steps.labels.outputs.build_azure }}
+          BUILD_OCI: ${{ steps.labels.outputs.build_oci }}
+          RUN_AMI_TEST: ${{ steps.labels.outputs.run_ami_test }}
+          RUN_GCE_TEST: ${{ steps.labels.outputs.run_gce_test }}
+          RUN_AZURE_TEST: ${{ steps.labels.outputs.run_azure_test }}
+          RUN_OCI_TEST: ${{ steps.labels.outputs.run_oci_test }}
         run: |
-          CLOUD="${{ steps.parse.outputs.cloud }}"
-          JOB_NAME="on-demand-image-test/${CLOUD}"
-          JOB_URL="$JENKINS_URL/job/$JOB_NAME"
+          set -euo pipefail
 
-          # Check if job exists before triggering
-          if curl --silent --fail --user "$JENKINS_USER:$JENKINS_API_TOKEN" "$JOB_URL/api/json" > /dev/null 2>&1; then
-            curl -X POST "$JOB_URL/buildWithParameters" \
-              --fail \
-              --user "$JENKINS_USER:$JENKINS_API_TOKEN" \
-              --data-urlencode "IMAGE_ID=${{ steps.image.outputs.image_id }}" \
-              --data-urlencode "CLOUD_TARGET=$CLOUD" \
-              --data-urlencode "ARCH=${{ steps.parse.outputs.arch }}" \
-              --data-urlencode "PR_NUMBER=${{ github.event.pull_request.number }}" \
-              --data-urlencode "PR_BRANCH=${{ github.event.pull_request.head.ref }}" \
-              --data-urlencode "PR_SHA=${{ github.event.pull_request.head.sha }}" \
-              || echo "::warning::Failed to trigger Jenkins job $JOB_NAME"
+          JOB_PATH="releng-testing/job/next-machine-image"
 
-            echo "JENKINS_JOB_URL=$JOB_URL" >> "$GITHUB_ENV"
-          else
-            echo "::warning::Jenkins job $JOB_NAME does not exist yet. Skipping trigger."
-            echo "JENKINS_JOB_URL=" >> "$GITHUB_ENV"
+          RESPONSE=$(curl -s -i -X POST \
+            "${JENKINS_URL}/job/${JOB_PATH}/buildWithParameters" \
+            --user "${JENKINS_USER}:${JENKINS_TOKEN}" \
+            --data-urlencode "MACHINE_IMAGE_REPO=${MACHINE_IMAGE_REPO}" \
+            --data-urlencode "MACHINE_IMAGE_BRANCH=${MACHINE_IMAGE_BRANCH}" \
+            --data-urlencode "BUILD_AMI=${BUILD_AMI}" \
+            --data-urlencode "BUILD_GCP=${BUILD_GCP}" \
+            --data-urlencode "BUILD_AZURE=${BUILD_AZURE}" \
+            --data-urlencode "BUILD_OCI=${BUILD_OCI}" \
+            --data-urlencode "BUILD_ARM=true" \
+            --data-urlencode "RUN_UNIFIED_TEST=true" \
+            --data-urlencode "RUN_AMI_TEST=${RUN_AMI_TEST}" \
+            --data-urlencode "RUN_GCE_TEST=${RUN_GCE_TEST}" \
+            --data-urlencode "RUN_AZURE_TEST=${RUN_AZURE_TEST}" \
+            --data-urlencode "RUN_OCI_TEST=${RUN_OCI_TEST}" \
+            --data-urlencode "DEBUG_MAIL=true" \
+            -w "\n%{http_code}")
+
+          HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+          if [[ "$HTTP_CODE" -lt 200 || "$HTTP_CODE" -ge 300 ]]; then
+            echo "::error::Failed to trigger Jenkins job (HTTP ${HTTP_CODE})"
+            echo "$RESPONSE" | head -20
+            exit 1
           fi
 
-      - name: Post PR comment (success)
-        if: success()
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const cloud = '${{ steps.parse.outputs.cloud }}';
-            const arch = '${{ steps.parse.outputs.arch }}';
-            const imageId = `${{ steps.image.outputs.image_id }}`;
-            const prNumber = context.payload.pull_request.number;
-            const sha = '${{ github.event.pull_request.head.sha }}'.substring(0, 8);
-            const label = '${{ steps.parse.outputs.label }}';
-            const actor = context.payload.sender.login;
-            const jenkinsUrl = process.env.JENKINS_JOB_URL;
-            const jenkinsLink = jenkinsUrl ? `[link](${jenkinsUrl})` : '_job not configured_';
+          QUEUE_URL=$(echo "$RESPONSE" | grep -i "^Location:" | sed 's/[Ll]ocation: //;s/\r//')
 
-            const body = `## Cloud Image Build: \`${cloud}\` (\`${arch}\`)
+          BUILD_URL=""
+          for i in $(seq 1 30); do
+            sleep 5
+            QUEUE_JSON=$(curl -s --user "${JENKINS_USER}:${JENKINS_TOKEN}" \
+              "${QUEUE_URL}api/json" 2>/dev/null || true)
+            BUILD_URL=$(echo "$QUEUE_JSON" | jq -r '.executable.url // empty' 2>/dev/null || true)
+            if [[ -n "$BUILD_URL" ]]; then
+              break
+            fi
+          done
 
-            | Field | Value |
-            |-------|-------|
-            | **Target** | \`${cloud}\` |
-            | **Architecture** | \`${arch}\` |
-            | **Image ID** | \`${imageId}\` |
-            | **PR** | #${prNumber} |
-            | **Commit** | \`${sha}\` |
-            | **Jenkins Tests** | ${jenkinsLink} |
+          if [[ -z "$BUILD_URL" ]]; then
+            BUILD_URL="${JENKINS_URL}/job/${JOB_PATH}/"
+          fi
 
-            Triggered by @${actor} via label \`${label}\``;
+          echo "build_url=${BUILD_URL}" >> "$GITHUB_OUTPUT"
 
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber,
-              body: body
-            });
+      - name: Add pending-ci label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh api "repos/${REPO}/issues/${PR_NUMBER}/labels" \
+            -f "labels[]=pending-ci" 2>/dev/null || true
 
-      - name: Swap labels (success)
-        if: success()
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const label = '${{ steps.parse.outputs.label }}';
-            const cloud = '${{ steps.parse.outputs.cloud }}';
-            const arch = '${{ steps.parse.outputs.arch }}';
-            const prNumber = context.payload.pull_request.number;
-            const resultLabel = `build-result/${cloud}-${arch}/success`;
+      - name: Set commit status
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.event.pull_request.head.sha }}
+          BUILD_URL: ${{ steps.jenkins.outputs.build_url }}
+          TARGETS: ${{ steps.labels.outputs.targets }}
+        run: |
+          gh api "repos/${REPO}/statuses/${SHA}" \
+            -f state="pending" \
+            -f context="jenkins/machine-image-build" \
+            -f description="Building: ${TARGETS}" \
+            -f target_url="${BUILD_URL}"
 
-            // Remove build label
-            try {
-              await github.rest.issues.removeLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: prNumber,
-                name: label
-              });
-            } catch (e) {
-              // Label may already be removed
-            }
+      - name: Post PR comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          BUILD_URL: ${{ steps.jenkins.outputs.build_url }}
+          TARGETS: ${{ steps.labels.outputs.targets }}
+          TESTS: ${{ steps.labels.outputs.tests }}
+          BRANCH: ${{ steps.repo.outputs.branch }}
+          SHA: ${{ github.event.pull_request.head.sha }}
+          SENDER: ${{ github.event.sender.login }}
+        run: |
+          SHORT_SHA="${SHA:0:8}"
 
-            // Ensure result label exists
-            try {
-              await github.rest.issues.createLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                name: resultLabel,
-                color: '0e8a16',
-                description: `Image build succeeded for ${cloud} ${arch}`
-              });
-            } catch (e) {
-              // Label may already exist
-            }
+          BODY="## :rocket: Machine Image Build Triggered
 
-            await github.rest.issues.addLabels({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber,
-              labels: [resultLabel]
-            });
+          | Field | Value |
+          |-------|-------|
+          | **Build targets** | ${TARGETS} |
+          | **Test targets** | ${TESTS} |
+          | **Branch** | \`${BRANCH}\` |
+          | **Commit** | \`${SHORT_SHA}\` |
+          | **Jenkins** | [Build Link](${BUILD_URL}) |
+          | **Triggered by** | @${SENDER} |
 
-      - name: Post PR comment (failure)
+          Status will be updated when the build completes."
+
+          gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" -f body="${BODY}"
+
+      - name: Post failure comment
         if: failure()
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const cloud = '${{ steps.parse.outputs.cloud }}';
-            const arch = '${{ steps.parse.outputs.arch }}';
-            const prNumber = context.payload.pull_request.number;
-            const sha = '${{ github.event.pull_request.head.sha }}'.substring(0, 8);
-            const label = '${{ steps.parse.outputs.label }}';
-            const actor = context.payload.sender.login;
-            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          BODY="## :x: Machine Image Build Failed to Trigger
 
-            const body = `## Cloud Image Build Failed: \`${cloud}\` (\`${arch}\`)
+          Check [workflow logs](${RUN_URL}) for details."
 
-            | Field | Value |
-            |-------|-------|
-            | **Target** | \`${cloud}\` |
-            | **Architecture** | \`${arch}\` |
-            | **PR** | #${prNumber} |
-            | **Commit** | \`${sha}\` |
-            | **Build Logs** | [GitHub Actions](${runUrl}) |
-
-            Triggered by @${actor} via label \`${label}\``;
-
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber,
-              body: body
-            });
-
-      - name: Swap labels (failure)
-        if: failure()
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const label = '${{ steps.parse.outputs.label }}';
-            const cloud = '${{ steps.parse.outputs.cloud }}';
-            const arch = '${{ steps.parse.outputs.arch }}';
-            const prNumber = context.payload.pull_request.number;
-            const resultLabel = `build-result/${cloud}-${arch}/failed`;
-
-            try {
-              await github.rest.issues.removeLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: prNumber,
-                name: label
-              });
-            } catch (e) {}
-
-            try {
-              await github.rest.issues.createLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                name: resultLabel,
-                color: 'e11d48',
-                description: `Image build failed for ${cloud} ${arch}`
-              });
-            } catch (e) {}
-
-            await github.rest.issues.addLabels({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber,
-              labels: [resultLabel]
-            });
+          gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" -f body="${BODY}"

--- a/.github/workflows/check-jenkins-status.yaml
+++ b/.github/workflows/check-jenkins-status.yaml
@@ -1,0 +1,173 @@
+name: Check Jenkins Build Status
+
+on:
+  schedule:
+    - cron: '*/10 * * * *'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  pull-requests: write
+  statuses: write
+
+jobs:
+  check-status:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Find PRs with pending-ci label
+        id: pending
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          PRS=$(gh api "repos/${REPO}/issues?labels=pending-ci&state=open&per_page=50" \
+            --jq '[.[] | select(.pull_request) | .number]')
+
+          COUNT=$(echo "$PRS" | jq 'length')
+          echo "count=${COUNT}" >> "$GITHUB_OUTPUT"
+          echo "prs=${PRS}" >> "$GITHUB_OUTPUT"
+          echo "Found ${COUNT} PRs with pending-ci label"
+
+      - name: Check Jenkins and update statuses
+        if: steps.pending.outputs.count != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          JENKINS_USER: ${{ secrets.JENKINS_USERNAME }}
+          JENKINS_TOKEN: ${{ secrets.JENKINS_TOKEN }}
+          JENKINS_URL: "https://jenkins.scylladb.com"
+          REPO: ${{ github.repository }}
+          PENDING_PRS: ${{ steps.pending.outputs.prs }}
+        run: |
+          set -euo pipefail
+
+          echo "$PENDING_PRS" | jq -r '.[]' | while read -r PR_NUMBER; do
+            echo "==> Checking PR #${PR_NUMBER}"
+
+            HEAD_SHA=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.head.sha')
+
+            STATUS_JSON=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/statuses" \
+              --jq '[.[] | select(.context == "jenkins/machine-image-build")] | sort_by(.updated_at) | last')
+
+            if [[ -z "$STATUS_JSON" || "$STATUS_JSON" == "null" ]]; then
+              echo "  No pending status found, removing label"
+              gh api -X DELETE "repos/${REPO}/issues/${PR_NUMBER}/labels/pending-ci" 2>/dev/null || true
+              continue
+            fi
+
+            STATE=$(echo "$STATUS_JSON" | jq -r '.state')
+            if [[ "$STATE" != "pending" ]]; then
+              echo "  Status already resolved (${STATE}), removing label"
+              gh api -X DELETE "repos/${REPO}/issues/${PR_NUMBER}/labels/pending-ci" 2>/dev/null || true
+              continue
+            fi
+
+            BUILD_URL=$(echo "$STATUS_JSON" | jq -r '.target_url')
+            if [[ -z "$BUILD_URL" || "$BUILD_URL" == "null" ]]; then
+              echo "  No build URL in status, skipping"
+              continue
+            fi
+
+            BUILD_JSON=$(curl -s --user "${JENKINS_USER}:${JENKINS_TOKEN}" \
+              "${BUILD_URL}api/json" 2>/dev/null || true)
+
+            if [[ -z "$BUILD_JSON" ]]; then
+              echo "  Could not reach Jenkins, skipping"
+              continue
+            fi
+
+            RESULT=$(echo "$BUILD_JSON" | jq -r '.result // empty')
+            if [[ -z "$RESULT" ]]; then
+              echo "  Build still running"
+              continue
+            fi
+
+            DURATION=$(echo "$BUILD_JSON" | jq -r '.duration // 0')
+            DURATION_MIN=$(( DURATION / 60000 ))
+
+            CONSOLE_URL="${BUILD_URL}consoleText"
+            CONSOLE=$(curl -s --user "${JENKINS_USER}:${JENKINS_TOKEN}" \
+              "${CONSOLE_URL}" 2>/dev/null || true)
+
+            SUBJOBS=""
+            if [[ -n "$CONSOLE" ]]; then
+              SUBJOBS=$(echo "$CONSOLE" | grep -oP 'Build .+ completed: \S+' | sort -u || true)
+            fi
+
+            SUBJOB_TABLE=""
+            if [[ -n "$SUBJOBS" ]]; then
+              SUBJOB_TABLE="
+          ### Sub-job Results
+          | Job | Result |
+          |-----|--------|"
+
+              while IFS= read -r line; do
+                JOB_NAME=$(echo "$line" | sed 's/Build //;s/ completed:.*//' | sed 's/ #[0-9]*//')
+                JOB_RESULT=$(echo "$line" | grep -oP 'completed: \K\S+')
+
+                case "$JOB_RESULT" in
+                  SUCCESS)  EMOJI=":white_check_mark:" ;;
+                  FAILURE)  EMOJI=":x:" ;;
+                  ABORTED)  EMOJI=":stop_sign:" ;;
+                  UNSTABLE) EMOJI=":warning:" ;;
+                  *)        EMOJI=":grey_question:" ;;
+                esac
+
+                SUBJOB_TABLE="${SUBJOB_TABLE}
+          | ${JOB_NAME} | ${EMOJI} ${JOB_RESULT} |"
+              done <<< "$SUBJOBS"
+            fi
+
+            case "$RESULT" in
+              SUCCESS)
+                GH_STATE="success"
+                DESCRIPTION="Build succeeded"
+                HEADER=":white_check_mark: Machine Image Build Succeeded"
+                ;;
+              FAILURE)
+                GH_STATE="failure"
+                DESCRIPTION="Build failed"
+                HEADER=":x: Machine Image Build Failed"
+                ;;
+              ABORTED)
+                GH_STATE="error"
+                DESCRIPTION="Build aborted"
+                HEADER=":stop_sign: Machine Image Build Aborted"
+                ;;
+              UNSTABLE)
+                GH_STATE="failure"
+                DESCRIPTION="Build unstable (test failures)"
+                HEADER=":warning: Machine Image Build Unstable"
+                ;;
+              *)
+                GH_STATE="error"
+                DESCRIPTION="Build result: ${RESULT}"
+                HEADER=":grey_question: Machine Image Build: ${RESULT}"
+                ;;
+            esac
+
+            gh api "repos/${REPO}/statuses/${HEAD_SHA}" \
+              -f state="${GH_STATE}" \
+              -f context="jenkins/machine-image-build" \
+              -f description="${DESCRIPTION}" \
+              -f target_url="${BUILD_URL}"
+
+            BODY="## ${HEADER}
+
+          | Field | Value |
+          |-------|-------|
+          | **Result** | ${RESULT} |
+          | **Duration** | ${DURATION_MIN}m |
+          | **Jenkins** | [Build Link](${BUILD_URL}) |
+          | **Console** | [Full Output](${BUILD_URL}console) |
+          ${SUBJOB_TABLE}"
+
+            gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" -f body="${BODY}"
+
+            gh api -X DELETE "repos/${REPO}/issues/${PR_NUMBER}/labels/pending-ci" 2>/dev/null || true
+
+            echo "  PR #${PR_NUMBER}: ${GH_STATE} (${RESULT})"
+          done

--- a/docs/cloud-image-build-credentials.md
+++ b/docs/cloud-image-build-credentials.md
@@ -1,0 +1,129 @@
+# Cloud Image Build Credentials Setup
+
+This document describes the GitHub Actions secrets required for the
+`build-cloud-image.yaml` workflow, which builds cloud images on-demand from PRs
+using `build/{cloud}-{arch}` labels.
+
+## AWS
+
+### Secrets
+
+| Secret | Description |
+|--------|-------------|
+| `AWS_ACCESS_KEY_ID` | IAM user access key ID |
+| `AWS_SECRET_ACCESS_KEY` | IAM user secret access key |
+
+### Setup
+
+1. Create an IAM user (e.g., `gha-image-builder`) with programmatic access.
+2. Attach a policy granting EC2 image build permissions:
+   - `ec2:RunInstances`, `ec2:TerminateInstances`, `ec2:DescribeInstances`
+   - `ec2:CreateImage`, `ec2:RegisterImage`, `ec2:DeregisterImage`
+   - `ec2:DescribeImages`, `ec2:CopyImage`, `ec2:ModifyImageAttribute`
+   - `ec2:CreateSecurityGroup`, `ec2:DeleteSecurityGroup`, `ec2:AuthorizeSecurityGroupIngress`
+   - `ec2:CreateKeyPair`, `ec2:DeleteKeyPair`
+   - `ec2:CreateTags`, `ec2:DescribeSubnets`, `ec2:DescribeSecurityGroups`
+   - `ec2:CreateSnapshot`, `ec2:DeleteSnapshot`, `ec2:DescribeSnapshots`
+   - `ec2:DescribeVolumes`, `ec2:CreateVolume`, `ec2:DeleteVolume`
+3. Generate an access key and store `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
+   as repository secrets.
+
+Region, security group, and other defaults are configured in `packer/ami_variables.json`.
+
+## GCE
+
+### Secrets
+
+| Secret | Description |
+|--------|-------------|
+| `GCE_SERVICE_ACCOUNT_JSON` | Full JSON key for a GCP service account |
+
+### Setup
+
+1. In the `scylla-images` GCP project, create a service account
+   (e.g., `gha-image-builder@scylla-images.iam.gserviceaccount.com`).
+2. Grant the following roles:
+   - `roles/compute.admin` (Compute Admin)
+   - `roles/storage.admin` (Storage Admin)
+3. Create and download a JSON key for the service account.
+4. Store the entire JSON content as the `GCE_SERVICE_ACCOUNT_JSON` repository secret.
+
+The workflow writes this to a temporary file and sets `GOOGLE_APPLICATION_CREDENTIALS`.
+Project and zone are configured in `packer/gce_variables.json`.
+
+## Azure
+
+### Secrets
+
+| Secret | Description |
+|--------|-------------|
+| `AZURE_CLIENT_ID` | Service principal application (client) ID |
+| `AZURE_CLIENT_SECRET` | Service principal password/secret |
+| `AZURE_TENANT_ID` | Azure AD tenant ID |
+| `AZURE_SUBSCRIPTION_ID` | Azure subscription ID |
+
+### Setup
+
+1. Create a service principal:
+   ```bash
+   az ad sp create-for-rbac --name "gha-image-builder" \
+     --role Contributor \
+     --scopes /subscriptions/<SUBSCRIPTION_ID>/resourceGroups/SCYLLA-IMAGES
+   ```
+2. The command outputs `appId`, `password`, and `tenant` — store these as
+   `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, and `AZURE_TENANT_ID` respectively.
+3. Store your subscription ID as `AZURE_SUBSCRIPTION_ID`.
+
+`build_image.sh` handles `az login --service-principal` automatically when these
+environment variables are set (see line 264).
+
+## OCI (Oracle Cloud Infrastructure)
+
+### Secrets
+
+| Secret | Description |
+|--------|-------------|
+| `OCI_USER_OCID` | OCID of the OCI user |
+| `OCI_TENANCY_OCID` | OCID of the OCI tenancy |
+| `OCI_FINGERPRINT` | Fingerprint of the API signing key |
+| `OCI_KEY_FILE_CONTENTS` | Base64-encoded PEM private key |
+| `OCI_REGION` | OCI region (e.g., `us-ashburn-1`) |
+| `OCI_COMPARTMENT_OCID` | OCID of the compartment for images |
+| `OCI_SUBNET_OCID` | OCID of the subnet for build instances |
+| `OCI_AVAILABILITY_DOMAIN` | Availability domain for build instances |
+
+### Setup
+
+1. In the OCI console, go to **User Settings > API Keys > Add API Key**.
+2. Upload or generate a PEM key pair.
+3. Note the fingerprint, user OCID, and tenancy OCID from the configuration preview.
+4. Base64-encode the private PEM key:
+   ```bash
+   base64 -w0 ~/.oci/oci_api_key.pem
+   ```
+5. Store the values as repository secrets per the table above.
+6. Set the infrastructure IDs (`OCI_COMPARTMENT_OCID`, `OCI_SUBNET_OCID`,
+   `OCI_AVAILABILITY_DOMAIN`) to point at the resources where build instances
+   should launch.
+
+The workflow decodes the PEM key to a temporary file and sets `OCI_CLI_KEY_FILE`.
+
+## Jenkins
+
+### Secrets
+
+| Secret | Description |
+|--------|-------------|
+| `JENKINS_USERNAME` | Jenkins API user |
+| `JENKINS_TOKEN` | Jenkins API token |
+
+These are shared with the existing `trigger_jenkins.yaml` workflow. The image
+build workflow triggers `on-demand-image-test/{cloud}` jobs on Jenkins, passing:
+
+- `IMAGE_ID` — the built image identifier
+- `CLOUD_TARGET` — cloud name (aws/gce/azure/oci)
+- `ARCH` — architecture (x86_64/aarch64)
+- `PR_NUMBER`, `PR_BRANCH`, `PR_SHA` — PR context
+
+These Jenkins jobs need to be created as parameterized jobs that accept
+the above parameters.


### PR DESCRIPTION
## Summary
- Add `build-cloud-image.yaml` workflow triggered by `build/{cloud}-{arch}` PR labels (e.g., `build/aws-x86_64`)
- Supports all four clouds (AWS, GCE, Azure, OCI) and both architectures (x86_64, aarch64)
- Builds image with Packer, extracts image ID, triggers Jenkins test job, and posts results as PR comment
- Includes credentials setup documentation in `docs/cloud-image-build-credentials.md`

## How it works
1. Add a label like `build/aws-x86_64` to a PR
2. Workflow runs Packer via `build_image.sh` with debug/PR-specific tags
3. On success: PR comment with image ID + Jenkins link, label swapped to `build-result/aws-x86_64/success`
4. On failure: PR comment with error link, label swapped to `build-result/aws-x86_64/failed`
5. To rebuild: remove result label, re-add build label

## Test plan
- [ ] Verify workflow YAML is valid (`act` or push to test branch)
- [ ] Configure secrets for at least one cloud (AWS recommended for initial test)
- [ ] Add `build/aws-x86_64` label to a test PR and verify full flow
- [ ] Verify PR comment is posted with correct image ID
- [ ] Verify label is swapped on success/failure
- [ ] Test with invalid label (e.g., `build/invalid-x86_64`) to verify error handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)