### PR TITLE
packer/oci: fix oci CLI lookup in add_image_shape_compat.sh

### DIFF
--- a/packer/oci/add_image_shape_compat.sh
+++ b/packer/oci/add_image_shape_compat.sh
@@ -51,17 +51,20 @@ done
 echo "Adding ${#SHAPES[@]} shape-compat entries to image ${IMAGE_ID}..."
 failures=0
 for shape in "${SHAPES[@]}"; do
+    stderr_file=$(mktemp)
     output=$("$OCI_CMD" compute image-shape-compatibility-entry add \
         --image-id "$IMAGE_ID" --shape-name "$shape" \
-        --query 'data.shape' --raw-output 2>&1) && rc=0 || rc=$?
+        --query 'data.shape' --raw-output 2>"$stderr_file") && rc=0 || rc=$?
     if [[ "$output" == "$shape" ]]; then
         echo "  + ${shape}"
-    elif [[ "$output" == *"already exists"* ]]; then
+    elif [[ "$output" == *"already exists"* ]] || grep -q "already exists" "$stderr_file" 2>/dev/null; then
         echo "  = ${shape} (already present)"
     else
-        echo "  ! ${shape}: ${output} (rc=${rc})" >&2
+        stderr_content=$(<"$stderr_file")
+        echo "  ! ${shape}: ${output} ${stderr_content} (rc=${rc})" >&2
         failures=$((failures + 1))
     fi
+    rm -f "$stderr_file"
 done
 echo "Done. ${failures} failure(s)."
 [[ "$failures" -gt 0 ]] && exit 1

--- a/packer/oci/add_image_shape_compat.sh
+++ b/packer/oci/add_image_shape_compat.sh
@@ -20,7 +20,7 @@
 set -euo pipefail
 
 IMAGE_ID=""
-OCI_CMD="${OCI_CMD:-$(command -v oci || true)}"
+OCI_CMD="${OCI_CMD:-$(command -v oci || echo "$HOME/bin/oci")}"
 
 # Shapes present on OCI Canonical-Ubuntu-24.04-Minimal marketplace
 # image but absent from a default custom-imported 26.04 image.


### PR DESCRIPTION
The `add_image_shape_compat.sh` script fails in the OCI build post-processor with:

```
Error: oci CLI not found (set OCI_CMD env var)
```

Build: https://jenkins.scylladb.com/job/scylla-master/job/next-machine-image/828/

The fallback `command -v oci || true` returns an empty string when `oci` is not in `$PATH`. Inside the dpackager container, the OCI CLI is installed at `$HOME/bin/oci` (matching how `setup_oci_image_capability_schema.sh` finds it).

Fix: use `$HOME/bin/oci` as the fallback path.

### Testing
- [x] https://jenkins.scylladb.com/job/releng-testing/job/next-machine-image/112/

Fixes: https://scylladb.atlassian.net/browse/RELENG-565