### PR TITLE
scylla_image_setup: run io_setup on GCE persistent-disk instances

### DIFF
--- a/common/scylla_image_setup
+++ b/common/scylla_image_setup
@@ -12,7 +12,7 @@ from pathlib import Path
 from subprocess import run
 
 from lib.log import setup_logging
-from lib.scylla_cloud import get_cloud_instance, is_azure, is_ec2, is_gce
+from lib.scylla_cloud import get_cloud_instance, is_azure, is_ec2
 
 
 LOGGER = logging.getLogger(__name__)
@@ -60,12 +60,7 @@ if __name__ == "__main__":
             else:
                 raise e
         if os.path.ismount("/var/lib/scylla") and cloud_instance.is_supported_instance_class():
-            # We run io_setup only when ehpemeral disks are available
-            if is_gce():
-                if cloud_instance.nvme_disk_count > 0:
-                    cloud_instance.io_setup()
-            else:
-                cloud_instance.io_setup()
+            cloud_instance.io_setup()
             run("systemctl daemon-reload", shell=True, check=True)
             run("systemctl enable var-lib-systemd-coredump.mount", shell=True, check=True)
             run("systemctl start var-lib-systemd-coredump.mount", shell=True, check=True)


### PR DESCRIPTION
## Summary


Scylla 2026.2 made missing I/O Scheduler configuration a fatal startup error (`std::runtime_error (Bad I/O Scheduler configuration)`). On GCE, `io_setup()` was only called when `nvme_disk_count > 0`, which skips persistent-disk-only instances (e.g. `n1-standard-2` with `pd-standard`/`pd-ssd`).

This causes first boot to fail on the `artifacts-gce-image-persistent-disk-test`.

## Changes

- Remove the GCE-specific NVMe guard so `io_setup()` runs for all supported GCE instance classes, not just those with local SSDs
- Remove unused `is_gce` import

The `GcpIoSetup.generate()` method already has fallback logic to invoke `scylla_io_setup` (iotune) when the instance type is not found in `gcp_io_params.yaml`, so persistent-disk instances will get a proper `io_properties.yaml` via disk benchmarking.

Fixes [SMI-281](https://scylladb.atlassian.net/browse/SMI-281)

## testing
- [x] - 🟢  https://jenkins.scylladb.com/job/releng-testing/job/unified-deb/131/
- [x] - building GCE image:  https://www.googleapis.com/compute/v1/projects/scylla-images/global/images/debug-scylla-2026-2-0-x86-64-2026-05-10t20-57-00
- [x] 🟢  [artifacts-gce-image-persistent-disk-test #8](https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-gce-image-persistent-disk-test/8/)

[SMI-281]: https://scylladb.atlassian.net/browse/SMI-281?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ