### PR TITLE
gcp: sync VPC MTU on boot and warn when jumbo frames are not enabled

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -364,6 +364,28 @@ uv venv                    # Create virtual environment
 5. Run integration tests: `make test-integration` (requires AWS)
 6. Start developing!
 
+## GCP: Enabling Jumbo Frames for Tier 1 Instances
+
+By default, GCP VPCs use an MTU of 1460. For Tier 1 networking instances,
+the VPC should be configured with jumbo frames (MTU 8896) to achieve full
+streaming throughput. The guest image cannot raise the MTU beyond what the
+VPC allows, so this is a VPC-level requirement.
+
+### Steps
+
+1. Set the VPC MTU to 8896:
+   ```bash
+   gcloud compute networks update <network> --mtu=8896
+   ```
+
+2. **Stop and start** (not reboot) all instances on that network. A guest
+   reboot does not refresh the MTU — only a stop/start causes GCP to
+   re-provision the NIC with the new VPC MTU via DHCP.
+
+The Scylla image will log a warning at login and in the journal when a
+Tier 1 instance has a VPC MTU below 8896, including the exact `gcloud`
+command to fix it. Standard (non-Tier 1) instances are not affected.
+
 ## Resources
 
 - [UV Documentation](https://github.com/astral-sh/uv)

--- a/common/scylla_image_setup
+++ b/common/scylla_image_setup
@@ -8,14 +8,131 @@ import logging
 import os
 import re
 import subprocess
+import urllib.error
 from pathlib import Path
 from subprocess import run
 
 from lib.log import setup_logging
-from lib.scylla_cloud import get_cloud_instance, is_azure, is_ec2
+from lib.scylla_cloud import (
+    GCP_MAX_MTU,
+    GCP_MTU_WARNING_PATH,
+    GCP_STANDARD_MTU,
+    gcp_mtu_warning,
+    get_cloud_instance,
+    is_azure,
+    is_ec2,
+    is_gce,
+)
 
 
 LOGGER = logging.getLogger(__name__)
+
+
+NETPLAN_MTU_PATH = Path("/etc/netplan/99-scylla-mtu.yaml")
+# Records the netplan config `netplan apply` last succeeded with. Tracking the
+# *applied* state rather than the desired state means an apply that failed on a
+# previous boot is retried, while an unchanged config doesn't restart networkd
+# on every boot.
+NETPLAN_APPLIED_STAMP = Path("/etc/scylla/gcp_mtu_netplan_applied")
+
+
+def _read_if_exists(path: Path) -> str:
+    return path.read_text() if path.exists() else ""
+
+
+def _apply_netplan_mtu(iface: str, mtu: int) -> None:
+    """Persist an explicit MTU for `iface` so DHCP renewals don't undo it."""
+    content = f"network:\n  version: 2\n  ethernets:\n    {iface}:\n      mtu: {mtu}\n"
+    rewritten = _read_if_exists(NETPLAN_MTU_PATH) != content
+    if rewritten:
+        NETPLAN_MTU_PATH.write_text(content)
+        NETPLAN_MTU_PATH.chmod(0o600)
+    # Apply when the config just changed, or when no successful apply of this
+    # exact config has been recorded. The `rewritten` term matters because the
+    # stamp can outlive the file it describes (e.g. the file was removed by
+    # hand), and a stale stamp must not suppress the apply.
+    if rewritten or _read_if_exists(NETPLAN_APPLIED_STAMP) != content:
+        run("netplan apply", shell=True, check=True)
+        # Stamped only after a successful apply, so a failure is retried.
+        NETPLAN_APPLIED_STAMP.write_text(content)
+
+
+def _clear_netplan_mtu() -> None:
+    """Drop a previously written MTU clamp, e.g. after an instance-type change."""
+    if NETPLAN_MTU_PATH.exists():
+        NETPLAN_MTU_PATH.unlink()
+        run("netplan apply", shell=True, check=True)
+    NETPLAN_APPLIED_STAMP.unlink(missing_ok=True)
+
+
+def _record_mtu_warning(mtu: int | None) -> None:
+    """Record (or clear) the warning the login banner prints.
+
+    The banner reads this file instead of querying the metadata server, so a
+    slow metadata server can never stall a login.
+    """
+    if mtu is None:
+        GCP_MTU_WARNING_PATH.unlink(missing_ok=True)
+        return
+    GCP_MTU_WARNING_PATH.write_text(gcp_mtu_warning(mtu) + "\n")
+    # The banner runs as the logging-in user, so the mode must be explicit —
+    # inheriting a restrictive umask would silently hide the warning.
+    GCP_MTU_WARNING_PATH.chmod(0o644)
+
+
+def sync_gcp_mtu_from_vpc():
+    """Configure GCP instance MTU based on networking tier.
+
+    Tier 1 instances: apply the VPC MTU from metadata to eth0 (defensive
+    reconcile) and remove any netplan clamp. Warn if the VPC MTU is below
+    8896 (jumbo frames not enabled).
+
+    Standard instances: clamp MTU to min(1460, VPC MTU) so that only Tier 1
+    instances benefit from jumbo frames. Persist via netplan so DHCP renewals
+    don't undo the clamp.
+
+    Unknown/inconclusive: skip entirely — don't risk degrading a working config.
+    """
+    try:
+        cloud_instance = get_cloud_instance()
+        # The image sets net.ifnames=0 in GRUB (packer/scylla_install_image),
+        # guaranteeing the primary NIC is always eth0. The whole codebase
+        # assumes this — e.g., scylla_sysconfig_setup --nic eth0 below.
+        iface = "eth0"
+        # Clear first, so the banner only ever shows a warning derived from this
+        # boot — a warning from a previous boot must not outlive the condition
+        # that produced it, including when detection turns out inconclusive.
+        _record_mtu_warning(None)
+        tier1 = cloud_instance.is_tier1_networking
+
+        if tier1 is None:
+            LOGGER.warning(
+                "Tier 1 detection inconclusive (unknown instance type or missing "
+                "gcp_net_params.json). Skipping MTU configuration."
+            )
+            return
+
+        mtu = cloud_instance.network_mtu
+        if tier1:
+            # Tier 1: use the VPC MTU (8896 for full performance).
+            LOGGER.info(f"Tier 1 instance detected. Setting MTU on {iface} to {mtu} (from VPC metadata)")
+            run(f"ip link set dev {iface} mtu {mtu}", shell=True, check=True)
+            _clear_netplan_mtu()
+            if mtu < GCP_MAX_MTU:
+                LOGGER.warning(gcp_mtu_warning(mtu))
+                _record_mtu_warning(mtu)
+        else:
+            # Standard: clamp to 1460 but never exceed the VPC MTU (which can
+            # be below 1460 on Cloud VPN / IPsec networks). Jumbo frames are
+            # reserved for Tier 1, so there is nothing to warn about here.
+            mtu = min(GCP_STANDARD_MTU, mtu)
+            LOGGER.info(f"Standard instance detected. Clamping MTU on {iface} to {mtu}")
+            run(f"ip link set dev {iface} mtu {mtu}", shell=True, check=True)
+            _apply_netplan_mtu(iface, mtu)
+    except (OSError, ValueError, urllib.error.URLError, subprocess.CalledProcessError):
+        LOGGER.warning("Failed to set GCP MTU", exc_info=True)
+    except Exception:
+        LOGGER.error("Unexpected error in sync_gcp_mtu_from_vpc", exc_info=True)
 
 
 def disable_perftune():
@@ -68,3 +185,11 @@ if __name__ == "__main__":
         if not os.path.ismount("/var/lib/scylla") and not cloud_instance.is_dev_instance_type():
             LOGGER.error("Failed to initialize RAID volume!")
         machine_image_configured.touch()
+
+    if is_gce():
+        # On Tier 1 instances, query the VPC-configured MTU from GCP metadata
+        # on every boot and apply it to eth0 as a defensive reconcile. This
+        # runs outside the machine_image_configured guard so it picks up VPC
+        # MTU changes after a stop/start cycle. Standard instances are clamped
+        # to 1460 to reserve jumbo frames for Tier 1 only.
+        sync_gcp_mtu_from_vpc()

--- a/lib/param_estimation.py
+++ b/lib/param_estimation.py
@@ -88,15 +88,20 @@ def _query_metadata_tier1_attribute() -> bool | None:
         return None
 
 
-def _detect_gcp_tier1(default_bw_gbps: float, tier1_bw_gbps: float | None, tier1_override: bool | None = None) -> bool:
-    """Detect whether GCP Tier 1 networking is active. Conservative: returns False if uncertain.
+def detect_gcp_tier1(
+    default_bw_gbps: float, tier1_bw_gbps: float | None, tier1_override: bool | None = None
+) -> bool | None:
+    """Detect whether GCP Tier 1 networking is active.
+
+    Returns True for Tier 1, False for known-not-Tier-1, None if detection
+    is inconclusive (no evidence in either direction).
 
     Detection order:
     1. User override (tier1_override param from cloud-init user-data) — always wins
     2. GCP instance metadata attribute scylla_tier1_networking — set at VM creation time
     3. /sys/class/net/<iface>/speed vs known default — no scope needed
     4. Compute Engine API networkPerformanceConfig — requires compute-ro scope
-    5. Conservative default: False
+    5. None (inconclusive)
     """
     if tier1_bw_gbps is None:
         return False  # Instance type doesn't support Tier 1
@@ -121,7 +126,13 @@ def _detect_gcp_tier1(default_bw_gbps: float, tier1_bw_gbps: float | None, tier1
 
     # 4. Compute Engine API (requires compute-ro scope)
     api_tier = _query_compute_api_tier()
-    return api_tier == "TIER_1"  # Conservative default: False when uncertain
+    if api_tier == "TIER_1":
+        return True
+    if api_tier == "DEFAULT":
+        return False
+
+    # No evidence — inconclusive
+    return None
 
 
 def estimate_streaming_bandwidth(cloud_instance=None):
@@ -174,7 +185,7 @@ def estimate_streaming_bandwidth(cloud_instance=None):
 
     elif is_gce():
         instance_type = cloud_instance.instancetype
-        tier1_override = getattr(cloud_instance, "_tier1_override", None)
+        tier1_override = cloud_instance.tier1_override
         # Data from GCP documentation for N2, N2D, and Z3 machine families
         # https://cloud.google.com/compute/docs/network-bandwidth
         # Format: [instance_type, default_bandwidth_gbps, tier1_bandwidth_gbps]
@@ -184,7 +195,7 @@ def estimate_streaming_bandwidth(cloud_instance=None):
             if instance_info:
                 default_bw_gbps = instance_info[0][1]
                 tier1_bw_gbps = instance_info[0][2]  # None if type doesn't support Tier 1
-                use_tier1 = _detect_gcp_tier1(default_bw_gbps, tier1_bw_gbps, tier1_override)
+                use_tier1 = detect_gcp_tier1(default_bw_gbps, tier1_bw_gbps, tier1_override)
                 net_bw_gbps = tier1_bw_gbps if (use_tier1 and tier1_bw_gbps) else default_bw_gbps
                 net_bw = int(net_bw_gbps * 1000 * 1000 * 1000)  # Gbps -> bps
 

--- a/lib/scylla_cloud.py
+++ b/lib/scylla_cloud.py
@@ -21,10 +21,28 @@ import urllib.error
 import urllib.request
 from abc import ABCMeta, abstractmethod
 from datetime import timezone
+from pathlib import Path
 from subprocess import CalledProcessError, run
 
 import psutil
 import traceback_with_variables
+
+
+GCP_MAX_MTU = 8896
+GCP_STANDARD_MTU = 1460
+GCP_NET_PARAMS_PATH = Path("/opt/scylladb/scylla-machine-image/gcp_net_params.json")
+# Written by scylla_image_setup at boot, read by the login banner.
+GCP_MTU_WARNING_PATH = Path("/etc/scylla/gcp_mtu_warning")
+
+
+def gcp_mtu_warning(mtu: int) -> str:
+    """Return the warning message when the VPC MTU is below GCP_MAX_MTU."""
+    return (
+        f"VPC MTU is {mtu}; jumbo frames are not enabled. For best streaming "
+        f"throughput set the VPC MTU to {GCP_MAX_MTU} "
+        f"('gcloud compute networks update <network> --mtu={GCP_MAX_MTU}'), then "
+        f"stop and start the instances — a guest reboot does not refresh the MTU."
+    )
 
 
 def out(cmd, shell=True, timeout=None, encoding="utf-8", ignore_error=False, user=None, group=None):
@@ -150,9 +168,8 @@ class CloudInstance(metaclass=ABCMeta):
     def io_setup(self):
         pass
 
-    @staticmethod
     @abstractmethod
-    def check():
+    def check(self):
         pass
 
     @property
@@ -431,9 +448,61 @@ class GcpInstance(CloudInstance):
     def private_ipv4(self):
         return self.__instance_metadata("network-interfaces/0/ip")
 
-    @staticmethod
-    def check():
-        pass
+    @functools.cached_property
+    def network_mtu(self) -> int:
+        """Return the VPC-configured MTU for the primary network interface."""
+        return int(self.__instance_metadata("network-interfaces/0/mtu"))
+
+    @property
+    def tier1_override(self):
+        """Explicit Tier 1 networking setting, or None when the user didn't set one.
+
+        Honours an override assigned directly on the instance (scylla_configure
+        does that after parsing user-data), otherwise reads `tier1_networking`
+        from this instance's user-data. Deliberately not cached, so an override
+        assigned after the first read is still picked up.
+        """
+        assigned = getattr(self, "_tier1_override", None)
+        if assigned is not None:
+            return assigned
+        # Late import: lib.user_data reaches back into this module.
+        from lib.user_data import UserData
+
+        return UserData(cloud_instance=self).instance_user_data.get("tier1_networking")
+
+    @functools.cached_property
+    def is_tier1_networking(self) -> bool | None:
+        """Whether Tier 1 networking is active on this instance.
+
+        True for Tier 1, False for known-not-Tier-1, None when detection is
+        inconclusive (unknown instance type, or missing/corrupt data file).
+        Callers must treat None as "don't touch anything".
+        """
+        # Late import to avoid a circular dependency (param_estimation imports this module).
+        from lib.param_estimation import detect_gcp_tier1
+
+        try:
+            with open(GCP_NET_PARAMS_PATH) as f:
+                netinfo = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            return None  # Data file missing or corrupt — detection inconclusive
+        instance_info = [info for info in netinfo if info[0] == self.instancetype]
+        if not instance_info:
+            return None  # Unknown instance type — detection inconclusive
+        default_bw_gbps = instance_info[0][1]
+        tier1_bw_gbps = instance_info[0][2]
+        return detect_gcp_tier1(default_bw_gbps, tier1_bw_gbps, self.tier1_override)
+
+    def check(self):
+        # Read the warning recorded at boot by scylla_image_setup rather than
+        # querying the metadata server: check() runs on every login, and a
+        # slow or unreachable metadata server must never stall it.
+        try:
+            warning = GCP_MTU_WARNING_PATH.read_text().strip()
+        except OSError:
+            return  # Nothing recorded (the usual case) — stay quiet.
+        if warning:
+            colorprint("{yellow}WARNING: {warning}{nocolor}", warning=warning)
 
     def io_setup(self):
         run("/opt/scylladb/scylla-machine-image/scylla_cloud_io_setup", check=True, shell=True)
@@ -628,8 +697,7 @@ class AzureInstance(CloudInstance):
     def private_ipv4(self):
         return self.__instance_metadata("/network/interface/0/ipv4/ipAddress/0/privateIpAddress")
 
-    @staticmethod
-    def check():
+    def check(self):
         pass
 
     def io_setup(self):
@@ -826,8 +894,7 @@ class OciInstance(CloudInstance):
         shape = self.instancetype
         return bool("Micro" in shape or shape.startswith("VM.Standard.E2.1"))
 
-    @staticmethod
-    def check():
+    def check(self):
         """Perform instance check."""
         return run("/opt/scylladb/scylla-machine-image/scylla_ec2_check --nic eth0", shell=True)
 
@@ -1158,8 +1225,7 @@ class AwsInstance(CloudInstance):
         mac_stat = self.__instance_metadata(f"meta-data/network/interfaces/macs/{mac}")
         return bool(re.search(r"^vpc-id$", mac_stat, flags=re.MULTILINE))
 
-    @staticmethod
-    def check():
+    def check(self):
         return run("/opt/scylladb/scylla-machine-image/scylla_ec2_check --nic eth0", shell=True)
 
     def io_setup(self):

--- a/lib/user_data.py
+++ b/lib/user_data.py
@@ -12,9 +12,12 @@ LOGGER = logging.getLogger(__name__)
 
 
 class UserData:
-    def __init__(self, *arg, **kwargs):
+    def __init__(self, *arg, cloud_instance=None, **kwargs):
         self._instance_user_data = None
-        self._cloud_instance = None
+        # Callers that already hold a CloudInstance can pass it in, so the
+        # user-data is read from that instance rather than a freshly
+        # identified one.
+        self._cloud_instance = cloud_instance
 
     @property
     def cloud_instance(self):

--- a/lib/user_data.py
+++ b/lib/user_data.py
@@ -44,7 +44,14 @@ class UserData:
                 # try parse yaml, and fallback to parsing json
                 self._instance_user_data = {}
                 if raw_user_data:
-                    self._instance_user_data = yaml.safe_load(raw_user_data)
+                    parsed = yaml.safe_load(raw_user_data)
+                    # user-data can be valid YAML without being a mapping (a bare
+                    # string parses fine), while every consumer here expects a
+                    # dict to .get() from.
+                    if isinstance(parsed, dict):
+                        self._instance_user_data = parsed
+                    else:
+                        LOGGER.warning("user-data is not a mapping (got %s). Will use defaults!", type(parsed).__name__)
                 LOGGER.debug("parsed user-data: %s", self._instance_user_data)
             except Exception as e:
                 LOGGER.warning("Error getting user data: %s. Will use defaults!", e)

--- a/tests/test_gcp_instance.py
+++ b/tests/test_gcp_instance.py
@@ -2,10 +2,12 @@ import importlib.util
 import json
 import logging
 import sys
+import tempfile
 import unittest.mock
 from collections import namedtuple
 from pathlib import Path
 from socket import AddressFamily, SocketKind
+from types import SimpleNamespace
 from unittest import IsolatedAsyncioTestCase, TestCase
 
 import httpretty
@@ -148,6 +150,8 @@ class GcpMetadata:
         num_local_disks=4,
         num_remote_disks=0,
         with_userdata=False,
+        userdata='{"scylla_yaml": {"cluster_name": "test-cluster"}}',
+        mtu=1460,
     ):
         httpretty.register_uri(
             httpretty.GET,
@@ -158,6 +162,11 @@ class GcpMetadata:
             httpretty.GET,
             "http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/ip?recursive=false",
             "172.16.0.1",
+        )
+        httpretty.register_uri(
+            httpretty.GET,
+            "http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/mtu?recursive=false",
+            str(mtu),
         )
         disks = []
         i = 0
@@ -208,7 +217,7 @@ class GcpMetadata:
             httpretty.register_uri(
                 httpretty.GET,
                 "http://metadata.google.internal/computeMetadata/v1/instance/attributes/user-data?recursive=false",
-                '{"scylla_yaml": {"cluster_name": "test-cluster"}}',
+                userdata,
             )
 
 
@@ -415,6 +424,111 @@ class TestGcpInstance(TestCase, GcpMetadata):
         self.httpretty_gcp_metadata()
         ins = GcpInstance()
         assert ins.private_ipv4() == "172.16.0.1"
+
+    def test_network_mtu_default(self):
+        self.httpretty_gcp_metadata()
+        ins = GcpInstance()
+        assert ins.network_mtu == 1460
+
+    def test_network_mtu_jumbo(self):
+        self.httpretty_gcp_metadata(mtu=8896)
+        ins = GcpInstance()
+        assert ins.network_mtu == 8896
+
+    def _net_params_file(self, netinfo):
+        """Point GCP_NET_PARAMS_PATH at a temporary gcp_net_params.json."""
+        tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmpdir.cleanup)
+        path = Path(tmpdir.name) / "gcp_net_params.json"
+        path.write_text(json.dumps(netinfo))
+        return unittest.mock.patch("lib.scylla_cloud.GCP_NET_PARAMS_PATH", path)
+
+    def test_is_tier1_networking_delegates_to_detection(self):
+        """A known instance type passes its bandwidth columns to detect_gcp_tier1."""
+        self.httpretty_gcp_metadata()
+        ins = GcpInstance()
+        with (
+            self._net_params_file([["n2-standard-8", 32.0, 50.0]]),
+            unittest.mock.patch("lib.param_estimation.detect_gcp_tier1", return_value=True) as mock_detect,
+        ):
+            assert ins.is_tier1_networking is True
+        mock_detect.assert_called_once_with(32.0, 50.0, None)
+
+    def test_is_tier1_networking_none_for_unknown_instance_type(self):
+        """An instance type missing from the table is inconclusive, not 'standard'."""
+        self.httpretty_gcp_metadata()
+        ins = GcpInstance()
+        with self._net_params_file([["some-other-type", 10.0, None]]):
+            assert ins.is_tier1_networking is None
+
+    def test_is_tier1_networking_none_when_data_file_missing(self):
+        """A missing data file is inconclusive, so callers leave the MTU alone."""
+        self.httpretty_gcp_metadata()
+        ins = GcpInstance()
+        with unittest.mock.patch("lib.scylla_cloud.GCP_NET_PARAMS_PATH", Path("/nonexistent/gcp_net_params.json")):
+            assert ins.is_tier1_networking is None
+
+    def test_is_tier1_networking_none_when_data_file_corrupt(self):
+        """Corrupt JSON is inconclusive rather than an exception or 'standard'."""
+        self.httpretty_gcp_metadata()
+        ins = GcpInstance()
+        tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmpdir.cleanup)
+        path = Path(tmpdir.name) / "gcp_net_params.json"
+        path.write_text("{ not json")
+        with unittest.mock.patch("lib.scylla_cloud.GCP_NET_PARAMS_PATH", path):
+            assert ins.is_tier1_networking is None
+
+    def test_is_tier1_networking_passes_user_data_override(self):
+        """tier1_networking from user-data reaches the detection helper."""
+        self.httpretty_gcp_metadata(with_userdata=True, userdata=yaml.dump({"tier1_networking": True}))
+        ins = GcpInstance()
+        with (
+            self._net_params_file([["n2-standard-8", 32.0, 50.0]]),
+            unittest.mock.patch("lib.param_estimation.detect_gcp_tier1", return_value=True) as mock_detect,
+        ):
+            assert ins.is_tier1_networking is True
+        mock_detect.assert_called_once_with(32.0, 50.0, True)
+
+    def test_tier1_override_none_when_user_data_is_not_a_mapping(self):
+        """Valid YAML that isn't a mapping must not raise out of tier1_override."""
+        self.httpretty_gcp_metadata(with_userdata=True, userdata="just a string")
+        ins = GcpInstance()
+        assert ins.tier1_override is None
+
+    def test_tier1_override_honours_assigned_value(self):
+        """An override assigned later (scylla_configure does this) wins and skips user-data."""
+        self.httpretty_gcp_metadata(with_userdata=True, userdata=yaml.dump({"tier1_networking": False}))
+        ins = GcpInstance()
+        ins._tier1_override = True
+        assert ins.tier1_override is True
+
+    def test_check_prints_recorded_warning(self):
+        """The banner prints whatever scylla_image_setup recorded at boot."""
+        ins = GcpInstance()
+        tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmpdir.cleanup)
+        path = Path(tmpdir.name) / "gcp_mtu_warning"
+        path.write_text("VPC MTU is 1460; jumbo frames are not enabled. Set it to 8896.\n")
+        with (
+            unittest.mock.patch("lib.scylla_cloud.GCP_MTU_WARNING_PATH", path),
+            unittest.mock.patch("builtins.print") as mock_print,
+        ):
+            ins.check()
+        mock_print.assert_called_once()
+        output = mock_print.call_args[0][0]
+        assert "1460" in output
+        assert "8896" in output
+
+    def test_check_silent_when_nothing_recorded(self):
+        """No recorded warning means a silent banner — and no metadata lookups."""
+        ins = GcpInstance()
+        with (
+            unittest.mock.patch("lib.scylla_cloud.GCP_MTU_WARNING_PATH", Path("/nonexistent/gcp_mtu_warning")),
+            unittest.mock.patch("builtins.print") as mock_print,
+        ):
+            ins.check()
+        mock_print.assert_not_called()
 
     def test_user_data(self):
         self.httpretty_gcp_metadata(with_userdata=True)
@@ -771,3 +885,145 @@ class TestGcpIoSetup(TestCase):
 
         with pytest.raises(UnsupportedInstanceClassError):
             io_setup.generate()
+
+
+# Load scylla_image_setup module (file without .py extension)
+_image_setup_path = Path(__file__).parent.parent / "common" / "scylla_image_setup"
+_setup_spec = importlib.util.spec_from_loader("scylla_image_setup", loader=None, origin=str(_image_setup_path))
+scylla_image_setup = importlib.util.module_from_spec(_setup_spec)
+with open(_image_setup_path) as _f:
+    exec(compile(_f.read(), _image_setup_path, "exec"), scylla_image_setup.__dict__)
+
+
+class TestSyncGcpMtu(TestCase, GcpMetadata):
+    NETPLAN_1460 = "network:\n  version: 2\n  ethernets:\n    eth0:\n      mtu: 1460\n"
+
+    def setUp(self):
+        httpretty.enable(verbose=True, allow_net_connect=False)
+
+    def tearDown(self):
+        httpretty.disable()
+        httpretty.reset()
+
+    def _paths(self):
+        """Redirect every path sync_gcp_mtu_from_vpc() writes into a temp dir."""
+        tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmpdir.cleanup)
+        root = Path(tmpdir.name)
+        return SimpleNamespace(
+            netplan=root / "99-scylla-mtu.yaml",
+            stamp=root / "gcp_mtu_netplan_applied",
+            warning=root / "gcp_mtu_warning",
+        )
+
+    def _sync(self, tier1, mtu, paths=None):
+        """Run one boot's worth of sync_gcp_mtu_from_vpc(), returning the run mock.
+
+        Pass the same `paths` twice to simulate consecutive boots.
+        """
+        paths = paths or self._paths()
+        httpretty.reset()
+        self.httpretty_gcp_metadata(mtu=mtu)
+        instance = GcpInstance()
+        with (
+            unittest.mock.patch.object(scylla_image_setup, "run") as mock_run,
+            unittest.mock.patch.object(scylla_image_setup, "get_cloud_instance", return_value=instance),
+            unittest.mock.patch.object(
+                type(instance), "is_tier1_networking", unittest.mock.PropertyMock(return_value=tier1)
+            ),
+            unittest.mock.patch.object(scylla_image_setup, "NETPLAN_MTU_PATH", paths.netplan),
+            unittest.mock.patch.object(scylla_image_setup, "NETPLAN_APPLIED_STAMP", paths.stamp),
+            unittest.mock.patch.object(scylla_image_setup, "GCP_MTU_WARNING_PATH", paths.warning),
+        ):
+            scylla_image_setup.sync_gcp_mtu_from_vpc()
+        return mock_run, paths
+
+    def test_tier1_applies_vpc_mtu(self):
+        """Tier 1 instance gets the VPC MTU applied to eth0, with no clamp left behind."""
+        mock_run, paths = self._sync(tier1=True, mtu=8896)
+        mock_run.assert_any_call("ip link set dev eth0 mtu 8896", shell=True, check=True)
+        assert not paths.netplan.exists()
+        assert not paths.warning.exists()
+
+    def test_tier1_on_non_jumbo_vpc_records_warning(self):
+        """A Tier 1 instance on a 1460 VPC records the warning for the login banner."""
+        _, paths = self._sync(tier1=True, mtu=1460)
+        recorded = paths.warning.read_text()
+        assert "1460" in recorded
+        assert "8896" in recorded
+
+    def test_recorded_warning_is_world_readable(self):
+        """The banner runs as the logging-in user, so the mode must not follow umask."""
+        _, paths = self._sync(tier1=True, mtu=1460)
+        assert paths.warning.stat().st_mode & 0o777 == 0o644
+
+    def test_standard_clamps_to_min_of_1460_and_vpc(self):
+        """Standard instance is clamped to min(1460, vpc_mtu) and the clamp is persisted."""
+        mock_run, paths = self._sync(tier1=False, mtu=8896)
+        mock_run.assert_any_call("ip link set dev eth0 mtu 1460", shell=True, check=True)
+        mock_run.assert_any_call("netplan apply", shell=True, check=True)
+        assert "mtu: 1460" in paths.netplan.read_text()
+        # Jumbo frames are reserved for Tier 1, so nothing to warn about.
+        assert not paths.warning.exists()
+
+    def test_standard_respects_low_vpc_mtu(self):
+        """Standard instance on a VPC below 1460 uses the VPC MTU, never exceeds it."""
+        mock_run, paths = self._sync(tier1=False, mtu=1400)
+        mock_run.assert_any_call("ip link set dev eth0 mtu 1400", shell=True, check=True)
+        assert "mtu: 1400" in paths.netplan.read_text()
+
+    def test_standard_does_not_reapply_netplan_on_second_boot(self):
+        """An unchanged, already-applied config must not restart networkd again."""
+        mock_run, paths = self._sync(tier1=False, mtu=8896)
+        assert mock_run.call_args_list.count(unittest.mock.call("netplan apply", shell=True, check=True)) == 1
+        second_run, _ = self._sync(tier1=False, mtu=8896, paths=paths)
+        assert unittest.mock.call("netplan apply", shell=True, check=True) not in second_run.call_args_list
+
+    def test_standard_reapplies_netplan_when_previous_apply_failed(self):
+        """A file written but never successfully applied is retried on the next boot."""
+        paths = self._paths()
+        paths.netplan.write_text(self.NETPLAN_1460)  # written last boot, stamp absent -> apply failed
+        mock_run, _ = self._sync(tier1=False, mtu=8896, paths=paths)
+        mock_run.assert_any_call("netplan apply", shell=True, check=True)
+        assert paths.stamp.read_text() == self.NETPLAN_1460
+
+    def test_standard_reapplies_netplan_when_file_removed_but_stamp_survives(self):
+        """A stamp that outlives the file it describes must not suppress the apply."""
+        mock_run, paths = self._sync(tier1=False, mtu=8896)
+        mock_run.assert_any_call("netplan apply", shell=True, check=True)
+        paths.netplan.unlink()  # file removed by hand; stamp still matches
+        second_run, _ = self._sync(tier1=False, mtu=8896, paths=paths)
+        assert paths.netplan.exists()
+        second_run.assert_any_call("netplan apply", shell=True, check=True)
+
+    def test_tier1_clears_stale_clamp(self):
+        """Switching from a standard to a Tier 1 instance type removes the netplan clamp."""
+        paths = self._paths()
+        paths.netplan.write_text(self.NETPLAN_1460)
+        paths.stamp.write_text(self.NETPLAN_1460)
+        mock_run, _ = self._sync(tier1=True, mtu=8896, paths=paths)
+        assert not paths.netplan.exists()
+        assert not paths.stamp.exists()
+        mock_run.assert_any_call("netplan apply", shell=True, check=True)
+
+    def test_unknown_instance_skips_mtu(self):
+        """Inconclusive detection changes nothing at all."""
+        mock_run, paths = self._sync(tier1=None, mtu=8896)
+        mock_run.assert_not_called()
+        assert not paths.netplan.exists()
+        assert not paths.warning.exists()
+
+    def test_inconclusive_boot_clears_stale_warning(self):
+        """A warning from a previous boot must not survive an inconclusive one."""
+        _, paths = self._sync(tier1=True, mtu=1460)
+        assert "1460" in paths.warning.read_text()
+        # Next boot: VPC raised to 8896, but detection can no longer tell.
+        self._sync(tier1=None, mtu=8896, paths=paths)
+        assert not paths.warning.exists()
+
+    def test_tier1_on_jumbo_vpc_clears_stale_warning(self):
+        """Once the VPC is fixed, the recorded warning goes away."""
+        _, paths = self._sync(tier1=True, mtu=1460)
+        assert paths.warning.exists()
+        self._sync(tier1=True, mtu=8896, paths=paths)
+        assert not paths.warning.exists()

--- a/tests/test_param_estimation.py
+++ b/tests/test_param_estimation.py
@@ -14,8 +14,8 @@ import pytest
 sys.path.append(str(Path(__file__).parent.parent))
 
 from lib.param_estimation import (
-    _detect_gcp_tier1,
     _get_nic_speed_mbps,
+    detect_gcp_tier1,
     estimate_streaming_bandwidth,
 )
 
@@ -27,6 +27,11 @@ OCI_NET_PARAMS_PATH = str(Path(__file__).parent.parent / "common" / "oci_net_par
 class DummyCloudInstance:
     def __init__(self, instancetype):
         self.instancetype = instancetype
+
+    @property
+    def tier1_override(self):
+        """Mirror GcpInstance.tier1_override, which honours an assigned override."""
+        return getattr(self, "_tier1_override", None)
 
 
 class DummyOciCloudInstance:
@@ -287,19 +292,19 @@ class TestGcpTier1Detection(TestCase):
         assert result is None
 
     def test_detect_gcp_tier1_returns_false_for_unsupported_instance(self):
-        """_detect_gcp_tier1 returns False when tier1_bw_gbps is None regardless of inputs."""
-        assert _detect_gcp_tier1(10.0, None) is False
-        assert _detect_gcp_tier1(10.0, None, tier1_override=True) is False
+        """detect_gcp_tier1 returns False when tier1_bw_gbps is None regardless of inputs."""
+        assert detect_gcp_tier1(10.0, None) is False
+        assert detect_gcp_tier1(10.0, None, tier1_override=True) is False
 
     def test_detect_gcp_tier1_override_respected_before_sysfs(self):
-        """_detect_gcp_tier1 returns override value before any sysfs/API calls."""
+        """detect_gcp_tier1 returns override value before any sysfs/API calls."""
         with (
             unittest.mock.patch("lib.param_estimation._get_nic_speed_mbps") as mock_speed,
             unittest.mock.patch("lib.param_estimation._query_compute_api_tier") as mock_api,
             unittest.mock.patch("lib.param_estimation._query_metadata_tier1_attribute") as mock_meta,
         ):
-            assert _detect_gcp_tier1(32.0, 50.0, tier1_override=True) is True
-            assert _detect_gcp_tier1(32.0, 50.0, tier1_override=False) is False
+            assert detect_gcp_tier1(32.0, 50.0, tier1_override=True) is True
+            assert detect_gcp_tier1(32.0, 50.0, tier1_override=False) is False
             mock_speed.assert_not_called()
             mock_api.assert_not_called()
             mock_meta.assert_not_called()
@@ -311,8 +316,32 @@ class TestGcpTier1Detection(TestCase):
             unittest.mock.patch("lib.param_estimation._get_nic_speed_mbps", return_value=None),
             unittest.mock.patch("lib.param_estimation._query_compute_api_tier", return_value=None),
         ):
-            result = _detect_gcp_tier1(32.0, 50.0, tier1_override=None)
+            result = detect_gcp_tier1(32.0, 50.0, tier1_override=None)
         assert result is True
+
+    def test_detect_gcp_tier1_inconclusive_returns_none(self):
+        """No evidence in either direction returns None, not False.
+
+        None must stay distinguishable from False: callers clamp the MTU on
+        False and skip entirely on None.
+        """
+        with (
+            unittest.mock.patch("lib.param_estimation._query_metadata_tier1_attribute", return_value=None),
+            unittest.mock.patch("lib.param_estimation._get_nic_speed_mbps", return_value=None),
+            unittest.mock.patch("lib.param_estimation._query_compute_api_tier", return_value=None),
+        ):
+            result = detect_gcp_tier1(32.0, 50.0, tier1_override=None)
+        assert result is None
+
+    def test_detect_gcp_tier1_api_default_returns_false(self):
+        """An explicit DEFAULT tier from the Compute API is negative evidence, not absence of it."""
+        with (
+            unittest.mock.patch("lib.param_estimation._query_metadata_tier1_attribute", return_value=None),
+            unittest.mock.patch("lib.param_estimation._get_nic_speed_mbps", return_value=None),
+            unittest.mock.patch("lib.param_estimation._query_compute_api_tier", return_value="DEFAULT"),
+        ):
+            result = detect_gcp_tier1(32.0, 50.0, tier1_override=None)
+        assert result is False
 
     def test_detect_gcp_tier1_metadata_attribute_false(self):
         """GCP instance metadata attribute scylla_tier1_networking=false disables tier1 even if sysfs says tier1."""
@@ -321,7 +350,7 @@ class TestGcpTier1Detection(TestCase):
             unittest.mock.patch("lib.param_estimation._get_nic_speed_mbps", return_value=50000),
             unittest.mock.patch("lib.param_estimation._query_compute_api_tier", return_value="TIER_1"),
         ):
-            result = _detect_gcp_tier1(32.0, 50.0, tier1_override=None)
+            result = detect_gcp_tier1(32.0, 50.0, tier1_override=None)
         assert result is False
 
     def test_detect_gcp_tier1_user_override_beats_metadata_attribute(self):
@@ -331,7 +360,7 @@ class TestGcpTier1Detection(TestCase):
             unittest.mock.patch("lib.param_estimation._get_nic_speed_mbps") as mock_speed,
         ):
             # User says False, metadata says True — user wins
-            result = _detect_gcp_tier1(32.0, 50.0, tier1_override=False)
+            result = detect_gcp_tier1(32.0, 50.0, tier1_override=False)
             assert result is False
             mock_meta.assert_not_called()
             mock_speed.assert_not_called()
@@ -343,15 +372,15 @@ class TestGcpTier1Detection(TestCase):
             unittest.mock.patch("lib.param_estimation._get_nic_speed_mbps") as mock_speed,
             unittest.mock.patch("lib.param_estimation._query_compute_api_tier") as mock_api,
         ):
-            assert _detect_gcp_tier1(32.0, 50.0, tier1_override="true") is True
-            assert _detect_gcp_tier1(32.0, 50.0, tier1_override="True") is True
-            assert _detect_gcp_tier1(32.0, 50.0, tier1_override="1") is True
-            assert _detect_gcp_tier1(32.0, 50.0, tier1_override="yes") is True
-            assert _detect_gcp_tier1(32.0, 50.0, tier1_override="false") is False
-            assert _detect_gcp_tier1(32.0, 50.0, tier1_override="False") is False
-            assert _detect_gcp_tier1(32.0, 50.0, tier1_override="0") is False
-            assert _detect_gcp_tier1(32.0, 50.0, tier1_override="no") is False
-            assert _detect_gcp_tier1(32.0, 50.0, tier1_override="garbage") is False
+            assert detect_gcp_tier1(32.0, 50.0, tier1_override="true") is True
+            assert detect_gcp_tier1(32.0, 50.0, tier1_override="True") is True
+            assert detect_gcp_tier1(32.0, 50.0, tier1_override="1") is True
+            assert detect_gcp_tier1(32.0, 50.0, tier1_override="yes") is True
+            assert detect_gcp_tier1(32.0, 50.0, tier1_override="false") is False
+            assert detect_gcp_tier1(32.0, 50.0, tier1_override="False") is False
+            assert detect_gcp_tier1(32.0, 50.0, tier1_override="0") is False
+            assert detect_gcp_tier1(32.0, 50.0, tier1_override="no") is False
+            assert detect_gcp_tier1(32.0, 50.0, tier1_override="garbage") is False
             mock_meta.assert_not_called()
             mock_speed.assert_not_called()
             mock_api.assert_not_called()


### PR DESCRIPTION
Query the VPC-configured MTU from GCP metadata on every boot and apply it to eth0 as a defensive reconcile. When the VPC MTU is below 8896 (GCP's maximum / jumbo frames), log a warning in the journal and display it at login with the exact gcloud command to fix it.

- Add GcpInstance.network_mtu property and gcp_mtu_warning() helper
- Add sync_gcp_mtu_from_vpc() to scylla_image_setup (runs every boot)
- Implement GcpInstance.check() for login banner warning
- Drop @staticmethod from CloudInstance.check() base declaration
- Add tests for network_mtu and check() behavior
- Document VPC MTU requirement in SETUP.md

Refs: SMI-248