### PR TITLE
packer: import tempfile and contextlib in scylla_install_image

### DIFF
--- a/packer/scylla_install_image
+++ b/packer/scylla_install_image
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse
+import contextlib
 import glob
 import hashlib
 import os
@@ -12,6 +13,7 @@ import platform
 import re
 import shutil
 import sys
+import tempfile
 import time
 from subprocess import run
 from textwrap import dedent


### PR DESCRIPTION
The image build fails on branch-2026.2 with:

    File "/tmp/scylla_install_image", line 90, in install_yq
        with tempfile.NamedTemporaryFile(...) as tmp:
    NameError: name 'tempfile' is not defined

install_yq() uses tempfile.NamedTemporaryFile and contextlib.suppress, but neither module is imported on this branch, so the provisioning script aborts and every image build (AMI/GCE/Azure/OCI) fails.

This is a backport regression. install_yq() was introduced by the cherry-pick 7c6d8bf (PR #962). On master it works only because tempfile and contextlib were already imported by earlier, unrelated commits that were not backported to branch-2026.2.

Fix by adding the two missing imports directly, keeping install_yq() self-contained rather than pulling in the unrelated feature commits.

### Verification ### 
- [X] https://jenkins.scylladb.com/job/scylla-2026.2/job/next-machine-image/14/ - it failed on push cause it run from my branch