### PR TITLE
Install etckeeper, nftables

### DIFF
--- a/docs/disabled-services-and-purged-packages.md
+++ b/docs/disabled-services-and-purged-packages.md
@@ -60,7 +60,8 @@ started, even by dependencies.
 | `motd-news.timer` | Periodically fetches MOTD news from the internet. Unnecessary network activity. |
 | `esm-cache.service` | Caches Ubuntu Extended Security Maintenance status. Makes HTTP calls to Canonical's API; not relevant for a database appliance. |
 | `dailyaidecheck.timer` | Runs daily AIDE (Advanced Intrusion Detection Environment) integrity checks. Full filesystem scans cause significant I/O load that can impact Scylla's performance. |
-| `etckeeper.timer` | Tracks `/etc` changes in a VCS (git). The periodic commit operations are unnecessary overhead; `/etc` changes on Scylla images are infrequent and managed via image builds. |
+| `etckeeper.service` | Tracks `/etc` changes in git. The etckeeper package ships installed on the image, but its automation is disabled — its stock service would conflict with Siren's own `/etc` management. |
+| `etckeeper.timer` | Periodic trigger for `etckeeper.service`. Masked for the same reason as the service. |
 | `fwupd-refresh.timer` | Periodically checks for firmware updates. Cloud guests do not manage their own firmware; these checks are wasted network and CPU cycles. |
 | `man-db.timer` | Rebuilds the `mandb` cache (man page index). CPU-intensive indexing operation with no benefit on a production database server where man pages are rarely consulted. |
 | `scylla-manager-check-for-updates.timer` | Periodically checks for Scylla Manager updates. Outbound HTTP request to check for new versions; updates should be performed deliberately, not automatically. |

--- a/packer/scylla_install_image
+++ b/packer/scylla_install_image
@@ -174,7 +174,7 @@ if __name__ == "__main__":
     run(
         f"apt-get install -y --auto-remove {args.product}-machine-image {args.product}-server-dbg "
         "chrony cpufrequtils curl dnsutils ethtool htop initramfs-tools jq mdadm ncat netcat-openbsd "
-        "net-tools nload nmap python3-boto sysstat systemd-coredump tmux traceroute vim-nox vim.tiny wget xfsprogs aide",
+        "net-tools nftables nload nmap python3-boto sysstat systemd-coredump tmux traceroute vim-nox vim.tiny wget xfsprogs aide",
         shell=True,
         check=True,
     )
@@ -237,9 +237,20 @@ if __name__ == "__main__":
 
     configure_chrony(args.target_cloud)
 
+    # pre-install etckeeper so Siren doesn't need to at bootstrap; disable all of its
+    # automation (timer, service, daily cron) because Siren manages /etc changes itself.
+    run("apt-get install -y etckeeper", shell=True, check=True)
+    run(
+        "sed -i 's/^#AVOID_DAILY_AUTOCOMMITS=1/AVOID_DAILY_AUTOCOMMITS=1/' /etc/etckeeper/etckeeper.conf",
+        shell=True,
+        check=True,
+    )
+    run("systemctl disable --now etckeeper.service etckeeper.timer", shell=True, check=False)
+    run("systemctl mask etckeeper.service etckeeper.timer", shell=True, check=True)
+
     run(
         "systemctl mask apt-daily-upgrade.timer apt-daily.timer dpkg-db-backup.timer motd-news.timer apt-news.service esm-cache.service dailyaidecheck.timer"
-        " etckeeper.timer fwupd-refresh.timer man-db.timer scylla-manager-check-for-updates.timer"
+        " fwupd-refresh.timer man-db.timer scylla-manager-check-for-updates.timer"
         " unattended-upgrades.service update-notifier-download.timer update-notifier-motd.timer",
         shell=True,
         check=True,


### PR DESCRIPTION
Siren installs etckeeper, nftables packages post-provisioning, adding time and a flaky apt-mirror dependency to each bootstrap.
The change ships them on the image instead.

Additionally, etckeeper's systemd service, timer, and daily cron autocommit are disabled, so its automation doesn't conflict with Siren own /etc management.

Closes: SMI-271
Refs: SMI-272

### Testing:
Built images for each provider; checked that packages are installed, etckeeper units are masked, scylla is starting.
AWS:
```
$ dpkg -l git etckeeper nftables
Desired=Unknown/Install/Remove/Purge/Hold
| Status=Not/Inst/Conf-files/Unpacked/halF-conf/Half-inst/trig-aWait/Trig-pend
|/ Err?=(none)/Reinst-required (Status,Err: uppercase=bad)
||/ Name           Version             Architecture Description
+++-==============-===================-============-==============================================================
ii  etckeeper      1.18.20-2           all          store /etc in git, mercurial, brz or darcs
ii  git            1:2.43.0-1ubuntu7.3 arm64        fast, scalable, distributed revision control system
ii  nftables       1.0.9-1ubuntu0.1    arm64        Program to control packet filtering rules by Netfilter project

$ systemctl is-enabled etckeeper.service etckeeper.timer
masked
masked

$ grep '^AVOID_DAILY_AUTOCOMMITS=1' /etc/etckeeper/etckeeper.conf
AVOID_DAILY_AUTOCOMMITS=1

$ systemctl status scylla-server --no-pager
● scylla-server.service - Scylla Server
     Loaded: loaded (/usr/lib/systemd/system/scylla-server.service; enabled; preset: enabled)
    Drop-In: /etc/systemd/system/scylla-server.service.d
             └─10-time-sync.conf, capabilities.conf, dependencies.conf, mounts.conf, sysconfdir.conf
     Active: active (running) since Fri 2026-04-17 11:17:38 UTC; 4min 31s ago
    Process: 2994 ExecStartPre=/opt/scylladb/scripts/scylla_prepare (code=exited, status=0/SUCCESS)
   Main PID: 3061 (scylla)
     Status: "serving"
      Tasks: 9 (limit: 9297)
     Memory: 5.9G (peak: 5.9G)
        CPU: 20.731s
     CGroup: /scylla.slice/scylla-server.slice/scylla-server.service
             └─3061 /usr/bin/scylla --log-to-syslog 1 --log-to-stdout 0 --default-log-level info --network-stack posix --io-properties-file=/etc/scylla.d/io_properties.yaml --cpuset 0-3 --lock-memory=1
```

GCE
```
$ dpkg -l git etckeeper nftables
Desired=Unknown/Install/Remove/Purge/Hold
| Status=Not/Inst/Conf-files/Unpacked/halF-conf/Half-inst/trig-aWait/Trig-pend
|/ Err?=(none)/Reinst-required (Status,Err: uppercase=bad)
||/ Name           Version             Architecture Description
+++-==============-===================-============-==============================================================
ii  etckeeper      1.18.20-2           all          store /etc in git, mercurial, brz or darcs
ii  git            1:2.43.0-1ubuntu7.3 amd64        fast, scalable, distributed revision control system
ii  nftables       1.0.9-1ubuntu0.1    amd64        Program to control packet filtering rules by Netfilter project

$ systemctl is-enabled etckeeper.service etckeeper.timer
masked
masked

$ grep '^AVOID_DAILY_AUTOCOMMITS=1' /etc/etckeeper/etckeeper.conf
AVOID_DAILY_AUTOCOMMITS=1

$ systemctl status scylla-server --no-pager
● scylla-server.service - Scylla Server
     Loaded: loaded (/usr/lib/systemd/system/scylla-server.service; enabled; preset: enabled)
    Drop-In: /etc/systemd/system/scylla-server.service.d
             └─10-time-sync.conf, capabilities.conf, dependencies.conf, mounts.conf, sysconfdir.conf
     Active: active (running) since Fri 2026-04-17 07:27:20 UTC; 35min ago
    Process: 2044 ExecStartPre=/opt/scylladb/scripts/scylla_prepare (code=exited, status=0/SUCCESS)
   Main PID: 2106 (scylla)
     Status: "serving"
      Tasks: 5 (limit: 9446)
     Memory: 6.2G (peak: 6.2G)
        CPU: 1min 7.312s
     CGroup: /scylla.slice/scylla-server.slice/scylla-server.service
             └─2106 /usr/bin/scylla --log-to-syslog 1 --log-to-stdout 0 --default-log-level info --network-stack posix --io-properties-file=/etc/scylla.d/io_properties.yaml --cpuset 0-1 --lock-memory=1
```

Azure
```
$ dpkg -l git etckeeper nftables
Desired=Unknown/Install/Remove/Purge/Hold
| Status=Not/Inst/Conf-files/Unpacked/halF-conf/Half-inst/trig-aWait/Trig-pend
|/ Err?=(none)/Reinst-required (Status,Err: uppercase=bad)
||/ Name           Version             Architecture Description
+++-==============-===================-============-==============================================================
ii  etckeeper      1.18.20-2           all          store /etc in git, mercurial, brz or darcs
ii  git            1:2.43.0-1ubuntu7.3 amd64        fast, scalable, distributed revision control system
ii  nftables       1.0.9-1ubuntu0.1    amd64        Program to control packet filtering rules by Netfilter project

$ systemctl is-enabled etckeeper.service etckeeper.timer
masked
masked

$ grep '^AVOID_DAILY_AUTOCOMMITS=1' /etc/etckeeper/etckeeper.conf
AVOID_DAILY_AUTOCOMMITS=1

$ systemctl status scylla-server --no-pager
● scylla-server.service - Scylla Server
     Loaded: loaded (/usr/lib/systemd/system/scylla-server.service; enabled; preset: enabled)
    Drop-In: /etc/systemd/system/scylla-server.service.d
             └─10-time-sync.conf, capabilities.conf, dependencies.conf, mounts.conf, sysconfdir.conf
     Active: active (running) since Fri 2026-04-17 09:09:33 UTC; 20min ago
    Process: 1508 ExecStartPre=/opt/scylladb/scripts/scylla_prepare (code=exited, status=0/SUCCESS)
   Main PID: 1570 (scylla)
     Status: "serving"
      Tasks: 15 (limit: 77125)
     Memory: 58.2G (peak: 58.2G)
        CPU: 2min 14.253s
     CGroup: /scylla.slice/scylla-server.slice/scylla-server.service
             └─1570 /usr/bin/scylla --log-to-syslog 1 --log-to-stdout 0 --default-log-level info --network-stack posix --io-properties-file=/etc/scylla.d/io_properties.yaml --cpuset 1-7 --lock-memory=1
```

OCI
```
$ dpkg -l git etckeeper nftables
Desired=Unknown/Install/Remove/Purge/Hold
| Status=Not/Inst/Conf-files/Unpacked/halF-conf/Half-inst/trig-aWait/Trig-pend
|/ Err?=(none)/Reinst-required (Status,Err: uppercase=bad)
||/ Name           Version             Architecture Description
+++-==============-===================-============-==============================================================
ii  etckeeper      1.18.20-2           all          store /etc in git, mercurial, brz or darcs
ii  git            1:2.43.0-1ubuntu7.3 amd64        fast, scalable, distributed revision control system
ii  nftables       1.0.9-1ubuntu0.1    amd64        Program to control packet filtering rules by Netfilter project

$ systemctl is-enabled etckeeper.service etckeeper.timer
masked
masked

$ grep '^AVOID_DAILY_AUTOCOMMITS=1' /etc/etckeeper/etckeeper.conf
AVOID_DAILY_AUTOCOMMITS=1

$ systemctl status scylla-server --no-pager
● scylla-server.service - Scylla Server
     Loaded: loaded (/usr/lib/systemd/system/scylla-server.service; enabled; preset: enabled)
    Drop-In: /etc/systemd/system/scylla-server.service.d
             └─10-time-sync.conf, capabilities.conf, dependencies.conf, mounts.conf, sysconfdir.conf
     Active: active (running) since Fri 2026-04-17 09:59:10 UTC; 36s ago
    Process: 6231 ExecStartPre=/opt/scylladb/scripts/scylla_prepare (code=exited, status=0/SUCCESS)
   Main PID: 6297 (scylla)
     Status: "serving"
      Tasks: 29 (limit: 154463)
     Memory: 116.6G (peak: 116.6G)
        CPU: 24.505s
     CGroup: /scylla.slice/scylla-server.slice/scylla-server.service
             └─6297 /usr/bin/scylla --log-to-syslog 1 --log-to-stdout 0 --default-log-level info --network-stack posix --io-properties-file=/etc/scylla.d/io_properties.yaml --cpuset 2-15 --lock-memory=1
```