### PR TITLE
fix: remove authorized_keys injected by cloud-init during AWS/OCI build

### DIFF
--- a/packer/scylla_install_image
+++ b/packer/scylla_install_image
@@ -387,6 +387,11 @@ WantedBy=multi-user.target
         run("cloud-init clean", shell=True, check=True)
         run("rm -f /etc/netplan/50-cloud-init.yaml", shell=True, check=True)
         run("cloud-init init", shell=True, check=check_init_command)
+        # Remove authorized_keys injected by cloud-init during build — the image must ship
+        # with no pre-baked SSH keys (required by AWS Marketplace security scan policy).
+        scyllaadm_ak = "/home/scyllaadm/.ssh/authorized_keys"
+        if os.path.exists(scyllaadm_ak):
+            os.remove(scyllaadm_ak)
         for skel in glob.glob("/etc/skel/.*"):
             shutil.copy(skel, "/home/scyllaadm")
             os.chown(skel, 1000, 1000)


### PR DESCRIPTION
## Summary

- `cloud-init init` re-creates `/home/scyllaadm/` and injects the Packer build SSH public key into `/home/scyllaadm/.ssh/authorized_keys`; nothing removed it, so the key was baked into the final AMI snapshot
- AWS Marketplace security scan rejects any AMI containing pre-baked authorized keys, blocking compliant publication
- Add an explicit `os.remove` of `/home/scyllaadm/.ssh/authorized_keys` immediately after `cloud-init init`, guarded by `os.path.exists` so it is a no-op when absent

<img width="1072" height="279" alt="image-2" src="https://github.com/user-attachments/assets/d2d63037-8a18-4831-83e7-e4d8fedd3be7" />
<img width="1536" height="697" alt="image-1" src="https://github.com/user-attachments/assets/14e07bde-f06d-4e11-95ed-4792dfe10b70" />

## Root cause (SMI-275)

Execution order in `packer/scylla_install_image` for AWS/OCI:
1. `userdel -r -f ubuntu` — deletes `/home/ubuntu` including the ubuntu user's authorized_keys ✅
2. `cloud-init clean` — resets cloud-init state
3. `cloud-init init` — re-creates `/home/scyllaadm/` and **injects the Packer SSH public key** into `/home/scyllaadm/.ssh/authorized_keys` ❌
4. *(nothing cleaned up the newly created file)*

Packer's `ssh_clear_authorized_keys: true` only affects the communicator user (`ubuntu`, already deleted) and does **not** touch `/home/scyllaadm/.ssh/authorized_keys`.

## Fix

After `cloud-init init`, explicitly remove the injected file:

```python
scyllaadm_ak = "/home/scyllaadm/.ssh/authorized_keys"
if os.path.exists(scyllaadm_ak):
    os.remove(scyllaadm_ak)
```

Applies to both AWS and OCI builds (both run the `cloud-init init` path).

Fixes SMI-275.