### PR TITLE
gcp: apply Google's local SSD limits when the instance has enough vCPUs

### DIFF
--- a/common/gcp_io_params.yaml
+++ b/common/gcp_io_params.yaml
@@ -63,3 +63,67 @@ z3-highmem-176-standardlssd:
   read_bandwidth: 38654705664
   write_iops: 6000000
   write_bandwidth: 32212254720
+
+# Local SSD (NVMe) performance limits published by Google, keyed by the number of
+# local SSD disks attached to the instance. Used for machine types which do not
+# have their own entry above (n1, n2, n2d, c2, ...).
+# https://cloud.google.com/compute/docs/disks/local-ssd#local-ssd-perf-nvme
+# Bandwidth is Google's MiB/s figure converted to bytes/s.
+# These numbers are only reachable when the instance has enough vCPUs, see
+# GcpIoSetup.MIN_CPU_FOR_MAX_PERFORMANCE in scylla_cloud_io_setup.
+local_ssd_nvme:
+  1:
+    read_iops: 170000
+    read_bandwidth: 692060160
+    write_iops: 90000
+    write_bandwidth: 367001600
+  2:
+    read_iops: 340000
+    read_bandwidth: 1384120320
+    write_iops: 180000
+    write_bandwidth: 734003200
+  3:
+    read_iops: 510000
+    read_bandwidth: 2076180480
+    write_iops: 270000
+    write_bandwidth: 1101004800
+  4:
+    read_iops: 680000
+    read_bandwidth: 2778726400
+    write_iops: 360000
+    write_bandwidth: 1468006400
+  5:
+    read_iops: 680000
+    read_bandwidth: 2778726400
+    write_iops: 360000
+    write_bandwidth: 1468006400
+  6:
+    read_iops: 680000
+    read_bandwidth: 2778726400
+    write_iops: 360000
+    write_bandwidth: 1468006400
+  7:
+    read_iops: 680000
+    read_bandwidth: 2778726400
+    write_iops: 360000
+    write_bandwidth: 1468006400
+  8:
+    read_iops: 680000
+    read_bandwidth: 2778726400
+    write_iops: 360000
+    write_bandwidth: 1468006400
+  16:
+    read_iops: 1600000
+    read_bandwidth: 6543114240
+    write_iops: 800000
+    write_bandwidth: 3271557120
+  24:
+    read_iops: 2400000
+    read_bandwidth: 9814671360
+    write_iops: 1200000
+    write_bandwidth: 4907335680
+  32:
+    read_iops: 3200000
+    read_bandwidth: 13086228480
+    write_iops: 1600000
+    write_bandwidth: 6543114240

--- a/common/gcp_io_params.yaml
+++ b/common/gcp_io_params.yaml
@@ -127,3 +127,60 @@ local_ssd_nvme:
     read_bandwidth: 13086228480
     write_iops: 1600000
     write_bandwidth: 6543114240
+
+# Measured on real instances by the SCT artifacts-gce-image-test job, keyed by
+# instance type and the number of local SSDs attached.
+#
+# Google's published figures under `local_ssd_nvme` below are not reachable on
+# every instance that clears MIN_CPU_FOR_MAX_PERFORMANCE: read_bandwidth in
+# particular depends on the instance size, not just the disk count. Measured on
+# 24 local SSDs, read_bandwidth ranged from 6.37 GB/s on n2-highmem-32 to
+# 10.16 GB/s on n2-highmem-64, against Google's published 9.81 GB/s.
+#
+# Values here are the lowest measurement observed for that instance type and
+# disk count, so the preset stays reachable, the same way aws_io_params.yaml is
+# built from measurements rather than published specs. This table is consulted
+# before `local_ssd_nvme`.
+measured_local_ssd:
+  n2-highmem-32:
+    # lowest of two runs (read_bandwidth 6372356096 and 6478479360)
+    16:
+      read_iops: 1679282
+      read_bandwidth: 5800099328
+      write_iops: 905453
+      write_bandwidth: 3841603328
+    24:
+      read_iops: 2386730
+      read_bandwidth: 6372356096
+      write_iops: 1358652
+      write_bandwidth: 5564101632
+  n2-highmem-48:
+    24:
+      read_iops: 2520061
+      read_bandwidth: 8896606208
+      write_iops: 1398789
+      write_bandwidth: 5772357632
+  n2-highmem-64:
+    24:
+      read_iops: 2520072
+      read_bandwidth: 10159486976
+      write_iops: 1400613
+      write_bandwidth: 5786063360
+  n2-highmem-80:
+    24:
+      read_iops: 2153194
+      read_bandwidth: 8922985472
+      write_iops: 1400245
+      write_bandwidth: 5796071936
+  n2-highmem-96:
+    24:
+      read_iops: 2519918
+      read_bandwidth: 10086702080
+      write_iops: 1399398
+      write_bandwidth: 5810061312
+  n2-highmem-128:
+    24:
+      read_iops: 2517489
+      read_bandwidth: 10026428416
+      write_iops: 1400363
+      write_bandwidth: 5834600960

--- a/common/gcp_io_params.yaml
+++ b/common/gcp_io_params.yaml
@@ -184,3 +184,44 @@ measured_local_ssd:
       read_bandwidth: 10026428416
       write_iops: 1400363
       write_bandwidth: 5834600960
+  n2-standard-32:
+    8:
+      read_iops: 719943
+      read_bandwidth: 2949060608
+      write_iops: 399649
+      write_bandwidth: 1648710016
+  # n2d reaches 8.3 GB/s read on 24 disks at 32 vCPUs, where n2-highmem-32 only
+  # reaches 6.4 GB/s -- the ceiling is a property of the machine family, not of
+  # the vCPU count. n2d never reaches Google's 9814671360, even at 96 vCPUs.
+  n2d-highmem-32:
+    24:
+      read_iops: 2332396
+      read_bandwidth: 8300612096
+      write_iops: 1400001
+      write_bandwidth: 5759377408
+  n2d-highmem-64:
+    24:
+      read_iops: 2520702
+      read_bandwidth: 8837319680
+      write_iops: 1399428
+      write_bandwidth: 5784706048
+  n2d-highmem-96:
+    24:
+      read_iops: 2519431
+      read_bandwidth: 8922923008
+      write_iops: 1399155
+      write_bandwidth: 5807921152
+  # c2 accepts at most 8 local SSDs (GCE rejects anything else with
+  # "should be one of [0, 4, 8]"), so there is no 16 or 24 disk entry for it.
+  c2-standard-30:
+    8:
+      read_iops: 719975
+      read_bandwidth: 2946133504
+      write_iops: 399731
+      write_bandwidth: 1649673344
+  c2-standard-60:
+    8:
+      read_iops: 719508
+      read_bandwidth: 2949644800
+      write_iops: 399585
+      write_bandwidth: 1660481280

--- a/common/scylla_cloud_io_setup
+++ b/common/scylla_cloud_io_setup
@@ -93,13 +93,18 @@ class GcpIoSetup(CloudIoSetup):
         instance_type = self.idata.instancetype
         nr_disks = self.idata.nvme_disk_count
 
-        # Try to load parameters from YAML file, first by instance type, then by
+        # Try to load parameters from YAML file: what we measured for this exact
+        # instance type and disk count first, then by instance type, and finally by
         # the number of local SSDs attached (Google's published limits).
         params = None
         try:
             with open("/opt/scylladb/scylla-machine-image/gcp_io_params.yaml") as f:
                 io_params = yaml.safe_load(f)
-            params = io_params.get(instance_type) or self.local_ssd_params(io_params, nr_disks)
+            params = (
+                io_params.get("measured_local_ssd", {}).get(instance_type, {}).get(nr_disks)
+                or io_params.get(instance_type)
+                or self.local_ssd_params(io_params, nr_disks)
+            )
         except FileNotFoundError:
             logging.warning("GCP I/O parameters file not found, falling back to scylla_io_setup")
         except Exception as e:
@@ -117,8 +122,10 @@ class GcpIoSetup(CloudIoSetup):
     def local_ssd_params(self, io_params, nr_disks):
         """Google's published local SSD (NVMe) limits for this number of disks, if applicable.
 
-        Returns None when the numbers are not applicable, so that the caller falls
-        back to measuring the disks with iotune.
+        Only consulted when we have no measurement of our own for this instance type
+        and disk count, see `measured_local_ssd` in gcp_io_params.yaml. Returns None
+        when the numbers are not applicable, so that the caller falls back to
+        measuring the disks with iotune.
         """
         min_cpu = self.min_cpu_for_max_performance()
         if self.idata.cpu < min_cpu:

--- a/common/scylla_cloud_io_setup
+++ b/common/scylla_cloud_io_setup
@@ -69,9 +69,20 @@ class AwsIoSetup(CloudIoSetup):
 
 
 class GcpIoSetup(CloudIoSetup):
+    # Google's local SSD limits are only reachable when the instance has enough vCPUs.
+    # https://cloud.google.com/compute/docs/disks/local-ssd#configure_your_instance_to_maximize_performance
+    MIN_CPU_FOR_MAX_PERFORMANCE = 24
+    # N1 is the exception, it needs more vCPUs than the rest of the machine families.
+    MIN_CPU_FOR_MAX_PERFORMANCE_PER_CLASS = {"n1": 32}
+
     def __init__(self, idata):
         self.idata = idata
         self.disk_properties = {}
+
+    def min_cpu_for_max_performance(self):
+        return self.MIN_CPU_FOR_MAX_PERFORMANCE_PER_CLASS.get(
+            self.idata.instance_class(), self.MIN_CPU_FOR_MAX_PERFORMANCE
+        )
 
     def generate(self):
         if not self.idata.is_supported_instance_class():
@@ -82,64 +93,41 @@ class GcpIoSetup(CloudIoSetup):
         instance_type = self.idata.instancetype
         nr_disks = self.idata.nvme_disk_count
 
-        # Try to load instance-specific parameters from YAML file
+        # Try to load parameters from YAML file, first by instance type, then by
+        # the number of local SSDs attached (Google's published limits).
+        params = None
         try:
             with open("/opt/scylladb/scylla-machine-image/gcp_io_params.yaml") as f:
                 io_params = yaml.safe_load(f)
-
-            t = None
-            if instance_type in io_params:
-                t = instance_type
-
-            if t:
-                for p in ["read_iops", "read_bandwidth", "write_iops", "write_bandwidth"]:
-                    self.disk_properties[p] = io_params[t][p]
-                self.save()
-                return
+            params = io_params.get(instance_type) or self.local_ssd_params(io_params, nr_disks)
         except FileNotFoundError:
-            logging.warning("GCP I/O parameters file not found, falling back to disk-count-based logic")
+            logging.warning("GCP I/O parameters file not found, falling back to scylla_io_setup")
         except Exception as e:
-            logging.warning(f"Error loading GCP I/O parameters: {e}, falling back to disk-count-based logic")
+            logging.warning(f"Error loading GCP I/O parameters: {e}, falling back to scylla_io_setup")
 
-        # Fallback to original disk-count-based logic for instances not in YAML
-        # below is based on https://cloud.google.com/compute/docs/disks/local-ssd#performance
-        # and https://cloud.google.com/compute/docs/disks/local-ssd#nvme
-        # note that scylla iotune might measure more, this is GCP recommended
-        mbs = 1024 * 1024
-        if nr_disks >= 1 and nr_disks < 4:
-            self.disk_properties["read_iops"] = 170000 * nr_disks
-            self.disk_properties["read_bandwidth"] = 660 * mbs * nr_disks
-            self.disk_properties["write_iops"] = 90000 * nr_disks
-            self.disk_properties["write_bandwidth"] = 350 * mbs * nr_disks
-        elif nr_disks >= 4 and nr_disks <= 8:
-            self.disk_properties["read_iops"] = 680000
-            self.disk_properties["read_bandwidth"] = 2650 * mbs
-            self.disk_properties["write_iops"] = 360000
-            self.disk_properties["write_bandwidth"] = 1400 * mbs
-        elif nr_disks == 16:
-            self.disk_properties["read_iops"] = 1600000
-            self.disk_properties["read_bandwidth"] = 4521251328
-            # below is google, above is our measured
-            # self.disk_properties["read_bandwidth"] = 6240 * mbs
-            self.disk_properties["write_iops"] = 800000
-            self.disk_properties["write_bandwidth"] = 2759452672
-            # below is google, above is our measured
-            # self.disk_properties["write_bandwidth"] = 3120 * mbs
-        elif nr_disks == 24:
-            self.disk_properties["read_iops"] = 2400000
-            self.disk_properties["read_bandwidth"] = 5921532416
-            # below is google, above is our measured
-            # self.disk_properties["read_bandwidth"] = 9360 * mbs
-            self.disk_properties["write_iops"] = 1200000
-            self.disk_properties["write_bandwidth"] = 4663037952
-            # below is google, above is our measured
-            # self.disk_properties["write_bandwidth"] = 4680 * mbs
-
-        if "read_iops" in self.disk_properties:
+        if params:
+            for p in ["read_iops", "read_bandwidth", "write_iops", "write_bandwidth"]:
+                self.disk_properties[p] = params[p]
             self.save()
-        else:
-            logging.warning("This is a supported instance but with no pre-configured io, scylla_io_setup will be run")
-            subprocess.run("scylla_io_setup", shell=True, check=True, capture_output=True, timeout=300)
+            return
+
+        logging.warning("This is a supported instance but with no pre-configured io, scylla_io_setup will be run")
+        subprocess.run("scylla_io_setup", shell=True, check=True, capture_output=True, timeout=300)
+
+    def local_ssd_params(self, io_params, nr_disks):
+        """Google's published local SSD (NVMe) limits for this number of disks, if applicable.
+
+        Returns None when the numbers are not applicable, so that the caller falls
+        back to measuring the disks with iotune.
+        """
+        min_cpu = self.min_cpu_for_max_performance()
+        if self.idata.cpu < min_cpu:
+            logging.warning(
+                f"Instance has {self.idata.cpu} vCPUs, at least {min_cpu} are needed to reach "
+                f"the local SSD performance published by Google, measuring the disks instead"
+            )
+            return None
+        return io_params.get("local_ssd_nvme", {}).get(nr_disks)
 
 
 class AzureIoSetup(CloudIoSetup):

--- a/tests/test_gcp_instance.py
+++ b/tests/test_gcp_instance.py
@@ -691,6 +691,16 @@ MOCK_GCP_IO_PARAMS = {
             "write_bandwidth": 4907335680,
         },
     },
+    "measured_local_ssd": {
+        "n2-highmem-32": {
+            24: {
+                "read_iops": 2386730,
+                "read_bandwidth": 6372356096,
+                "write_iops": 1358652,
+                "write_bandwidth": 5564101632,
+            },
+        },
+    },
 }
 
 
@@ -797,6 +807,45 @@ class TestGcpIoSetup(TestCase):
                     assert io_setup.disk_properties["write_iops"] == write_iops
                     assert io_setup.disk_properties["write_bandwidth"] == write_bandwidth
                     mock_save.assert_called_once()
+
+    def test_gcp_io_setup_prefers_measured_values(self):
+        """What we measured for this instance type and disk count wins over Google's table.
+
+        n2-highmem-32 clears the 24 vCPU gate but only reaches 6372356096 read_bandwidth
+        on 24 local SSDs, not the 9814671360 Google publishes.
+        """
+        mock_instance = MockGcpInstance(instance_type="n2-highmem-32", nvme_disk_count=24, cpu=32)
+        io_setup = GcpIoSetup(mock_instance)
+
+        mock_yaml_content = yaml.dump(MOCK_GCP_IO_PARAMS)
+
+        with (
+            unittest.mock.patch("builtins.open", unittest.mock.mock_open(read_data=mock_yaml_content)),
+            unittest.mock.patch.object(io_setup, "save") as mock_save,
+        ):
+            io_setup.generate()
+
+            assert io_setup.disk_properties["read_iops"] == 2386730
+            assert io_setup.disk_properties["read_bandwidth"] == 6372356096
+            assert io_setup.disk_properties["write_iops"] == 1358652
+            assert io_setup.disk_properties["write_bandwidth"] == 5564101632
+            mock_save.assert_called_once()
+
+    def test_gcp_io_setup_measured_only_applies_to_the_disk_count_measured(self):
+        """A measured instance type at a disk count we never measured uses Google's table."""
+        mock_instance = MockGcpInstance(instance_type="n2-highmem-32", nvme_disk_count=4, cpu=32)
+        io_setup = GcpIoSetup(mock_instance)
+
+        mock_yaml_content = yaml.dump(MOCK_GCP_IO_PARAMS)
+
+        with (
+            unittest.mock.patch("builtins.open", unittest.mock.mock_open(read_data=mock_yaml_content)),
+            unittest.mock.patch.object(io_setup, "save") as mock_save,
+        ):
+            io_setup.generate()
+
+            assert io_setup.disk_properties["read_bandwidth"] == 2778726400
+            mock_save.assert_called_once()
 
     def test_gcp_io_setup_runs_iotune_when_not_enough_cpus(self):
         """Instances with too few vCPUs cannot reach Google's limits, so iotune measures them."""

--- a/tests/test_gcp_instance.py
+++ b/tests/test_gcp_instance.py
@@ -665,19 +665,49 @@ MOCK_GCP_IO_PARAMS = {
         "write_iops": 1000000,
         "write_bandwidth": 5368709120,
     },
+    "local_ssd_nvme": {
+        2: {
+            "read_iops": 340000,
+            "read_bandwidth": 1384120320,
+            "write_iops": 180000,
+            "write_bandwidth": 734003200,
+        },
+        4: {
+            "read_iops": 680000,
+            "read_bandwidth": 2778726400,
+            "write_iops": 360000,
+            "write_bandwidth": 1468006400,
+        },
+        16: {
+            "read_iops": 1600000,
+            "read_bandwidth": 6543114240,
+            "write_iops": 800000,
+            "write_bandwidth": 3271557120,
+        },
+        24: {
+            "read_iops": 2400000,
+            "read_bandwidth": 9814671360,
+            "write_iops": 1200000,
+            "write_bandwidth": 4907335680,
+        },
+    },
 }
 
 
 class MockGcpInstance:
     """Mock GCP instance for testing GcpIoSetup."""
 
-    def __init__(self, instance_type="z3-highmem-8-highlssd", nvme_disk_count=4, supported=True):
+    def __init__(self, instance_type="z3-highmem-8-highlssd", nvme_disk_count=4, supported=True, cpu=32):
         self.instancetype = instance_type
         self.nvme_disk_count = nvme_disk_count
+        self.cpu = cpu
         self._supported = supported
 
     def is_supported_instance_class(self):
         return self._supported
+
+    def instance_class(self):
+        return self.instancetype.split("-")[0]
 
 
 class TestGcpIoSetup(TestCase):
@@ -725,8 +755,8 @@ class TestGcpIoSetup(TestCase):
             mock_save.assert_called_once()
 
     def test_gcp_io_setup_fallback_to_disk_count_logic(self):
-        """Test GcpIoSetup falls back to disk-count-based logic when instance not in YAML."""
-        mock_instance = MockGcpInstance(instance_type="n2-standard-8", nvme_disk_count=2)
+        """Test GcpIoSetup falls back to the per-disk-count Google limits when instance not in YAML."""
+        mock_instance = MockGcpInstance(instance_type="n2-standard-32", nvme_disk_count=2, cpu=32)
         io_setup = GcpIoSetup(mock_instance)
 
         mock_yaml_content = yaml.dump(MOCK_GCP_IO_PARAMS)
@@ -737,32 +767,106 @@ class TestGcpIoSetup(TestCase):
         ):
             io_setup.generate()
 
-            # Should use disk-count-based logic for 2 disks (1-3 range)
-            mbs = 1024 * 1024
-            assert io_setup.disk_properties["read_iops"] == 170000 * 2
-            assert io_setup.disk_properties["read_bandwidth"] == 660 * mbs * 2
-            assert io_setup.disk_properties["write_iops"] == 90000 * 2
-            assert io_setup.disk_properties["write_bandwidth"] == 350 * mbs * 2
+            assert io_setup.disk_properties["read_iops"] == 340000
+            assert io_setup.disk_properties["read_bandwidth"] == 1384120320
+            assert io_setup.disk_properties["write_iops"] == 180000
+            assert io_setup.disk_properties["write_bandwidth"] == 734003200
+            mock_save.assert_called_once()
+
+    def test_gcp_io_setup_uses_google_limits(self):
+        """Google's published limits are used for the 16 and 24 local SSD configurations."""
+        expected = {
+            16: (1600000, 6543114240, 800000, 3271557120),
+            24: (2400000, 9814671360, 1200000, 4907335680),
+        }
+        mock_yaml_content = yaml.dump(MOCK_GCP_IO_PARAMS)
+
+        for nr_disks, (read_iops, read_bandwidth, write_iops, write_bandwidth) in expected.items():
+            with self.subTest(nr_disks=nr_disks):
+                mock_instance = MockGcpInstance(instance_type="n2-standard-32", nvme_disk_count=nr_disks, cpu=32)
+                io_setup = GcpIoSetup(mock_instance)
+
+                with (
+                    unittest.mock.patch("builtins.open", unittest.mock.mock_open(read_data=mock_yaml_content)),
+                    unittest.mock.patch.object(io_setup, "save") as mock_save,
+                ):
+                    io_setup.generate()
+
+                    assert io_setup.disk_properties["read_iops"] == read_iops
+                    assert io_setup.disk_properties["read_bandwidth"] == read_bandwidth
+                    assert io_setup.disk_properties["write_iops"] == write_iops
+                    assert io_setup.disk_properties["write_bandwidth"] == write_bandwidth
+                    mock_save.assert_called_once()
+
+    def test_gcp_io_setup_runs_iotune_when_not_enough_cpus(self):
+        """Instances with too few vCPUs cannot reach Google's limits, so iotune measures them."""
+        # n2 needs at least 24 vCPUs, n1 needs at least 32
+        for instance_type, cpu in [("n2-standard-16", 16), ("n1-standard-24", 24)]:
+            with self.subTest(instance_type=instance_type):
+                mock_instance = MockGcpInstance(instance_type=instance_type, nvme_disk_count=24, cpu=cpu)
+                io_setup = GcpIoSetup(mock_instance)
+
+                mock_yaml_content = yaml.dump(MOCK_GCP_IO_PARAMS)
+
+                with (
+                    unittest.mock.patch("builtins.open", unittest.mock.mock_open(read_data=mock_yaml_content)),
+                    unittest.mock.patch.object(io_setup, "save") as mock_save,
+                    unittest.mock.patch("subprocess.run") as mock_run,
+                ):
+                    io_setup.generate()
+
+                    assert "read_iops" not in io_setup.disk_properties
+                    mock_save.assert_not_called()
+                    mock_run.assert_called_once()
+                    assert mock_run.call_args.args[0] == "scylla_io_setup"
+
+    def test_gcp_io_setup_runs_iotune_for_unknown_disk_count(self):
+        """A disk count Google doesn't publish limits for is measured by iotune."""
+        mock_instance = MockGcpInstance(instance_type="n2-standard-32", nvme_disk_count=9, cpu=32)
+        io_setup = GcpIoSetup(mock_instance)
+
+        mock_yaml_content = yaml.dump(MOCK_GCP_IO_PARAMS)
+
+        with (
+            unittest.mock.patch("builtins.open", unittest.mock.mock_open(read_data=mock_yaml_content)),
+            unittest.mock.patch.object(io_setup, "save") as mock_save,
+            unittest.mock.patch("subprocess.run") as mock_run,
+        ):
+            io_setup.generate()
+
+            mock_save.assert_not_called()
+            mock_run.assert_called_once()
+
+    def test_gcp_io_setup_uses_instance_type_regardless_of_cpu_count(self):
+        """A machine type with its own entry is measured from that entry, not the per-disk table."""
+        mock_instance = MockGcpInstance(instance_type="z3-highmem-8-highlssd", nvme_disk_count=4, cpu=8)
+        io_setup = GcpIoSetup(mock_instance)
+
+        mock_yaml_content = yaml.dump(MOCK_GCP_IO_PARAMS)
+
+        with (
+            unittest.mock.patch("builtins.open", unittest.mock.mock_open(read_data=mock_yaml_content)),
+            unittest.mock.patch.object(io_setup, "save") as mock_save,
+        ):
+            io_setup.generate()
+
+            assert io_setup.disk_properties["read_iops"] == 750000
             mock_save.assert_called_once()
 
     def test_gcp_io_setup_fallback_when_file_not_found(self):
-        """Test GcpIoSetup falls back to disk-count logic when YAML file not found."""
-        mock_instance = MockGcpInstance(instance_type="n2-standard-8", nvme_disk_count=4)
+        """Test GcpIoSetup falls back to iotune when the YAML file is not found."""
+        mock_instance = MockGcpInstance(instance_type="n2-standard-32", nvme_disk_count=4, cpu=32)
         io_setup = GcpIoSetup(mock_instance)
 
         with (
             unittest.mock.patch("builtins.open", side_effect=FileNotFoundError("File not found")),
             unittest.mock.patch.object(io_setup, "save") as mock_save,
+            unittest.mock.patch("subprocess.run") as mock_run,
         ):
             io_setup.generate()
 
-            # Should use disk-count-based logic for 4 disks (4-8 range)
-            mbs = 1024 * 1024
-            assert io_setup.disk_properties["read_iops"] == 680000
-            assert io_setup.disk_properties["read_bandwidth"] == 2650 * mbs
-            assert io_setup.disk_properties["write_iops"] == 360000
-            assert io_setup.disk_properties["write_bandwidth"] == 1400 * mbs
-            mock_save.assert_called_once()
+            mock_save.assert_not_called()
+            mock_run.assert_called_once()
 
     def test_gcp_io_setup_raises_for_unsupported_instance_class(self):
         """Test that GcpIoSetup raises UnsupportedInstanceClassError for unsupported instances."""


### PR DESCRIPTION
The disk performance on GCP was verified against Google's specification and,
for most metrics, it matches — so there is no reason to keep using the lower
numbers we measured ourselves. But measuring across the n2, n2d and c2
families showed Google's published figures are not reachable everywhere, so
this PR both adopts them as a baseline and overrides them with our own
measurements where they do not hold.

What changed:

- Google's published local SSD (NVMe) limits moved into
  `common/gcp_io_params.yaml` under a `local_ssd_nvme` section, keyed by the
  number of local SSDs. It covers every configuration Google documents
  (1-8, 16, 24 and 32 disks), with the bandwidth values converted from
  Google's MiB/s figures to bytes/s.
- A `measured_local_ssd` section keyed by **instance type and disk count**,
  holding the lowest value we measured for each combination — the same way
  `aws_io_params.yaml` is built from measurements rather than published
  specs. This is consulted first.
- The hardcoded disk-count table is gone from `GcpIoSetup`. Lookup order is
  now: measured (instance type + disk count) → instance type (the existing
  `z3-*` entries) → Google's per-disk-count table → `scylla_io_setup`.
- Google's numbers are only applied when the instance has enough vCPUs — 24
  for most machine families, 32 for n1 — so below that threshold we let
  iotune measure the disks instead of writing limits they cannot reach.

Refs:
- https://cloud.google.com/compute/docs/disks/local-ssd#local-ssd-perf-nvme
- https://cloud.google.com/compute/docs/disks/local-ssd#configure_your_instance_to_maximize_performance

Fixes: SMI-222

## Why a measured table, and not just Google's numbers

16 SCT runs on real instances (`artifacts-gce-image-test` #179-#198) showed
the achievable performance at a given disk count **depends on the machine
family and instance size**, which a single per-disk-count row cannot express:

- **n2-highmem-32 with 24 disks reaches 6372356096 read_bandwidth**, 35%
  below Google's published 9814671360. Reproduced twice (#180, #190, 1.7%
  apart).
- **n2d-highmem-32 with the same 24 disks reaches 8300612096** — 30% higher
  than n2 at the identical vCPU count. The ceiling belongs to the machine
  family, so no vCPU threshold can express it.
- **n2-highmem-64 reaches 10159486976**, above Google's figure. So the
  published number is real, just not universally reachable.
- `write_bandwidth` and `write_iops` are flat and **above** Google's figures
  on every shape measured, in every family, at both 8 and 24 disks.
- At 8 disks Google's row is **conservative** — measurements run 6-12% above
  it, and performance is flat from 16 vCPUs up across n2 and c2.

Full dataset and analysis: **SMI-308**.


## What changes versus what is on `next` today

Today `GcpIoSetup` has a hardcoded disk-count table with no vCPU check, so
every supported instance with that disk count gets the same numbers:

| disks | read_iops | read_bandwidth | write_iops | write_bandwidth |
|---|---|---|---|---|
| 4-8 | 680000 | 2778726400 | 360000 | 1468006400 |
| 16 | 1600000 | 4521251328 | 800000 | 2759452672 |
| 24 | 2400000 | 5921532416 | 1200000 | 4663037952 |

Anything else (9-15, 17-23, 25+) falls to `scylla_io_setup`.

### 1. Shapes we measured — now get their own entry

Percentages are against the current `next` value for that disk count.

| shape | disks | read_iops | read_bandwidth | write_iops | write_bandwidth |
|---|---|---|---|---|---|
| `n2-standard-32` | 8 | 719943 (+6%) | **2949060608 (+6%)** | 399649 (+11%) | 1648710016 (+12%) |
| `c2-standard-30` | 8 | 719975 (+6%) | **2946133504 (+6%)** | 399731 (+11%) | 1649673344 (+12%) |
| `c2-standard-60` | 8 | 719508 (+6%) | **2949644800 (+6%)** | 399585 (+11%) | 1660481280 (+13%) |
| `n2-highmem-32` | 16 | 1679282 (+5%) | **5800099328 (+28%)** | 905453 (+13%) | 3841603328 (+39%) |
| `n2-highmem-32` | 24 | 2386730 (-1%) | **6372356096 (+8%)** | 1358652 (+13%) | 5564101632 (+19%) |
| `n2-highmem-48` | 24 | 2520061 (+5%) | **8896606208 (+50%)** | 1398789 (+17%) | 5772357632 (+24%) |
| `n2-highmem-64` | 24 | 2520072 (+5%) | **10159486976 (+72%)** | 1400613 (+17%) | 5786063360 (+24%) |
| `n2-highmem-80` | 24 | 2153194 (-10%) | **8922985472 (+51%)** | 1400245 (+17%) | 5796071936 (+24%) |
| `n2-highmem-96` | 24 | 2519918 (+5%) | **10086702080 (+70%)** | 1399398 (+17%) | 5810061312 (+25%) |
| `n2-highmem-128` | 24 | 2517489 (+5%) | **10026428416 (+69%)** | 1400363 (+17%) | 5834600960 (+25%) |
| `n2d-highmem-32` | 24 | 2332396 (-3%) | **8300612096 (+40%)** | 1400001 (+17%) | 5759377408 (+24%) |
| `n2d-highmem-64` | 24 | 2520702 (+5%) | **8837319680 (+49%)** | 1399428 (+17%) | 5784706048 (+24%) |
| `n2d-highmem-96` | 24 | 2519431 (+5%) | **8922923008 (+51%)** | 1399155 (+17%) | 5807921152 (+25%) |

Mostly increases, because the numbers currently on `next` were measured on
smaller instances than the ones that actually run these disk counts. Three
values go **down**, which is the safety-relevant direction: `n2-highmem-80`
read_iops -10%, `n2d-highmem-32` -3%, `n2-highmem-32` at 24 disks -1%.

### 2. Shapes we did not measure — fall through to Google's table

| disks | change vs `next` |
|---|---|
| 1-8 | **none** — the current `2650 * mbs` is byte-identical to Google's 2778726400 |
| 16 | read_bandwidth **+45%** (4521251328 → 6543114240), write_bandwidth **+19%** (2759452672 → 3271557120) |
| 24 | read_bandwidth **+66%** (5921532416 → 9814671360), write_bandwidth **+5%** (4663037952 → 4907335680) |
| 32 | **new** — was `scylla_io_setup`, now 3200000 / 13086228480 / 1600000 / 6543114240 |
| 9-15, 17-23, 25-31 | none — still `scylla_io_setup` |

`read_iops` and `write_iops` are unchanged at every disk count; only bandwidth
moves. **This is the riskiest part of the PR for review**: an unmeasured 16- or
24-disk shape gets a read_bandwidth 45-66% higher than today, and SMI-308 shows
that is not always reachable — `n2-highmem-32` at 24 disks only does
6372356096 against the 9814671360 it would be handed. The measured table covers
the shapes we know about; the vCPU gate is the only thing protecting the rest,
and SMI-307 records that it is the wrong mechanism.

### 3. New behaviour: below the vCPU gate, iotune replaces the table

Instances under 24 vCPUs (32 for n1) previously got table values regardless of
whether they could reach them. Two live examples of what that was worth, both
at 8 disks where `next` writes 680000 read_iops:

| shape | vCPUs | `next` writes | iotune measures | verdict |
|---|---|---|---|---|
| `n1-standard-2` ([#179](https://jenkins.scylladb.com/job/releng-testing/job/artifacts/job/artifacts-gce-image-test/179/)) | 2 | 680000 | 317764 | `next` is **2.1x too high** |
| `n2-standard-16` ([#182](https://jenkins.scylladb.com/job/releng-testing/job/artifacts/job/artifacts-gce-image-test/182/)) | 16 | 680000 | 719634 | `next` is 5% too low |

So the gate is a real correction for genuinely small instances, and a small
loss (plus a ~2 minute boot-time iotune) for 16-vCPU ones that were already
fine — see finding 4 in the comments.
## Testing

`pytest tests/` — 282 passed. Unit tests cover the measured table taking
precedence, falling through to Google's table for an unmeasured disk count,
Google's 16 and 24 disk limits being applied, the iotune fallback when there
are too few vCPUs (n2 with 16, n1 with 24), an undocumented disk count
falling back to iotune, and a machine type with its own YAML entry not being
subject to the vCPU check.

Verified on live GCE instances, image `6673890868994677990`:

| disks | shapes measured | result |
|---|---|---|
| 24 | n2-highmem-32/48/64/80/96/128, n2d-highmem-32/64/96 | measured, in `measured_local_ssd` |
| 16 | n2-highmem-32 | measured |
| 8 | n2-standard-32, c2-standard-30/60 | measured |
| 8 | n1-standard-2, n2-standard-16 (below the gate) | iotune fallback confirmed, 0% deviation |

## Known gaps

- `MIN_CPU_FOR_MAX_PERFORMANCE = 24` is still the wrong mechanism for
  unmeasured shapes — too permissive at 24 disks, too strict at 8. **SMI-307**.
- n2-highmem-64/96/128 rest on a single sample each in the ~10.0 GB/s
  cluster while n2-highmem-48/80 measured ~8.9 GB/s. A strict lower bar would
  cap them at 8896606208.
- Unmeasured, still falling through to Google's table: n2-standard at 16/24
  disks, n2d at 8/16, c2 at 1-4, n1 entirely, and the 1-4 disk rows.
- c4 is not supported by the image at all and exits 1 without even the iotune
  fallback — **SMI-309**, its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
