### PR TITLE
aws: add m8gd and m9gd instance types

### DIFF
--- a/common/aws_io_params.yaml
+++ b/common/aws_io_params.yaml
@@ -558,6 +558,121 @@ m6gd.metal:
   read_iops: 416257
   write_bandwidth: 1063657088
   write_iops: 156326
+m8gd.medium:
+  read_bandwidth: 117872872
+  read_iops: 16771
+  write_bandwidth: 56385748
+  write_iops: 8385
+m8gd.large:
+  read_bandwidth: 235787232
+  read_iops: 33548
+  write_bandwidth: 112775504
+  write_iops: 16771
+m8gd.xlarge:
+  read_bandwidth: 472332096
+  read_iops: 67096
+  write_bandwidth: 225749776
+  write_iops: 33548
+m8gd.2xlarge:
+  read_bandwidth: 948200448
+  read_iops: 134267
+  write_bandwidth: 452300128
+  write_iops: 67097
+m8gd.4xlarge:
+  read_bandwidth: 1910598912
+  read_iops: 268818
+  write_bandwidth: 907828672
+  write_iops: 134267
+m8gd.8xlarge:
+  read_bandwidth: 3878826496
+  read_iops: 556019
+  write_bandwidth: 1828710656
+  write_iops: 268821
+m8gd.12xlarge:
+  read_bandwidth: 1906256213
+  read_iops: 268615
+  write_bandwidth: 910725376
+  write_iops: 134176
+m8gd.16xlarge:
+  read_bandwidth: 3878843648
+  read_iops: 568444
+  write_bandwidth: 1830901376
+  write_iops: 268800
+m8gd.24xlarge:
+  read_bandwidth: 3855307093
+  read_iops: 569045
+  write_bandwidth: 1834861568
+  write_iops: 268750
+m8gd.48xlarge:
+  read_bandwidth: 3852229291
+  read_iops: 531897
+  write_bandwidth: 1855815168
+  write_iops: 268734
+m8gd.metal-24xl:
+  read_bandwidth: 3855307093
+  read_iops: 569045
+  write_bandwidth: 1834861568
+  write_iops: 268750
+m8gd.metal-48xl:
+  read_bandwidth: 3852229291
+  read_iops: 531897
+  write_bandwidth: 1855815168
+  write_iops: 268734
+m9gd.medium:
+  read_bandwidth: 153176960
+  read_iops: 21953
+  write_bandwidth: 73314176
+  write_iops: 10901
+m9gd.large:
+  read_bandwidth: 306258592
+  read_iops: 43614
+  write_bandwidth: 146620480
+  write_iops: 21803
+m9gd.xlarge:
+  read_bandwidth: 612473728
+  read_iops: 87229
+  write_bandwidth: 293559840
+  write_iops: 43614
+m9gd.2xlarge:
+  read_bandwidth: 1230786176
+  read_iops: 174581
+  write_bandwidth: 587091264
+  write_iops: 87229
+m9gd.4xlarge:
+  read_bandwidth: 2461633792
+  read_iops: 349163
+  write_bandwidth: 1174193792
+  write_iops: 174604
+m9gd.8xlarge:
+  read_bandwidth: 4923173376
+  read_iops: 698324
+  write_bandwidth: 2370153984
+  write_iops: 349163
+m9gd.12xlarge:
+  read_bandwidth: 2458539179
+  read_iops: 348786
+  write_bandwidth: 1177227520
+  write_iops: 174421
+m9gd.16xlarge:
+  read_bandwidth: 10070989824
+  read_iops: 977547
+  write_bandwidth: 4740768256
+  write_iops: 698329
+m9gd.24xlarge:
+  read_bandwidth: 4883516416
+  read_iops: 706226
+  write_bandwidth: 2373460309
+  write_iops: 348915
+m9gd.48xlarge:
+  read_bandwidth: 10157772800
+  read_iops: 763355
+  write_bandwidth: 4752725675
+  write_iops: 718667
+m9gd.metal-48xl:
+  read_bandwidth: 10157772800
+  read_iops: 763355
+  write_bandwidth: 4752725675
+  write_iops: 718667
 r5d.large:
   read_bandwidth: 158538149
   read_iops: 33271

--- a/common/aws_net_params.json
+++ b/common/aws_net_params.json
@@ -2990,6 +2990,61 @@
     1.875
   ],
   [
+    "m9gd.12xlarge",
+    "25 Gigabit",
+    25.0
+  ],
+  [
+    "m9gd.16xlarge",
+    "34 Gigabit",
+    34.0
+  ],
+  [
+    "m9gd.24xlarge",
+    "50 Gigabit",
+    50.0
+  ],
+  [
+    "m9gd.2xlarge",
+    "Up to 17 Gigabit",
+    4.25
+  ],
+  [
+    "m9gd.48xlarge",
+    "100 Gigabit",
+    100.0
+  ],
+  [
+    "m9gd.4xlarge",
+    "Up to 17 Gigabit",
+    8.5
+  ],
+  [
+    "m9gd.8xlarge",
+    "17 Gigabit",
+    17.0
+  ],
+  [
+    "m9gd.large",
+    "Up to 15 Gigabit",
+    1.0
+  ],
+  [
+    "m9gd.medium",
+    "Up to 15 Gigabit",
+    0.55
+  ],
+  [
+    "m9gd.metal-48xl",
+    "100 Gigabit",
+    100.0
+  ],
+  [
+    "m9gd.xlarge",
+    "Up to 15 Gigabit",
+    2.1
+  ],
+  [
     "mac1.metal",
     "25 Gigabit",
     25.0

--- a/lib/scylla_cloud.py
+++ b/lib/scylla_cloud.py
@@ -1101,6 +1101,8 @@ class AwsInstance(CloudInstance):
             "i7ie",
             "i8g",
             "i8ge",
+            "m8gd",
+            "m9gd",
         ]
 
     def is_dev_instance_type(self):
@@ -1170,6 +1172,8 @@ class AwsInstance(CloudInstance):
             "i7ie",
             "i8g",
             "i8ge",
+            "m8gd",
+            "m9gd",
         ]:
             return "ena"
         if instance_class == "m4":

--- a/tests/test_aws_instance.py
+++ b/tests/test_aws_instance.py
@@ -1,4 +1,5 @@
 import importlib.util
+import json
 import logging
 import sys
 import unittest.mock
@@ -309,6 +310,18 @@ class TestAwsInstance(TestCase, AwsMetadata):
         self.httpretty_aws_metadata(instance_type="t3.nano")
         ins = AwsInstance()
         assert not ins.is_supported_instance_class()
+
+    def test_is_supported_instance_class_m8gd(self):
+        self.httpretty_aws_metadata(instance_type="m8gd.4xlarge")
+        ins = AwsInstance()
+        assert ins.is_supported_instance_class()
+        assert ins.get_en_interface_type() == "ena"
+
+    def test_is_supported_instance_class_m9gd(self):
+        self.httpretty_aws_metadata(instance_type="m9gd.metal-48xl")
+        ins = AwsInstance()
+        assert ins.is_supported_instance_class()
+        assert ins.get_en_interface_type() == "ena"
 
     def test_get_en_interface_type_ena(self):
         self.httpretty_aws_metadata()
@@ -771,3 +784,50 @@ class TestAwsIoSetup(TestCase):
 
         with pytest.raises(UnsupportedInstanceClassError):
             io_setup.generate()
+
+
+@pytest.mark.unit
+class TestAwsM8gdM9gdParams(TestCase):
+    """m8gd/m9gd must have both pre-configured IO params and network params."""
+
+    io_params_path = Path(__file__).parent.parent / "common" / "aws_io_params.yaml"
+    net_params_path = Path(__file__).parent.parent / "common" / "aws_net_params.json"
+
+    sizes = [
+        "medium",
+        "large",
+        "xlarge",
+        "2xlarge",
+        "4xlarge",
+        "8xlarge",
+        "12xlarge",
+        "16xlarge",
+        "24xlarge",
+        "48xlarge",
+    ]
+
+    def test_io_and_net_params_present(self):
+        with open(self.io_params_path) as f:
+            io_params = yaml.safe_load(f)
+        with open(self.net_params_path) as f:
+            net_params = {info[0] for info in json.load(f)}
+
+        for family in ("m8gd", "m9gd"):
+            for size in self.sizes:
+                instance_type = f"{family}.{size}"
+                assert instance_type in io_params, f"{instance_type} missing from aws_io_params.yaml"
+                assert instance_type in net_params, f"{instance_type} missing from aws_net_params.json"
+                params = io_params[instance_type]
+                for key in ("read_iops", "read_bandwidth", "write_iops", "write_bandwidth"):
+                    assert params[key] > 0, f"{instance_type}: {key} must be positive"
+
+    def test_metal_sizes_match_their_virtualized_counterpart(self):
+        with open(self.io_params_path) as f:
+            io_params = yaml.safe_load(f)
+
+        for metal, virtualized in (
+            ("m8gd.metal-24xl", "m8gd.24xlarge"),
+            ("m8gd.metal-48xl", "m8gd.48xlarge"),
+            ("m9gd.metal-48xl", "m9gd.48xlarge"),
+        ):
+            assert io_params[metal] == io_params[virtualized]


### PR DESCRIPTION
Add IO and network parameters for the `Graviton4-based m8gd`
and `Graviton5-based m9gd` families.
Mark both as supported instance classes (ENA-enabled) on AwsInstance.
    
Network parameters (`aws_net_params.json`) are taken from the EC2 API
using the command documented in param_estimation.py:
```
  aws ec2 describe-instance-types --query "InstanceTypes[].[InstanceType,
  NetworkInfo.NetworkPerformance,
  NetworkInfo.NetworkCards[0].BaselineBandwidthInGbps]" --output json
```
 
Only the `m9gd` rows are new; the m8gd rows already present were verified
against the API and left untouched.
    
IO parameters (aws_io_params.yaml) are measured with iotune, using
the 'tools/io_properties_measurements/get_scylla_io_properties.py' script.
    
The `metal-24xl` and the `metal-48xl` instance types mirror
their virtualized counterparts (same hardware and same drives),
because the measurement tool's family expansion skips metal types.
    
Closes: #SMI-294