### PR TITLE
packer: replace `vim-nox` with `vim` to drop Ruby from cloud images

### DIFF
--- a/packer/scylla_install_image
+++ b/packer/scylla_install_image
@@ -257,7 +257,7 @@ if __name__ == "__main__":
     apt_get(
         f"install -y --auto-remove {args.product}-machine-image {args.product}-server-dbg "
         "chrony cpufrequtils curl dnsutils ethtool htop initramfs-tools jq mdadm ncat netcat-openbsd "
-        "net-tools nftables nload nmap python3-boto3 sysstat systemd-coredump tmux traceroute vim-nox vim.tiny wget xfsprogs aide"
+        "net-tools nftables nload nmap python3-boto3 sysstat systemd-coredump tmux traceroute vim wget xfsprogs aide"
     )
     apt_get(
         "purge -y accountsservice acpid amd64-microcode apport fuse fwupd-signed modemmanager motd-news-config open-vm-tools postfix python3-apport snapd sudo-rs udisks2 unattended-upgrades update-notifier-common"


### PR DESCRIPTION
vim-nox is Vim built with every embedded scripting interpreter,
which is the sole reason Ruby is installed in our cloud images.
Plain vim is the same editor without those interpreters,
so the whole stack drops out and the image gets smaller.

Also drop the redundant, misspelled `vim.tiny` argument.

Ref: https://github.com/scylladb/siren-devops/issues/1764

Closes: #SMI-250