### PR TITLE
packer: retry AMI build on InsufficientInstanceCapacity

### DIFF
--- a/packer/build_image.sh
+++ b/packer/build_image.sh
@@ -377,31 +377,46 @@ mkdir -p build
 export PACKER_LOG=1
 export PACKER_LOG_PATH
 
-set -x
-/usr/bin/packer ${PACKER_SUB_CMD} \
-  -only="$TARGET" \
-  -var-file="$JSON_FILE" \
-  ${EXTRA_VAR_FILE_ARG:+"$EXTRA_VAR_FILE_ARG"} \
-  -var install_args="$INSTALL_ARGS" \
-  -var ssh_username="$SSH_USERNAME" \
-  -var scylla_full_version="$SCYLLA_FULL_VERSION" \
-  -var scylla_version="$VERSION" \
-  -var scylla_machine_image_version="$SCYLLA_MACHINE_IMAGE_VERSION" \
-  -var scylla_python3_version="$SCYLLA_FULL_VERSION" \
-  -var creation_timestamp="$CREATION_TIMESTAMP" \
-  -var scylla_build_sha_id="$SCYLLA_BUILD_SHA_ID" \
-  -var build_tag="$BUILD_TAG" \
-  -var environment="$ENV_TAG" \
-  -var operating_system="$OPERATING_SYSTEM" \
-  -var branch="$BRANCH" \
-  -var ami_regions="$AMI_REGIONS" \
-  -var arch="$ARCH" \
-  -var product="$PRODUCT" \
-  -var build_mode="$BUILD_MODE" \
-  -var image_name="$IMAGE_NAME" \
-  "${PACKER_ARGS[@]}" \
-  "$DIR"/scylla.json
-set +x
+# Retry the whole build on InsufficientInstanceCapacity: scylla.json
+# subnet_filter uses "random": true, so each attempt re-picks a subnet
+# (and likely a different AZ); other failures exit immediately.
+MAX_ATTEMPTS=3
+RETRY_SLEEP=90
+for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+  : > "$PACKER_LOG_PATH"   # fresh log so the grep below only sees this attempt
+  set -x
+  /usr/bin/packer ${PACKER_SUB_CMD} \
+    -only="$TARGET" \
+    -var-file="$JSON_FILE" \
+    ${EXTRA_VAR_FILE_ARG:+"$EXTRA_VAR_FILE_ARG"} \
+    -var install_args="$INSTALL_ARGS" \
+    -var ssh_username="$SSH_USERNAME" \
+    -var scylla_full_version="$SCYLLA_FULL_VERSION" \
+    -var scylla_version="$VERSION" \
+    -var scylla_machine_image_version="$SCYLLA_MACHINE_IMAGE_VERSION" \
+    -var scylla_python3_version="$SCYLLA_FULL_VERSION" \
+    -var creation_timestamp="$CREATION_TIMESTAMP" \
+    -var scylla_build_sha_id="$SCYLLA_BUILD_SHA_ID" \
+    -var build_tag="$BUILD_TAG" \
+    -var environment="$ENV_TAG" \
+    -var operating_system="$OPERATING_SYSTEM" \
+    -var branch="$BRANCH" \
+    -var ami_regions="$AMI_REGIONS" \
+    -var arch="$ARCH" \
+    -var product="$PRODUCT" \
+    -var build_mode="$BUILD_MODE" \
+    -var image_name="$IMAGE_NAME" \
+    "${PACKER_ARGS[@]}" \
+    "$DIR"/scylla.json && PACKER_STATUS=0 || PACKER_STATUS=$?
+  set +x
+  [ "$PACKER_STATUS" -eq 0 ] && break
+  if [ "$attempt" -lt "$MAX_ATTEMPTS" ] && grep -q "InsufficientInstanceCapacity" "$PACKER_LOG_PATH"; then
+    echo "WARNING: AMI build attempt ${attempt}/${MAX_ATTEMPTS} hit InsufficientInstanceCapacity; retrying in ${RETRY_SLEEP}s with a re-selected subnet/AZ."
+    sleep "$RETRY_SLEEP"
+    continue
+  fi
+  exit "$PACKER_STATUS"   # non-capacity failure, or capacity retries exhausted
+done
 # For some errors packer gives a success status even if fails.
 # Search log for errors
 if $DRY_RUN ; then


### PR DESCRIPTION
The AWS amazon-ebs builder pins a single subnet/AZ up-front (scylla.json subnet_filter selects a random "image-build-subnet*") and has no native cross-AZ fallback. When the chosen AZ is out of capacity for the build instance type, packer fails the whole build with no retry.

Seen in https://jenkins.scylladb.com/job/scylla-2026.1/job/next-machine-image/36/ 
aarch64 (Build AMI), which failed the entire pipeline:

```
  ==> amazon-ebs.aws: Error launching source instance: operation error EC2:
  RunInstances, exceeded maximum number of attempts, 10, https response error
  StatusCode: 500, api error InsufficientInstanceCapacity: We currently do not
  have sufficient i8g.xlarge capacity in the Availability Zone you requested
  (us-east-1c). ... You can currently get i8g.xlarge capacity by not specifying
  an Availability Zone in your request or choosing us-east-1a, us-east-1b,
  us-east-1d.
  Build 'amazon-ebs.aws' errored after 2 minutes 14 seconds: ...
```

Fix: wrap the packer invocation in a retry loop (MAX_ATTEMPTS=3). Because subnet_filter uses "random": true, each attempt re-picks a subnet and thus likely a different AZ. Only InsufficientInstanceCapacity is retried (with a RETRY_SLEEP=90s pause); a successful build breaks out immediately, and any other failure (or exhausted capacity retries) exits at once, preserving packer's exit code. This will allow not to rerun all the job manually again

- [X] verification: https://jenkins.scylladb.com/job/releng-testing/job/next-machine-image/124/