### PR TITLE
packer: disable dynamic MOTD at the PAM layer

### DIFF
--- a/docs/disabled-services-and-purged-packages.md
+++ b/docs/disabled-services-and-purged-packages.md
@@ -74,6 +74,26 @@ started, even by dependencies.
 |---|---|
 | `fstrim.timer` / `fstrim.service` | Periodic SSD TRIM operations. Scylla images use XFS with online discard (`discard` mount option), which handles TRIM inline. Running `fstrim` on top of that is redundant and causes I/O pauses. (Ref: SMI-249) |
 
+## PAM MOTD hardening
+
+Dynamic MOTD in Ubuntu runs scripts under `/etc/update-motd.d/` on every SSH login
+via the `pam_motd.so` PAM module. Those scripts make outbound network calls, hold
+APT locks briefly, and can race with latency-sensitive Scylla workload during the
+login window. Masking `motd-news.timer` / `update-notifier-motd.timer` (see above)
+disables only the periodic refresh path; the login-time path is separate.
+
+During image build, `/etc/pam.d/sshd` and `/etc/pam.d/login` are rewritten:
+
+- the `session optional pam_motd.so motd=/run/motd.dynamic ...` line (invokes
+  `/etc/update-motd.d/*`) is removed;
+- the remaining `pam_motd` line is normalized, so only the static `/etc/motd`
+  is shown and no "update" pass runs;
+- `/etc/motd` is replaced with an empty regular file (mode 0644, `root:root`),
+  detaching it from `/run/motd` regeneration.
+
+Result: SSH logins no longer trigger MOTD helpers, network activity, or APT
+lock contention. (Ref: SMI-273)
+
 ## General Principles
 
 1. **Latency sensitivity**: Scylla is designed for low-latency, high-throughput database operations. Any background process that causes I/O, CPU, or memory pressure can introduce tail latency spikes (P99/P999).

--- a/packer/scylla_install_image
+++ b/packer/scylla_install_image
@@ -5,12 +5,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse
+import contextlib
 import glob
 import os
 import platform
 import re
 import shutil
 import sys
+from pathlib import Path
 from subprocess import run
 from textwrap import dedent
 
@@ -263,6 +265,27 @@ if __name__ == "__main__":
         shell=True,
         check=True,
     )
+    # disable Ubuntu dynamic MOTD at the PAM layer
+    for pam_file in ("/etc/pam.d/sshd", "/etc/pam.d/login"):
+        p = Path(pam_file)
+        content = p.read_text()
+        content = re.sub(
+            r"^\s*session\s+optional\s+pam_motd\.so\s+motd=/run/motd\.dynamic.*\n", "", content, flags=re.MULTILINE
+        )
+        content = re.sub(
+            r"^\s*session\s+optional\s+pam_motd\.so.*$",
+            "session    optional     pam_motd.so motd=/etc/motd noupdate",
+            content,
+            flags=re.MULTILINE,
+        )
+        p.write_text(content)
+    # reset /etc/motd to an empty static file
+    motd = Path("/etc/motd")
+    with contextlib.suppress(FileNotFoundError):
+        motd.unlink()
+    motd.write_text("")
+    motd.chmod(0o644)
+
     run("systemctl daemon-reload", shell=True, check=True)
     run("systemctl enable scylla-image-setup.service", shell=True, check=True)
     run("systemctl enable scylla-image-post-start.service", shell=True, check=True)


### PR DESCRIPTION
pam_motd runs /etc/update-motd.d/* per SSH login, making outbound HTTP calls and holding APT locks. To address this the change rewrites /etc/pam.d/sshd and /etc/pam.d/login to point at a static empty /etc/motd with `noupdate`.

Fixes: SMI-273

### Testing:
- check that pam edit landed - pam_motd in PAM stacks
```
scyllaadm@ip-10-0-1-45:~$ grep -n pam_motd /etc/pam.d/sshd /etc/pam.d/login
/etc/pam.d/sshd:33:session    optional     pam_motd.so motd=/etc/motd noupdate
/etc/pam.d/login:33:session    optional     pam_motd.so motd=/etc/motd noupdate
scyllaadm@ip-10-0-1-45:~$
```
- /etc/motd is detached from the dynamic regen path
```
scyllaadm@ip-10-0-1-45:~$ wc -c /etc/motd; readlink /etc/motd
0 /etc/motd
scyllaadm@ip-10-0-1-45:~$ 
```
- on fresh login there is no MOTD processes and scripts never ran (there is no /run/motd.dynamic)
```
scyllaadm@ip-10-0-1-45:~$ ps -ef | grep -E "update-motd|check-new-release|motd-news" | grep -v -E "grep|pgrep"
scyllaadm@ip-10-0-1-45:~$ ls -la /run/motd.dynamic
ls: cannot access '/run/motd.dynamic': No such file or directory
scyllaadm@ip-10-0-1-45:~$
```
