### PR TITLE
packer: pin and verify yq and syft downloads (supply-chain hardening)

### DIFF
--- a/packer/scylla.json
+++ b/packer/scylla.json
@@ -251,10 +251,15 @@
     },
     {
       "inline": [
-        "curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sudo sh -s -- -b /usr/local/bin",
+        "SYFT_VERSION=1.45.0",
+        "case \"$(uname -m)\" in x86_64) SYFT_ARCH=amd64; SYFT_SHA256=cd5efa489e93ecde99c03a218db5dee8b3f03610466d7565cefd735610d1b28b;; aarch64) SYFT_ARCH=arm64; SYFT_SHA256=3101fc588a6662ab3d46eda470159f82d6c6c0fd59f618fdd29928ed1c1197bb;; *) echo \"unsupported arch: $(uname -m)\" >&2; exit 1;; esac",
+        "curl -fL --retry 5 --retry-delay 2 -o /tmp/syft.tar.gz \"https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/syft_${SYFT_VERSION}_linux_${SYFT_ARCH}.tar.gz\"",
+        "echo \"${SYFT_SHA256}  /tmp/syft.tar.gz\" | sha256sum -c -",
+        "sudo tar -xzf /tmp/syft.tar.gz -C /usr/local/bin syft",
+        "sudo chmod +x /usr/local/bin/syft",
         "sudo syft -o cyclonedx-json@1.4 / > /tmp/sbom_report.json",
         "python3 -c 'import json; d=json.load(open(\"/tmp/sbom_report.json\")); d[\"components\"]=[c for c in d[\"components\"] if c.get(\"type\")!=\"file\"]; json.dump(d, open(\"/tmp/ami_sbom_report_{{user `scylla_version`}}_{{user `arch`}}.json\", \"w\"), indent=2)'",
-        "sudo rm -f /usr/local/bin/syft /tmp/sbom_report.json"
+        "sudo rm -f /usr/local/bin/syft /tmp/sbom_report.json /tmp/syft.tar.gz"
       ],
       "only": ["aws"],
       "type": "shell"

--- a/packer/scylla_install_image
+++ b/packer/scylla_install_image
@@ -7,6 +7,7 @@
 import argparse
 import contextlib
 import glob
+import hashlib
 import os
 import platform
 import re
@@ -24,6 +25,15 @@ import yaml
 my_env = os.environ.copy()
 my_env["DEBIAN_FRONTEND"] = "noninteractive"
 apt_keys_dir = "/etc/apt/keyrings"
+
+# Pin yq to a fixed version and verify its SHA-256 to protect against
+# supply-chain attacks. Bump YQ_VERSION together with the matching hashes
+# from the release "checksums" file (the SHA-256 column).
+YQ_VERSION = "4.53.2"
+YQ_SHA256 = {
+    "amd64": "d56bf5c6819e8e696340c312bd70f849dc1678a7cda9c2ad63eebd906371d56b",
+    "arm64": "03061b2a50c7a498de2bbb92d7cb078ce433011f085a4994117c2726be4106ea",
+}
 
 
 def _wait_for_apt_lock(timeout=300, interval=10):
@@ -63,6 +73,38 @@ def arch():
 def deb_arch():
     darch = {"x86_64": "amd64", "aarch64": "arm64"}
     return darch[arch()]
+
+
+def install_yq():
+    """Download a pinned yq release and verify its SHA-256 before installing."""
+    yq_arch = deb_arch()
+    # Defensive: guards against a new arch being added to deb_arch() without a
+    # corresponding pinned hash here.
+    expected = YQ_SHA256.get(yq_arch)
+    if expected is None:
+        print(f"no pinned yq SHA-256 for architecture {yq_arch!r}", file=sys.stderr)
+        sys.exit(1)
+    url = f"https://github.com/mikefarah/yq/releases/download/v{YQ_VERSION}/yq_linux_{yq_arch}"
+    dest = "/usr/local/bin/yq"
+    # Download into the destination directory so the final move is an atomic,
+    # same-filesystem rename rather than a cross-filesystem copy.
+    with tempfile.NamedTemporaryFile(dir=os.path.dirname(dest), delete=False) as tmp:
+        tmp_path = tmp.name
+    try:
+        run(["curl", "-fL", "--retry", "5", "--retry-delay", "2", "-o", tmp_path, url], check=True)
+        with open(tmp_path, "rb") as f:
+            actual = hashlib.file_digest(f, "sha256").hexdigest()
+        if actual.lower() != expected.lower():
+            print(
+                f"yq checksum mismatch for {yq_arch}: expected {expected}, got {actual}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        os.chmod(tmp_path, 0o755)
+        os.replace(tmp_path, dest)
+    finally:
+        with contextlib.suppress(FileNotFoundError):
+            os.remove(tmp_path)
 
 
 def get_chrony_sources(target_cloud: str) -> str:
@@ -225,11 +267,7 @@ if __name__ == "__main__":
         shell=True,
         check=False,
     )
-    run(
-        f"curl -L -o /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_{deb_arch()} && chmod +x /usr/local/bin/yq",
-        shell=True,
-        check=True,
-    )
+    install_yq()
     os.remove("/etc/apt/sources.list.d/scylla_install.list")
     if args.repo_for_update:
         run(f"curl -L -o /etc/apt/sources.list.d/scylla.list {args.repo_for_update}", shell=True, check=True)


### PR DESCRIPTION
## Problem

The image build downloaded two third-party binaries with no version pinning and no integrity verification, leaving the build open to supply-chain attacks:

- **yq** (`packer/scylla_install_image`): fetched from the `latest` release with no checksum check.
- **syft** (`packer/scylla.json`): installed by piping an unpinned `install.sh` from the `main` branch straight into a root shell — arbitrary remote code, not just an unverified binary. Used to generate the AWS SBOM, then removed.

## Fix (2 commits)

**1. Pin & verify yq** — pinned to `v4.53.2`; a new `install_yq()` helper downloads the per-arch binary, verifies its SHA-256 (from the release `checksums` file, SHA-256 column) and fails the build on mismatch. Uses a streamed digest, an argument-list `curl` (no shell), and an atomic same-filesystem `os.replace`.

**2. Pin & verify syft** — pinned to `v1.45.0`; downloads the release tarball, verifies its per-arch SHA-256 with `sha256sum -c -` (fail-closed under Packer's default `/bin/sh -e`) before extracting and running. No more `curl | sh`.

Both pinned versions equal the current `latest`, so there is no behavioral change today — only fail-closed integrity verification. Future upgrades become a deliberate version + hash bump.

## Notes
- yq SHA-256: `amd64 d56bf5c6…1d56b`, `arm64 03061b2a…06ea`
- syft SHA-256: `amd64 cd5efa48…1b28b`, `arm64 3101fc58…97bb`
- yq's `checksums` file is multi-column/multi-algorithm; hashes were taken from the SHA-256 column (#18 per `checksums_hashes_order`) to avoid the common mistake of grabbing CRC32/MD5.
