### PR TITLE
packer: replace Azure rootdelay with rootwait

### DIFF
--- a/packer/scylla_install_image
+++ b/packer/scylla_install_image
@@ -262,7 +262,8 @@ if __name__ == "__main__":
         with open("/etc/default/instance_configs.cfg", "w") as f:
             f.write(instance_configs)
     elif args.target_cloud == "azure":
-        kernel_opt = " rootdelay=300"
+        # mount root as soon as it appears, bounded by 30s
+        kernel_opt = " rootwait=30"
         grub_variable = "GRUB_CMDLINE_LINUX"
         run("systemctl mask walinuxagent", shell=True, check=True)
     elif args.target_cloud == "oci":


### PR DESCRIPTION
The Azure image has `rootdelay=300` parameter on the kernel command line, which forces the unconditional 5-minute kernel sleep before mounting root on every Azure boot (even though the OS/NVMe disk is ready within seconds).

The change improves this by switching to rootwait, which mounts root as soon as it appears, bounded by 30s max timeout value.

## Testing:
- :green_circle: [releng-testing/next-machine-image run for azure](https://jenkins.scylladb.com/view/releng-testing/job/releng-testing/job/next-machine-image/114/)
- created a VM from the image built with this change. With it the root was mounted at 1.68s:
```
[    1.684774] EXT4-fs (sda1): mounted filesystem ... ro
```
as opposed to previous behaviour, e.g. from the original issue logs the mounting is only happening after unconditional rootdelay is expired:
```
[  333.585245] md: Waiting for all devices...  ← rootdelay expired, finally mounting
```

- Also executed locally `LISA` (open-source Linux image validation tool by Microsoft) as the `Azure Marketplace Self-Test API` used in https://github.com/scylladb/scylla-machine-image/pull/433 (where rootdelay was introduced)  is no longer available. Its endpoint (isvapp.azurewebsites.net) now returns HTTP 403 `This web app is stopped`.
Seems like Microsoft retired `Azure Marketplace Self-Test API` it and replaced it with `AITL` (Azure Image Testing for Linux) and LISA uses under the hood the same test engine as AITL.

The result was:
9 passed, 16 skipped (those need the access to Azure so LISA deploys the VM itself, and we were running it against already booted VM), and 1 failed on an Ubuntu warning (something pre-existing and unrelated, about regulatory.db firmware not found) .

Fixes: SMI-284