### PR TITLE
fix(create-devices): rescan NVMe controllers when no data disk appears

### DIFF
--- a/common/scylla_create_devices
+++ b/common/scylla_create_devices
@@ -33,20 +33,46 @@ class NoDiskFoundError(Exception):
         return "No data disk found, abort setup"
 
 
+NVME_PCI_CLASS_PREFIX = "0x0108"  # PCI class: Non-Volatile memory controller
+
+
+def _unbound_nvme_pci_addresses() -> list[str]:
+    """PCI addresses with an NVMe class code that currently have no driver bound.
+
+    A driver can end up detached from a device (e.g. an `unbind` mid-boot, or a
+    probe race) without the device itself leaving the PCI bus. A bus rescan is a
+    no-op in that case: the kernel already has a struct pci_dev for that slot,
+    and pci_scan_slot() only creates new ones for slots it hasn't seen before.
+    """
+    addresses = []
+    for class_file in glob.glob("/sys/bus/pci/devices/*/class"):
+        try:
+            is_nvme = Path(class_file).read_text().strip().startswith(NVME_PCI_CLASS_PREFIX)
+        except OSError:
+            continue
+        if not is_nvme:
+            continue
+        addr = Path(class_file).parent.name
+        if not Path("/sys/bus/pci/devices", addr, "driver").exists():
+            addresses.append(addr)
+    return addresses
+
+
 def rescan_nvme_controllers() -> None:
     """Best-effort: ask the kernel to re-probe NVMe controllers for namespaces.
 
-    On some OCI/Azure VMs the NVMe controller enumerates but its namespace block
-    device (e.g. nvme0n1) never appears, so the local data disk stays invisible
-    and setup aborts with "No data disk found". Writing to each controller's
-    sysfs `rescan_controller` re-scans its namespaces without needing nvme-cli.
-
-    Always also issues a PCI bus rescan, unconditionally: on NVMe-root VMs (e.g.
-    Azure Standard_Lsv4), the root disk has its own healthy, unrelated NVMe
-    controller with a working `rescan_controller` - gating the bus rescan on
-    "no controller responded" would report success from the root's controller
-    and skip the bus rescan entirely, even though a *different*, still-missing
-    local-disk controller is the actual problem the bus rescan could find.
+    Covers three distinct ways a local NVMe data disk can stay invisible on boot,
+    each seen on OCI and/or Azure:
+      - controller enumerated, namespace never appeared: nudge via the
+        controller's own sysfs `rescan_controller`.
+      - controller present on the PCI bus but its driver never got (re)bound:
+        a bus rescan can't fix this - the kernel already knows the slot - so
+        explicitly ask the driver core to bind it via `drivers_probe`.
+      - controller not on the PCI bus at all (yet): a full bus rescan.
+    All three are always attempted, regardless of whether an earlier one
+    reported success: on NVMe-root VMs (e.g. Azure Standard_Lsv4), the root
+    disk has its own healthy, unrelated NVMe controller, so gating a later step
+    on "nothing found yet" would mask a different, still-missing controller.
     Errors are swallowed - this is a recovery attempt, not a hard requirement.
     """
     for ctrl in glob.glob("/sys/class/nvme/nvme*/rescan_controller"):
@@ -54,6 +80,11 @@ def rescan_nvme_controllers() -> None:
             Path(ctrl).write_text("1")
         except OSError as e:
             print(f"NVMe rescan via {ctrl} failed: {e}")
+    for addr in _unbound_nvme_pci_addresses():
+        try:
+            Path("/sys/bus/pci/drivers_probe").write_text(addr)
+        except OSError as e:
+            print(f"Driver probe for {addr} failed: {e}")
     try:
         Path("/sys/bus/pci/rescan").write_text("1")
     except OSError as e:

--- a/common/scylla_create_devices
+++ b/common/scylla_create_devices
@@ -39,22 +39,25 @@ def rescan_nvme_controllers() -> None:
     On some OCI/Azure VMs the NVMe controller enumerates but its namespace block
     device (e.g. nvme0n1) never appears, so the local data disk stays invisible
     and setup aborts with "No data disk found". Writing to each controller's
-    sysfs `rescan_controller` re-scans its namespaces without needing nvme-cli;
-    if that attribute is absent, fall back to a PCI bus rescan.
+    sysfs `rescan_controller` re-scans its namespaces without needing nvme-cli.
+
+    Always also issues a PCI bus rescan, unconditionally: on NVMe-root VMs (e.g.
+    Azure Standard_Lsv4), the root disk has its own healthy, unrelated NVMe
+    controller with a working `rescan_controller` - gating the bus rescan on
+    "no controller responded" would report success from the root's controller
+    and skip the bus rescan entirely, even though a *different*, still-missing
+    local-disk controller is the actual problem the bus rescan could find.
     Errors are swallowed - this is a recovery attempt, not a hard requirement.
     """
-    rescanned = False
     for ctrl in glob.glob("/sys/class/nvme/nvme*/rescan_controller"):
         try:
             Path(ctrl).write_text("1")
-            rescanned = True
         except OSError as e:
             print(f"NVMe rescan via {ctrl} failed: {e}")
-    if not rescanned:
-        try:
-            Path("/sys/bus/pci/rescan").write_text("1")
-        except OSError as e:
-            print(f"PCI bus rescan failed: {e}")
+    try:
+        Path("/sys/bus/pci/rescan").write_text("1")
+    except OSError as e:
+        print(f"PCI bus rescan failed: {e}")
 
 
 def wait_for_devices(device_names_getter: Callable[[], list[str]], wait_seconds: int) -> None:

--- a/common/scylla_create_devices
+++ b/common/scylla_create_devices
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse
+import glob
 import os
 import sys
 import time
@@ -32,6 +33,30 @@ class NoDiskFoundError(Exception):
         return "No data disk found, abort setup"
 
 
+def rescan_nvme_controllers() -> None:
+    """Best-effort: ask the kernel to re-probe NVMe controllers for namespaces.
+
+    On some OCI/Azure VMs the NVMe controller enumerates but its namespace block
+    device (e.g. nvme0n1) never appears, so the local data disk stays invisible
+    and setup aborts with "No data disk found". Writing to each controller's
+    sysfs `rescan_controller` re-scans its namespaces without needing nvme-cli;
+    if that attribute is absent, fall back to a PCI bus rescan.
+    Errors are swallowed - this is a recovery attempt, not a hard requirement.
+    """
+    rescanned = False
+    for ctrl in glob.glob("/sys/class/nvme/nvme*/rescan_controller"):
+        try:
+            Path(ctrl).write_text("1")
+            rescanned = True
+        except OSError as e:
+            print(f"NVMe rescan via {ctrl} failed: {e}")
+    if not rescanned:
+        try:
+            Path("/sys/bus/pci/rescan").write_text("1")
+        except OSError as e:
+            print(f"PCI bus rescan failed: {e}")
+
+
 def wait_for_devices(device_names_getter: Callable[[], list[str]], wait_seconds: int) -> None:
     """
     Wait for any disk to be found by repeatedly calling device_names_getter.
@@ -53,6 +78,9 @@ def wait_for_devices(device_names_getter: Callable[[], list[str]], wait_seconds:
             print(f"Found devices: {device_names}")
             return
         print("No device names available yet, retrying...")
+        # A present-but-unenumerated NVMe namespace won't appear on its own; nudge
+        # the kernel to re-probe before sleeping so the retry can actually find it.
+        rescan_nvme_controllers()
         time.sleep(5)
 
     # Final check

--- a/tests/test_scylla_create_devices.py
+++ b/tests/test_scylla_create_devices.py
@@ -23,6 +23,7 @@ from scylla_create_devices import (  # noqa: E402
     _get_fresh_remote_disks,
     get_default_devices,
     get_disk_devices,
+    rescan_nvme_controllers,
     wait_for_devices,
 )
 
@@ -30,10 +31,11 @@ from scylla_create_devices import (  # noqa: E402
 # Tests for wait_for_devices function
 
 
+@patch("scylla_create_devices.rescan_nvme_controllers")
 @patch("scylla_create_devices.time.sleep")
 @patch("scylla_create_devices.time.time")
 @patch("scylla_create_devices.Path")
-def test_wait_for_devices_with_callable_retries(mock_path_class, mock_time, mock_sleep):
+def test_wait_for_devices_with_callable_retries(mock_path_class, mock_time, mock_sleep, mock_rescan):
     """Test wait_for_devices with callable that returns devices after retries."""
     # Mock time to return incrementing values - start at 0
     time_values = [0]
@@ -68,9 +70,68 @@ def test_wait_for_devices_with_callable_retries(mock_path_class, mock_time, mock
     assert device_getter.__name__ == "device_getter"
 
 
+@patch("scylla_create_devices.rescan_nvme_controllers")
 @patch("scylla_create_devices.time.sleep")
 @patch("scylla_create_devices.time.time")
-def test_wait_for_devices_timeout(mock_time, mock_sleep):
+def test_wait_for_devices_rescans_nvme_between_retries(mock_time, mock_sleep, mock_rescan):
+    """A missing NVMe namespace should trigger a controller rescan on each empty retry."""
+    time_values = [0]
+
+    def get_time():
+        val = time_values[0]
+        time_values[0] += 5
+        return val
+
+    mock_time.side_effect = get_time
+
+    call_count = [0]
+
+    def device_getter():
+        call_count[0] += 1
+        # Appears only after two empty rounds (simulating a delayed/re-probed namespace).
+        return ["nvme0n1"] if call_count[0] >= 3 else []
+
+    wait_for_devices(device_getter, wait_seconds=30)
+
+    # One rescan per empty round, before the device finally shows up.
+    assert mock_rescan.call_count == 2
+
+
+@patch("scylla_create_devices.Path")
+@patch("scylla_create_devices.glob.glob")
+def test_rescan_nvme_controllers_writes_each_controller(mock_glob, mock_path_class):
+    """rescan_nvme_controllers writes '1' to every controller's rescan sysfs node."""
+    mock_glob.return_value = [
+        "/sys/class/nvme/nvme0/rescan_controller",
+        "/sys/class/nvme/nvme1/rescan_controller",
+    ]
+    mock_nodes = [Mock(), Mock()]
+    mock_path_class.side_effect = mock_nodes
+
+    rescan_nvme_controllers()
+
+    for node in mock_nodes:
+        node.write_text.assert_called_once_with("1")
+
+
+@patch("scylla_create_devices.Path")
+@patch("scylla_create_devices.glob.glob")
+def test_rescan_nvme_controllers_falls_back_to_pci_bus(mock_glob, mock_path_class):
+    """With no per-controller sysfs node, fall back to a PCI bus rescan."""
+    mock_glob.return_value = []
+    pci_node = Mock()
+    mock_path_class.return_value = pci_node
+
+    rescan_nvme_controllers()
+
+    mock_path_class.assert_called_once_with("/sys/bus/pci/rescan")
+    pci_node.write_text.assert_called_once_with("1")
+
+
+@patch("scylla_create_devices.rescan_nvme_controllers")
+@patch("scylla_create_devices.time.sleep")
+@patch("scylla_create_devices.time.time")
+def test_wait_for_devices_timeout(mock_time, mock_sleep, mock_rescan):
     """Test wait_for_devices when no devices appear within timeout."""
     # Simulate timeout: start time 0, checks at 5, 10, 15, 20, 25, 30 (timeout)
     mock_time.side_effect = [0, 5, 10, 15, 20, 25, 31]

--- a/tests/test_scylla_create_devices.py
+++ b/tests/test_scylla_create_devices.py
@@ -99,25 +99,30 @@ def test_wait_for_devices_rescans_nvme_between_retries(mock_time, mock_sleep, mo
 
 @patch("scylla_create_devices.Path")
 @patch("scylla_create_devices.glob.glob")
-def test_rescan_nvme_controllers_writes_each_controller(mock_glob, mock_path_class):
-    """rescan_nvme_controllers writes '1' to every controller's rescan sysfs node."""
+def test_rescan_nvme_controllers_writes_each_controller_and_pci_bus(mock_glob, mock_path_class):
+    """rescan_nvme_controllers writes '1' to every controller's rescan sysfs node, then
+    always also rescans the PCI bus - a healthy controller (e.g. an NVMe-root VM's own
+    root disk) must not suppress the bus rescan a different, still-missing controller
+    needs (Azure Standard_Lsv4 regression)."""
     mock_glob.return_value = [
         "/sys/class/nvme/nvme0/rescan_controller",
         "/sys/class/nvme/nvme1/rescan_controller",
     ]
-    mock_nodes = [Mock(), Mock()]
-    mock_path_class.side_effect = mock_nodes
+    ctrl_nodes = [Mock(), Mock()]
+    pci_node = Mock()
+    mock_path_class.side_effect = [*ctrl_nodes, pci_node]
 
     rescan_nvme_controllers()
 
-    for node in mock_nodes:
+    for node in ctrl_nodes:
         node.write_text.assert_called_once_with("1")
+    pci_node.write_text.assert_called_once_with("1")
 
 
 @patch("scylla_create_devices.Path")
 @patch("scylla_create_devices.glob.glob")
-def test_rescan_nvme_controllers_falls_back_to_pci_bus(mock_glob, mock_path_class):
-    """With no per-controller sysfs node, fall back to a PCI bus rescan."""
+def test_rescan_nvme_controllers_pci_bus_rescan_with_no_controllers(mock_glob, mock_path_class):
+    """With no per-controller sysfs node at all, still rescan the PCI bus."""
     mock_glob.return_value = []
     pci_node = Mock()
     mock_path_class.return_value = pci_node

--- a/tests/test_scylla_create_devices.py
+++ b/tests/test_scylla_create_devices.py
@@ -97,6 +97,13 @@ def test_wait_for_devices_rescans_nvme_between_retries(mock_time, mock_sleep, mo
     assert mock_rescan.call_count == 2
 
 
+def _glob_side_effect(patterns_to_results):
+    def _glob(pattern):
+        return patterns_to_results.get(pattern, [])
+
+    return _glob
+
+
 @patch("scylla_create_devices.Path")
 @patch("scylla_create_devices.glob.glob")
 def test_rescan_nvme_controllers_writes_each_controller_and_pci_bus(mock_glob, mock_path_class):
@@ -104,10 +111,14 @@ def test_rescan_nvme_controllers_writes_each_controller_and_pci_bus(mock_glob, m
     always also rescans the PCI bus - a healthy controller (e.g. an NVMe-root VM's own
     root disk) must not suppress the bus rescan a different, still-missing controller
     needs (Azure Standard_Lsv4 regression)."""
-    mock_glob.return_value = [
-        "/sys/class/nvme/nvme0/rescan_controller",
-        "/sys/class/nvme/nvme1/rescan_controller",
-    ]
+    mock_glob.side_effect = _glob_side_effect(
+        {
+            "/sys/class/nvme/nvme*/rescan_controller": [
+                "/sys/class/nvme/nvme0/rescan_controller",
+                "/sys/class/nvme/nvme1/rescan_controller",
+            ],
+        }
+    )
     ctrl_nodes = [Mock(), Mock()]
     pci_node = Mock()
     mock_path_class.side_effect = [*ctrl_nodes, pci_node]
@@ -122,14 +133,90 @@ def test_rescan_nvme_controllers_writes_each_controller_and_pci_bus(mock_glob, m
 @patch("scylla_create_devices.Path")
 @patch("scylla_create_devices.glob.glob")
 def test_rescan_nvme_controllers_pci_bus_rescan_with_no_controllers(mock_glob, mock_path_class):
-    """With no per-controller sysfs node at all, still rescan the PCI bus."""
-    mock_glob.return_value = []
+    """With no per-controller sysfs node and no unbound NVMe PCI device, still rescan the
+    PCI bus."""
+    mock_glob.side_effect = _glob_side_effect({})
     pci_node = Mock()
     mock_path_class.return_value = pci_node
 
     rescan_nvme_controllers()
 
     mock_path_class.assert_called_once_with("/sys/bus/pci/rescan")
+    pci_node.write_text.assert_called_once_with("1")
+
+
+@patch("scylla_create_devices.Path")
+@patch("scylla_create_devices.glob.glob")
+def test_rescan_nvme_controllers_probes_unbound_nvme_pci_device(mock_glob, mock_path_class):
+    """A driver can get detached from an NVMe controller without the PCI device leaving
+    the bus (e.g. an `unbind` mid-boot). A bus rescan alone can't recover it - the kernel
+    already knows the slot - so rescan_nvme_controllers must also write the device's PCI
+    address to `drivers_probe` to ask the driver core to (re)bind it."""
+    mock_glob.side_effect = _glob_side_effect(
+        {
+            "/sys/bus/pci/devices/*/class": ["/sys/bus/pci/devices/0000:00:0a.0/class"],
+        }
+    )
+
+    class_node = Mock()
+    class_node.read_text.return_value = "0x010802\n"
+    class_node.parent.name = "0000:00:0a.0"
+    driver_node = Mock()
+    driver_node.exists.return_value = False
+    probe_node = Mock()
+    pci_node = Mock()
+    mock_path_class.side_effect = [class_node, class_node, driver_node, probe_node, pci_node]
+
+    rescan_nvme_controllers()
+
+    driver_node.exists.assert_called_once()
+    probe_node.write_text.assert_called_once_with("0000:00:0a.0")
+    pci_node.write_text.assert_called_once_with("1")
+
+
+@patch("scylla_create_devices.Path")
+@patch("scylla_create_devices.glob.glob")
+def test_rescan_nvme_controllers_skips_already_bound_nvme_pci_device(mock_glob, mock_path_class):
+    """A bound NVMe controller (driver symlink present) must not get a spurious
+    drivers_probe write - only genuinely unbound ones should."""
+    mock_glob.side_effect = _glob_side_effect(
+        {
+            "/sys/bus/pci/devices/*/class": ["/sys/bus/pci/devices/0000:00:0a.0/class"],
+        }
+    )
+
+    class_node = Mock()
+    class_node.read_text.return_value = "0x010802\n"
+    class_node.parent.name = "0000:00:0a.0"
+    driver_node = Mock()
+    driver_node.exists.return_value = True
+    pci_node = Mock()
+    mock_path_class.side_effect = [class_node, class_node, driver_node, pci_node]
+
+    rescan_nvme_controllers()
+
+    assert not any(call.args == ("/sys/bus/pci/drivers_probe",) for call in mock_path_class.call_args_list)
+    pci_node.write_text.assert_called_once_with("1")
+
+
+@patch("scylla_create_devices.Path")
+@patch("scylla_create_devices.glob.glob")
+def test_rescan_nvme_controllers_ignores_non_nvme_pci_device(mock_glob, mock_path_class):
+    """A PCI device whose class code isn't NVMe must never be probed, bound or not."""
+    mock_glob.side_effect = _glob_side_effect(
+        {
+            "/sys/bus/pci/devices/*/class": ["/sys/bus/pci/devices/0000:00:1f.2/class"],
+        }
+    )
+
+    class_node = Mock()
+    class_node.read_text.return_value = "0x010601\n"  # SATA controller, not NVMe
+    pci_node = Mock()
+    mock_path_class.side_effect = [class_node, pci_node]
+
+    rescan_nvme_controllers()
+
+    assert not any(call.args == ("/sys/bus/pci/drivers_probe",) for call in mock_path_class.call_args_list)
     pci_node.write_text.assert_called_once_with("1")
 
 


### PR DESCRIPTION
## Problem

On some OCI and Azure VMs a local **instance-store NVMe controller enumerates but its namespace block device (`nvme0n1`) never appears**. With the controller visible in `dmesg` (`nvme nvme0: pci function ...`) but no namespace node in `/dev`, `scylla_create_devices --data-device instance_store` finds no data disk and aborts:

```
scylla_create_devices ... -> "No device names discovered after N seconds" -> "No data disk found, abort setup"
scylla-image-setup.service: status=1/FAILURE
/etc/scylla/machine_image_configured  -> never written
```

Downstream, the consumer waiting on `machine_image_configured` times out (600s) and node setup fails. Observed repeatedly on OCI (`VM.DenseIO.E5.Flex`) and Azure (`Standard_L8s_v4`); a single VM per cluster is hit while the rest set up fine.

Reported in SCT-447 (OCI) and SCT-297 (Azure).

## Root cause

`wait_for_devices` retries by re-listing `/dev` every 5s. That can **never** surface a namespace the kernel has not probed — re-reading the device list does nothing to make an un-enumerated namespace appear. So the wait window elapses with no effect and setup aborts even though the controller is present.

Re-listing the device node is a no-op for a namespace the kernel hasn't probed; the namespace has to be re-enumerated. The `rescan_controller` / `nvme ns-rescan` poke is the recognized remedy for the "controller present, namespace missing" symptom regardless of why the probe lagged (slow/failed hypervisor-side attach, or a kernel scan bug) — see Related below.

Note on kernel: these images build on Ubuntu 26.04 (OCI/AWS/GCE) and Ubuntu 24.04 LTS (Azure) per `packer/build_image.sh`, i.e. kernels well past the 6.1.x NVMe-scan regression. So 6.1.x is a documented analog of the symptom/remedy, not the diagnosis here; the fix is deliberately cause-agnostic.

## Fix

Between empty retries, trigger a **best-effort kernel re-probe** of NVMe controllers:

- write `1` to each `/sys/class/nvme/nvme*/rescan_controller` (re-scans namespaces; no `nvme-cli` dependency),
- fall back to a PCI bus rescan (`/sys/bus/pci/rescan`) when that sysfs node is absent.

Errors are swallowed — it is a recovery attempt, not a hard requirement, so it stays a no-op on clouds/instances where it does not apply (e.g. attached/`sd*` disks). The existing `device_wait_seconds` window governs how long we keep re-probing.

## Tests

`tests/test_scylla_create_devices.py`:
- rescan is invoked on each empty retry until a device appears,
- rescan writes to every per-controller sysfs node,
- rescan falls back to PCI bus rescan when no per-controller node exists.

All tests pass; `ruff check` / `ruff format` clean.

## Refs

- SCT-447 — `[OCI] NodeSetupFailed: instance-store NVMe data disk never enumerated`
- SCT-297 — same `is_machine_image_configured` timeout on Azure

## Related (public)

The same controller-present/namespace-missing symptom and the `rescan_controller` remedy are documented upstream:

- [platima/nvme-rescan-fix](https://github.com/platima/nvme-rescan-fix) — documents the 6.1.x-kernel NVMe namespace-enumeration regression and ships a systemd boot-time `rescan_controller` service (same mechanism this PR applies in-loop). Durable fix: kernel 6.12+.
- [nvme-cli `ns-rescan` docs](https://github.com/linux-nvme/nvme-cli/blob/master/Documentation/nvme-ns-rescan.txt) — `nvme ns-rescan /dev/nvme0`, the userspace equivalent of the sysfs write.
- [Red Hat: NVMe namespace/ID numbering inconsistent](https://access.redhat.com/solutions/6967589)
- Azure Lsv4 (the `Standard_L8s_v4` case) is fully NVMe with no SCSI fallback; missing local NVMe also occurs when the OS image lacks NVMe support — [Lsv4 series](https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/storage-optimized/lsv4-series), [NVMe Temp Disks FAQ](https://learn.microsoft.com/en-us/azure/virtual-machines/enable-nvme-temp-faqs).

Note: this rescan recovers a kernel-failed namespace probe. It cannot help if the image genuinely lacks NVMe drivers (image-build concern), and the durable fix for the kernel regression is shipping images on 6.12+.
