### PR TITLE
tests: guard AWS instance support lists against drift

### DIFF
--- a/tests/test_aws_instance_support_consistency.py
+++ b/tests/test_aws_instance_support_consistency.py
@@ -1,0 +1,138 @@
+#
+# Copyright 2026 ScyllaDB
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Guard the hand-maintained AWS instance lists against drifting apart.
+
+Supporting a new AWS instance family currently takes three separate edits:
+
+1. ``common/aws_io_params.yaml`` -- the measured I/O properties, written by
+   ``tools/io_properties_measurements/get_scylla_io_properties.py``
+2. ``AwsInstance.is_supported_instance_class()`` -- gates I/O setup at first boot
+3. ``AwsInstance.get_en_interface_type()`` -- gates the ``scylla_ec2_check`` login banner
+
+Nothing ties the three together, and they have already drifted: i7i was added to
+aws_io_params.yaml in commit 1598dc6 (2025-05-12) but only reached the two Python
+lists in commit bcfeee3 (2025-07-02). For those seven weeks i7i shipped with I/O
+presets that could never be read -- ``AwsIoSetup.generate()`` raises
+``UnsupportedInstanceClassError`` before it ever opens the YAML, ``scylla_image_setup``
+skips ``io_setup()`` entirely, and ``scylla_login`` greets the user with
+"unsupported instance type".
+
+These tests make that class of mistake fail in CI instead of in an AMI.
+
+See SMI-184.
+"""
+
+import ast
+import inspect
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+sys.path.append(str(Path(__file__).parent.parent))
+from lib.scylla_cloud import AwsInstance
+
+
+AWS_IO_PARAMS_PATH = Path(__file__).parent.parent / "common" / "aws_io_params.yaml"
+
+IO_PARAM_KEYS = frozenset({"read_iops", "read_bandwidth", "write_iops", "write_bandwidth"})
+
+
+def aws_instance(instance_type):
+    """Build an AwsInstance that answers for `instance_type` without touching the metadata service.
+
+    ``instancetype`` is a functools.cached_property, so seeding the instance
+    __dict__ short-circuits the lookup it would otherwise do over HTTP.
+    """
+    instance = AwsInstance.__new__(AwsInstance)
+    instance.__dict__["instancetype"] = instance_type
+    return instance
+
+
+def io_params():
+    with open(AWS_IO_PARAMS_PATH) as f:
+        return yaml.safe_load(f)
+
+
+def io_params_classes():
+    """The instance classes aws_io_params.yaml has presets for, e.g. {"i3", "i4i", ...}."""
+    return {key.split(".")[0] for key in io_params()}
+
+
+def hardcoded_supported_classes():
+    """The literal list inside AwsInstance.is_supported_instance_class()."""
+    tree = ast.parse(inspect.getsource(AwsInstance.is_supported_instance_class).strip())
+    classes = {
+        element.value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.List)
+        for element in node.elts
+        if isinstance(element, ast.Constant) and isinstance(element.value, str)
+    }
+    assert classes, (
+        "Could not find a literal list of instance classes in "
+        "AwsInstance.is_supported_instance_class(). If the list is now derived from "
+        f"{AWS_IO_PARAMS_PATH.name} (see SMI-184), this test has served its purpose and can go."
+    )
+    return classes
+
+
+class TestAwsInstanceSupportConsistency:
+    def test_io_params_classes_are_all_supported(self):
+        """A class with measured I/O presets must be one we admit to supporting.
+
+        This is the i7i regression: presets land in the YAML, the Python list is
+        forgotten, and the instance boots as "unsupported" with no I/O tuning.
+        """
+        missing = sorted(
+            cls for cls in io_params_classes() if not aws_instance(f"{cls}.large").is_supported_instance_class()
+        )
+        assert not missing, (
+            f"{AWS_IO_PARAMS_PATH.name} has I/O presets for {missing}, but "
+            "AwsInstance.is_supported_instance_class() rejects them, so those presets can never "
+            "be applied. Add them to the list in lib/scylla_cloud.py."
+        )
+
+    def test_supported_classes_have_io_params(self):
+        """A class we claim to support should have presets, or first boot falls back to iotune."""
+        missing = sorted(hardcoded_supported_classes() - io_params_classes())
+        assert not missing, (
+            f"AwsInstance.is_supported_instance_class() accepts {missing}, but "
+            f"{AWS_IO_PARAMS_PATH.name} has no presets for them, so first boot falls back to "
+            "running scylla_io_setup. Add the measured values with "
+            "tools/io_properties_measurements/get_scylla_io_properties.py --update-aws-params."
+        )
+
+    def test_supported_classes_have_enhanced_networking_type(self):
+        """Every supported class must map to a NIC driver, or scylla_ec2_check cries wolf.
+
+        scylla_ec2_check is only ever reached (via scylla_login) once
+        is_supported_instance_class() returned True. A supported class missing from
+        get_en_interface_type() therefore prints a red "doesn't support enhanced
+        networking!" on every login and exits 1, for no reason.
+        """
+        missing = sorted(
+            cls for cls in hardcoded_supported_classes() if aws_instance(f"{cls}.large").get_en_interface_type() is None
+        )
+        assert not missing, (
+            f"AwsInstance.get_en_interface_type() returns None for supported classes {missing}. "
+            "scylla_ec2_check will report they don't support enhanced networking. Add them to "
+            "the ENA list in lib/scylla_cloud.py."
+        )
+
+    @pytest.mark.parametrize("instance_type", sorted(io_params()))
+    def test_io_params_entries_are_well_formed(self, instance_type):
+        """aws_io_params.yaml is tool-generated; make sure a bad run cannot ship silently."""
+        entry = io_params()[instance_type]
+        assert instance_type.count(".") == 1, f"{instance_type!r} is not a <class>.<size> key"
+        assert isinstance(entry, dict), f"{instance_type} is not a mapping"
+        assert (
+            set(entry) == IO_PARAM_KEYS
+        ), f"{instance_type} has keys {sorted(entry)}, expected {sorted(IO_PARAM_KEYS)}"
+        for key, value in entry.items():
+            assert isinstance(value, int), f"{instance_type}.{key} is {value!r}, expected an int"
+            assert value > 0, f"{instance_type}.{key} is {value}, expected a positive int"


### PR DESCRIPTION
Supporting a new AWS instance family currently takes three separate edits, and nothing ties them together:

| # | What | Maintained how |
|---|------|----------------|
| 1 | `common/aws_io_params.yaml` | tool-generated (`get_scylla_io_properties.py --update-aws-params`) |
| 2 | `AwsInstance.is_supported_instance_class()` | by hand |
| 3 | `AwsInstance.get_en_interface_type()` | by hand |

Because step 1 is automated and steps 2–3 are not, the tooling actively encourages drift — and it has already happened.

## The regression this would have caught

- `1598dc6` "aws: add i7i instance type" (2025-05-12) added i7i to `aws_io_params.yaml` **only**.
- `bcfeee3` "aws: add i7i to supported instance family" (2025-07-02) came back ~7 weeks later and added i7i to both Python lists.

In between, i7i shipped with I/O presets that could never be read: `AwsIoSetup.generate()` raises `UnsupportedInstanceClassError` before it ever opens the YAML, `scylla_image_setup` skips `io_setup()` entirely, and `scylla_login` greets the user with "unsupported instance type". Silently no I/O tuning.

The mirror-image mistake is just as cheap to make: a class added to `is_supported_instance_class()` but missed in `get_en_interface_type()` makes `scylla_ec2_check` print a red **"<class> doesn't support enhanced networking!"** on every login and exit 1 — a pure false alarm, since that list is only ever consulted for classes we already declared supported (`scylla_ec2_check` is reached from `scylla_login` inside the branch where `is_supported_instance_class()` already returned True).

## What this adds

`tests/test_aws_instance_support_consistency.py`, four checks, no production code touched:

1. **`test_io_params_classes_are_all_supported`** — every class with measured presets is accepted by `is_supported_instance_class()`. This is the i7i case.
2. **`test_supported_classes_have_io_params`** — every class we claim to support has presets, or first boot silently falls back to running `scylla_io_setup`.
3. **`test_supported_classes_have_enhanced_networking_type`** — every supported class maps to a NIC driver, so `scylla_ec2_check` cannot cry wolf.
4. **`test_io_params_entries_are_well_formed`** — `aws_io_params.yaml` keys are `<class>.<size>` and every entry has exactly the four required properties as positive ints, so a bad measurement run cannot ship silently.

All three lists agree today, so this is a pure safety net — nothing to fix alongside it.

Test 2 reads the list literal out of `is_supported_instance_class()` with `ast`; if that list ever stops being a literal (e.g. because it gets derived from the YAML, see below) the helper fails with a message saying so rather than silently passing.

## Verified it actually catches the drift

Deleting `"i7i"` from `is_supported_instance_class()`:

```
AssertionError: aws_io_params.yaml has I/O presets for ['i7i'], but
AwsInstance.is_supported_instance_class() rejects them, so those presets can never
be applied. Add them to the list in lib/scylla_cloud.py.
```

Deleting `"i7i"` from the ENA list in `get_en_interface_type()`:

```
AssertionError: AwsInstance.get_en_interface_type() returns None for supported
classes ['i7i']. scylla_ec2_check will report they don't support enhanced
networking. Add them to the ENA list in lib/scylla_cloud.py.
```

Full suite: 496 passed. No CI workflow change needed — `build.yml` already runs `uv run pytest ./tests`.

## Follow-ups (SMI-184)

This is step 1 of three. The remaining two delete the duplicated data rather than just guarding it:

- Derive `is_supported_instance_class()` from `aws_io_params.yaml` — removes list #2. The class sets are identical today, so it is behaviour-preserving, and the "supported but no preset" path stays meaningful (e.g. `i7i` has entries only up to `2xlarge` and no `i7i.ALL`, so `i7i.4xlarge` still correctly falls through to `scylla_io_setup`).
- Replace `get_en_interface_type()` with a `driver in ("ena", "ixgbevf")` check in `scylla_ec2_check` — removes list #3 and the unreachable `OciInstance.get_en_interface_type()`.

Refs SMI-184

🤖 Generated with [Claude Code](https://claude.com/claude-code)