### PR TITLE
packer: tolerate cloud-init recoverable errors (exit 2) in Azure build

### DIFF
--- a/packer/scylla.json
+++ b/packer/scylla.json
@@ -238,7 +238,7 @@
     },
     {
       "inline": [
-        "sudo /usr/bin/cloud-init status --wait",
+        "cloudinit_status=0; sudo /usr/bin/cloud-init status --wait || cloudinit_status=$?; if [ \"$cloudinit_status\" -eq 1 ]; then echo 'cloud-init failed (exit 1)' >&2; exit 1; elif [ \"$cloudinit_status\" -eq 2 ]; then echo 'WARNING: cloud-init finished with recoverable errors (exit 2); continuing'; fi",
         "sudo /tmp/scylla_install_image --target-cloud {{build_name}} --scylla-version {{user `scylla_full_version`}} {{user `install_args`}}"
       ],
       "type": "shell"


### PR DESCRIPTION
## Problem

The first inline provisioner in the Azure image build runs:

```sh
sudo /usr/bin/cloud-init status --wait
```

Per the [cloud-init docs](https://docs.cloud-init.io/en/latest/reference/cli.html#status), `cloud-init status` exits:

- `0` — boot finished cleanly
- `1` — cloud-init crashed (a real failure)
- `2` — boot finished but hit **recoverable errors** (a degraded-but-fine state)

Packer's default inline shebang is `/bin/sh -e`, so a `cloud-init status --wait` return of **`2`** aborted the provisioner immediately — before `scylla_install_image` even ran — failing the whole Azure build with `Script exited with non-zero exit status: 2`. Because the degraded boot state is transient, this produced **intermittent** Azure build failures with no useful output (`SMI-278`).

This was misdiagnosed previously as a `scylla_install_image` failure; in reality the script never ran (no apt output appears), and it has no exit-2 path. The failing command is the cloud-init check that runs first.

### Seen in

- https://jenkins.scylladb.com/job/scylla-2026.2/job/next-machine-image/19/ 
- https://jenkins.scylladb.com/job/scylla-master/job/next-machine-image/832/ (master)

## Fix

Capture the exit code and branch on it instead of letting `set -e` treat every non-zero as fatal: `1` fails the build, `2` logs a warning and continues, `0` continues normally. The warning line makes the intermittent path observable in CI logs.

## Verification

Ran the `next-machine-image` job (releng-testing) with `BUILD_AZURE` + `RUN_AZURE_TEST` only (other clouds/tests disabled), against this fork's branches.

| Build | Branch | RELENG | Build & Test Azure Result |
|---|---|---|---|
| [#119](https://jenkins.scylladb.com/job/releng-testing/job/next-machine-image/119/) | `fix-azure-cloudinit-exit2-next` | `next` | **SUCCESS** |
| [#117](https://jenkins.scylladb.com/job/releng-testing/job/next-machine-image/117/) | `fix-azure-cloudinit-exit2-next` | `next` | **SUCCESS** |
| [#118](https://jenkins.scylladb.com/job/releng-testing/job/next-machine-image/118/) | `fix-azure-cloudinit-exit2-2026.2` (backport) | `next-2026.2` | **SUCCESS** |

**Key evidence — the fix works on the real failure path.** Build #116 actually hit the intermittent degraded boot, and the fix let it continue past the exit-2 that previously broke the build:

```
==> azure-arm.azure: WARNING: cloud-init finished with recoverable errors (exit 2); continuing
```

Fixes: SMI-278
