### PR TITLE
common/azure: fix wrong IOPS for 5 Azure instance sizes

### DIFF
--- a/common/azure_io_params.yaml
+++ b/common/azure_io_params.yaml
@@ -36,10 +36,10 @@ Standard_L4s_v4:
     write_bandwidth: 749365312
 Standard_L8aos_v4:
   disks:
-  - read_iops: 162204
-    read_bandwidth: 4401689600
-    write_iops: 62388
-    write_bandwidth: 2061798528
+  - read_iops: 718283
+    read_bandwidth: 4392082432
+    write_iops: 287006
+    write_bandwidth: 1985829120
 Standard_L8as_v3:
   disks:
   - read_iops: 620172
@@ -54,10 +54,10 @@ Standard_L8as_v4:
     write_bandwidth: 1499555072
 Standard_L8s_v3:
   disks:
-  - read_iops: 14245
-    read_bandwidth: 3734856960
-    write_iops: 10017
-    write_bandwidth: 2612137984
+  - read_iops: 894399
+    read_bandwidth: 3740749056
+    write_iops: 607182
+    write_bandwidth: 2494925312
 Standard_L8s_v4:
   disks:
   - read_iops: 549031
@@ -90,10 +90,10 @@ Standard_L16as_v4:
     write_bandwidth: 3000305920
 Standard_L16s_v3:
   disks:
-  - read_iops: 28489
-    read_bandwidth: 7467323392
-    write_iops: 20005
-    write_bandwidth: 5135863296
+  - read_iops: 1376027
+    read_bandwidth: 7458523648
+    write_iops: 891599
+    write_bandwidth: 3713746176
 Standard_L16s_v4:
   disks:
   - read_iops: 1098789
@@ -138,10 +138,10 @@ Standard_L48as_v4:
     write_bandwidth: 9004469248
 Standard_L48s_v3:
   disks:
-  - read_iops: 85440
-    read_bandwidth: 22391074816
-    write_iops: 59385
-    write_bandwidth: 15443830784
+  - read_iops: 5344012
+    read_bandwidth: 22344859648
+    write_iops: 3523259
+    write_bandwidth: 14548556800
 Standard_L48s_v4:
   disks:
   - read_iops: 3280604
@@ -156,10 +156,10 @@ Standard_L64as_v3:
     write_bandwidth: 19616075776
 Standard_L64as_v4:
   disks:
-  - read_iops: 1115399
-    read_bandwidth: 23921129472
-    write_iops: 1759073
-    write_bandwidth: 12010074112
+  - read_iops: 4403160
+    read_bandwidth: 23945021440
+    write_iops: 1740036
+    write_bandwidth: 10790373376
 Standard_L64s_v3:
   disks:
   - read_iops: 5506751


### PR DESCRIPTION
## What

read/write IOPS for `L8s_v3`, `L16s_v3`, `L48s_v3`, `L8aos_v4` and read IOPS for `L64as_v4` were measured with a wrong block size, yielding values ~40x too low (256 KB block artifact for the `*s_v3` trio) or otherwise inconsistent with sibling SKUs. Bandwidth columns were correct.

Re-benchmarked the affected SKUs and replaced the IOPS values (plus `L16s_v3` write_bandwidth, which was also off) with the measured numbers.

## Verification

Post-fix sanity vs sibling SKUs:
- L8s_v3 read 894k vs L8as_v3 620k / L8s_v4 549k ✓
- L16s_v3 1.38M vs L16s_v4 1.10M ✓
- L48s_v3 5.34M vs L48s_v4 3.28M ✓
- L8aos_v4 718k vs L8as_v4 549k, now > L2aos_v4 ✓
- L64as_v4 4.40M vs L64s_v4 4.40M ✓

All benchmark deviations now green except IOPS (expected — that's what we fixed).

fixes SMI-237