### PR TITLE
Disable google-guest-agent multiqueue on GCE images

### DIFF
--- a/packer/scylla_install_image
+++ b/packer/scylla_install_image
@@ -217,6 +217,13 @@ if __name__ == "__main__":
         kernel_opt = ""
         grub_variable = "GRUB_CMDLINE_LINUX_DEFAULT"
         run("systemctl mask google-osconfig-agent", shell=True, check=True)
+        # Disable google-guest-agent multiqueue setup to avoid conflicting with scylla's network configuration
+        instance_configs = dedent("""\
+            [InstanceSetup]
+            set_multiqueue = false
+        """)
+        with open("/etc/default/instance_configs.cfg", "w") as f:
+            f.write(instance_configs)
     elif args.target_cloud == "azure":
         kernel_opt = " rootdelay=300"
         grub_variable = "GRUB_CMDLINE_LINUX"


### PR DESCRIPTION
## Summary
- Configure google-guest-agent to disable multiqueue setup on GCE images via `/etc/default/instance_configs.cfg`
- Prevents the agent from conflicting with scylla's own network interface configuration
- The `set_multiqueue` option controls whether the guest-agent invokes the `google_set_multiqueue` script, which configures network queue count and IRQ affinity — this should be left to scylla's own `perftune.py`

Refs: CUSTOMER-124

## Test plan
- [x] Build a GCE image and verify `/etc/default/instance_configs.cfg` contains `set_multiqueue = false` (projects/scylla-images/global/images/debug-scylla-2026-2-0-x86-64-2026-04-14t22-57-21)
- [x] 🟢 [artifacts-gce-image-test #30](https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-gce-image-test/30/)
- [x] Verify scylla network configuration works correctly on GCE without multiqueue interference

### Verified on a running GCE instance

1. **Config file in place:**
   ```
   $ cat /etc/default/instance_configs.cfg
   [InstanceSetup]
   set_multiqueue = false
   ```

2. **`google_set_multiqueue` script was never invoked** — no journal entries:
   ```
   $ sudo journalctl --no-pager | grep -i google_set_multiqueue
   (no output)
   ```

3. **No multiqueue setup activity in guest-agent logs** — only normal `multicast` interface flags, no queue configuration:
   ```
   $ sudo journalctl -u google-guest-agent --no-pager | grep -i "multi\|queue"
   (only multicast flag in interface state, no queue setup)
   ```

This confirms the guest-agent reads the config and skips calling `google_set_multiqueue`, leaving network queue configuration solely to scylla's `perftune.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)