### PR TITLE
fix(oci): fix capability schema setup failing in `us-phoenix-1`

### DIFF
--- a/packer/oci/OCI_BUILD_GUIDE.md
+++ b/packer/oci/OCI_BUILD_GUIDE.md
@@ -90,7 +90,7 @@ The build process can take 20-30 minutes.
 
 After the image is successfully built, the `build_image.sh` script will automatically run the `setup_oci_image_capability_schema.sh` script. This script creates and attaches an Image Capability Schema to the new image, which defines the supported configurations for instances launched from this image (e.g., supported shapes, volume types).
 
-The schema sets `Storage.LocalDataVolumeType` to `NVME` by default.
+The schema intentionally omits `Storage.LocalDataVolumeType` so that OCI does not restrict local volume types. This allows the image to launch on shapes with NVMe local storage (e.g., VM.DenseIO.E5.Flex) without compatibility issues.
 
 ## Using the Image
 

--- a/packer/oci/setup_oci_image_capability_schema.sh
+++ b/packer/oci/setup_oci_image_capability_schema.sh
@@ -182,12 +182,6 @@ if [[ -z "$SCHEMA_FILE" ]]; then
       "source": "IMAGE",
       "defaultValue": "true"
     },
-    "Storage.LocalDataVolumeType": {
-      "descriptorType": "enumstring",
-      "source": "IMAGE",
-      "defaultValue": "NVME",
-      "values": ["NVME", "PARAVIRTUALIZED"]
-    },
     "Storage.RemoteDataVolumeType": {
       "descriptorType": "enumstring",
       "source": "IMAGE",
@@ -254,13 +248,14 @@ if [[ -n "$IMAGE_SCHEMA_ID" ]] && [[ "$IMAGE_SCHEMA_ID" != "null" ]]; then
     print_info "Existing schema name: ${EXISTING_SCHEMA_NAME}"
     print_info "Updating existing schema with current capabilities..."
     
+    update_rc=0
     UPDATE_OUTPUT=$($OCI_CMD compute image-capability-schema update \
         --image-capability-schema-id "${SCHEMA_ID}" \
         --schema-data "$SCHEMA_DATA" \
         --force \
-        2>&1)
+        2>&1) || update_rc=$?
     
-    if [[ $? -eq 0 ]]; then
+    if [[ $update_rc -eq 0 ]]; then
         print_success "Updated Image Capability Schema: ${SCHEMA_ID}"
     else
         print_error "Failed to update Image Capability Schema"
@@ -282,13 +277,14 @@ else
         
         # Update the existing schema with our schema data
         print_info "Updating existing schema with current capabilities..."
+        update_rc2=0
         UPDATE_OUTPUT=$($OCI_CMD compute image-capability-schema update \
             --image-capability-schema-id "${SCHEMA_ID}" \
             --schema-data "$SCHEMA_DATA" \
             --force \
-            2>&1)
+            2>&1) || update_rc2=$?
         
-        if [[ $? -eq 0 ]]; then
+        if [[ $update_rc2 -eq 0 ]]; then
             print_success "Updated Image Capability Schema: ${SCHEMA_ID}"
         else
             print_error "Failed to update Image Capability Schema"
@@ -298,13 +294,14 @@ else
         
         # Attach the schema to the image
         print_info "Attaching schema to image..."
+        attach_rc=0
         IMAGE_UPDATE_OUTPUT=$($OCI_CMD compute image update \
             --image-id "${IMAGE_ID}" \
             --image-capability-schema-id "${SCHEMA_ID}" \
             --force \
-            2>&1)
+            2>&1) || attach_rc=$?
         
-        if [[ $? -ne 0 ]]; then
+        if [[ $attach_rc -ne 0 ]]; then
             print_error "Failed to attach schema to image"
             echo "$IMAGE_UPDATE_OUTPUT"
             exit 1
@@ -313,15 +310,16 @@ else
         # Step 3: Create a new Image Capability Schema
         print_info "Creating new Image Capability Schema: ${SCHEMA_NAME}"
         
+        create_rc=0
         CREATE_OUTPUT=$($OCI_CMD compute image-capability-schema create \
             --compartment-id "${COMPARTMENT_ID}" \
             --image-id "${IMAGE_ID}" \
             --global-image-capability-schema-version-name "${GLOBAL_SCHEMA_VERSION}" \
             --display-name "${SCHEMA_NAME}" \
             --schema-data "$SCHEMA_DATA" \
-            2>&1)
+            2>&1) || create_rc=$?
         
-        if [[ $? -eq 0 ]]; then
+        if [[ $create_rc -eq 0 ]]; then
             SCHEMA_ID=$(echo "$CREATE_OUTPUT" | jq -r '.data.id')
             print_success "Created Image Capability Schema: ${SCHEMA_ID}"
         else


### PR DESCRIPTION
The `setup_oci_image_capability_schema.sh` script was failing in `us-phoenix-1` due to the following issues:

- OCI auto-attaches a capability schema to images in phoenix, taking the "update existing" code path
  which used `VAR=$(cmd 2>&1)` followed by `if [[ $? -eq 0 ]]`.
  With `set -euo pipefail`, a non-zero exit from the command kills the script before $? is checked.
  Fix it by capturing the exit code with `|| rc=$?`.

- The schema included the `NVME` value in Storage.LocalDataVolumeType,
  but phoenix's global schema only allows [ISCSI, SCSI, IDE, PARAVIRTUALIZED].
  Fix it by removing the 'LocalDataVolumeType' descriptor entirely so OCI imposes no restriction,
  allowing the image to launch on DenseIO.E5 shapes with NVMe storage.

Ref: #SCT-651